### PR TITLE
fixed missing name error reporting

### DIFF
--- a/src/value-template.ts
+++ b/src/value-template.ts
@@ -1,7 +1,6 @@
 import { Pojo } from "./types";
 
 export function valueTemplate(value: string, data: Pojo, debug: boolean = false, throwCondition = 0): string {
-    if (throwCondition > 10 || value === undefined) { throw new Error('Unresolvable variable: ' + name) }
     return value.replace(/value\((.*?)\)/g, function (match: string, name: string) {
         let translatedValue = data[name];
         if (~name.indexOf(',')) {
@@ -11,6 +10,7 @@ export function valueTemplate(value: string, data: Pojo, debug: boolean = false,
             defaultValue = data[defaultValue] || defaultValue;
             translatedValue = data[variableName] || defaultValue;
         }
+        if (throwCondition > 10 || translatedValue === undefined) { throw new Error('Unresolvable variable: ' + name) }
         const res = valueTemplate(translatedValue, data, debug, throwCondition + 1);
         return res !== undefined ? res + (debug ? `/*${match}*/` : '') : match;
     });


### PR DESCRIPTION
`Module build failed: Error: Unresolvable variable: my-variable` instead of
`Module build failed: ReferenceError: name is not defined` for any error