### PR TITLE
arnonk/section-order

### DIFF
--- a/_docs/references/global-selectors.md
+++ b/_docs/references/global-selectors.md
@@ -5,7 +5,7 @@ Selectors inside `:global()` directive selector are not scoped to the stylesheet
 CSS input
 ```css
     @namespace "App";
-    .classA :global(.classB > .classC) .classD:global(:hover) {
+    .classA :global(.classB > .classC) .classD:hover {
         color: red;
     }
 
@@ -18,5 +18,11 @@ CSS output
     }
 ```
 
-
+> Note: you can also use global pseudo-classes and elements, to override an override. But why would you?! You describe them using this syntax:
+>
+> ```css
+> .classA :global(.classB > .classC) .classD:global(:hover) {
+>     color: red;
+> }
+> ```
 

--- a/_docs/references/pseudo-classes.md
+++ b/_docs/references/pseudo-classes.md
@@ -8,9 +8,9 @@ Native pseudo-classes like `:hover` and `:nth-child()` are valid and supported n
 
 ## Define custom pseudo-classes
 
-To define custom pseudo-classes, you use the **Stylable** directive rule `-sb-states` to provide a list of the possible custom pseudo-classes that you want to use in the CSS.
+To define custom pseudo-classes, you use the **Stylable** directive rule `-st-states` to provide a list of the possible custom pseudo-classes that you want to use in the CSS.
 
-The `-sb-states` directive rule can be defined only for simple selectors like [tag selector](./tag-selectors.md), [class selector](./class-selectors.md) and [root](./root.md).
+The `-st-states` directive rule can be defined only for simple selectors like [tag selector](./tag-selectors.md), [class selector](./class-selectors.md) and [root](./root.md).
 
 ## Name custom pseudo-classes and assign a style to them
 
@@ -35,28 +35,8 @@ CSS OUTPUT:
 .root[data-example1-loading][data-example1-toggled] { color:blue; }
 ```
 
-> Note: You can also override the behavior of native pseudo-class. This can enable you to write [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill) for forthcoming CSS pseudo-classes to ensure that when you define a name for a custom pseudo-class, if there are clashes with a new CSS pseudo-class in the future, your app's behavior does not change. We don't recommend you to override an existing CSS pseudo-class unless you want to drive your teammates insane.
+> Note: You can also override the behavior of native pseudo-classes. This can enable you to write [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill) for forthcoming CSS pseudo-classes to ensure that when you define a name for a custom pseudo-class, if there are clashes with a new CSS pseudo-class in the future, your app's behavior does not change. We don't recommend you to override an existing CSS pseudo-class unless you want to drive your teammates insane.
 
-## Map custom pseudo-classes
-
-You can use this feature to define states even if the existing components you are targeting are not based on **Stylable**. In this example, `toggled` and `loading` are defined on the root class with their custom implementation. In the CSS output, instead of the default behavior in **Stylable** of generating the `data-*` attributes to target states, it uses the custom implementation defined in the source. 
-
-CSS API:
-```css
-/* example-custom.css */
-.root{
-    -st-states: toggled(".on"), loading("[data-spinner]");
-}
-.root:toggled { color:red; }
-.root:loading { color:green; }
-```
-
-CSS OUTPUT:
-```css
-/* namespaced to example-custom */
-.root.on { color:red; }
-.root[data-spinner] { color:green; }
-```
 
 ## Extend external stylesheet
 
@@ -91,7 +71,28 @@ CSS OUTPUT:
 .root .media-button[data-example2-toggled] { color:gold;} /* toggled scoped to example2 - last to declare */
 ```
 
-## Enabling custom pseudo-classes
+## Map custom pseudo-classes
+
+You can use this feature to define states even if the existing components you are targeting are not based on **Stylable**. In this example, `toggled` and `loading` are defined on the root class with their custom implementation. In the CSS output,instead of the default behavior in **Stylable** of generating the `data-*` attributes to target states, it uses the custom implementation defined in the source. 
+
+CSS API:
+```css
+/* example-custom.css */
+.root{
+    -st-states: toggled(".on"), loading("[data-spinner]");
+}
+.root:toggled { color:red; }
+.root:loading { color:green; }
+```
+
+CSS OUTPUT:
+```css
+/* namespaced to example-custom */
+.root.on { color:red; }
+.root[data-spinner] { color:green; }
+```
+
+## Enable custom pseudo-classes
 
 Custom pseudo-classes are implemented using `data-*` attributes and need additional runtime logic to control when they are on and off. *<Should this also be explained above?>*
 

--- a/_docs/references/pseudo-elements.md
+++ b/_docs/references/pseudo-elements.md
@@ -5,7 +5,7 @@ In addition to CSS's native [pseudo-elements](https://developer.mozilla.org/en/d
 
 ## Styling custom pseudo-elements
 
-use `::` to access an internal part of a component after a [custom tag selector](./tag-selectors.md#custom-element) or [extended class selector](./extend-stylesheet.md).
+Use `::` to access an internal part of a component after a [custom tag selector](./tag-selectors.md#custom-element) or [extended class selector](./extend-stylesheet.md).
 
 Stylesheet can [import](./imports.md) a `video-player` component (stylesheet), extend it and style an internal `play-button`:
 

--- a/_docs/references/variants.md
+++ b/_docs/references/variants.md
@@ -30,59 +30,9 @@ CSS API :
 }
 ```
 
-## Define inline variants
+## Use a variant with `-st-extends`
 
-When you create a component, it's useful to keep in one file all of its styles and any variants you offer to consumers of your component.
-
-For example, consider the following button and its variant `BigButton`. While the button component has a height of 2em, the variant has a different height so the original style and the variant's style are both available for use from the same file. 
-
-```css
-.root {
-    color:red;
-    background-color:blue;
-    height:2em;
-}
-
-.BigButton {
-    -st-variant: true; /* variant of root */
-    height:5em;
-}
-```
-
-> Note: Variants without an [extends directive rule](./extend-stylesheet.md) are automatically variants of the owner stylesheet `root` class.
-
-
-## Use variants
-
-When you apply a variant as a mixin, you are applying the variant's styles and behavior and cannot access its custom internal parts, like pseudo-elements or pseudo-classes. 
-
-CSS API:
-```css
-/* page.css */
-:import {
-    -st-from: "./theme.css";
-    -st-names: SaleBtn;
-}
-
-.sale-button {
-    -st-mixin: SaleBtn;
-}
-```
-
-CSS OUTPUT:
-```css
-/* namespaced to page */
-.root .sale-button {
-    color: red;
-}
-.root .sale-button:hover {
-    color: pink;
-}
-```
-
-## Use variants with extends 
-
-When you use a variant with `-st-extends`, the class also inherits the variant base type enabling access to pseudo-elements and pseudo-classes. In this example, the CSS can style the button's `icon` because in the `theme.css` file, the `SaleBtn` variant extends `Button`.
+You use a variant using the `-st-extends` directive. The class then inherits the variant base type enabling access to its root definitions as well as all pseudo-elements and pseudo-classes. In this example, the CSS can style the button's `icon` because in the `theme.css` file, the `SaleBtn` variant extends `Button`. The hover behavior is also inherited from the base class.
 
 CSS API:
 ```css
@@ -114,3 +64,53 @@ CSS OUTPUT:
     border: 2px solid green;
 }
 ```
+
+## Use a variant with `-st-mixin`
+
+When you apply a variant as a mixin, you are applying the variant's styles and behavior only, and cannot access its custom internal parts, like pseudo-elements or pseudo-classes. 
+
+CSS API:
+```css
+/* page.css */
+:import {
+    -st-from: "./theme.css";
+    -st-names: SaleBtn;
+}
+
+.sale-button {
+    -st-mixin: SaleBtn;
+}
+```
+
+CSS OUTPUT:
+```css
+/* namespaced to page */
+.root .sale-button {
+    color: red;
+}
+.root .sale-button:hover {
+    color: pink;
+}
+```
+
+## Define inline variants
+
+When you create a component, it's useful to keep in one file all of its styles and any variants you offer to consumers of your component.
+
+For example, consider the following button and its variant `BigButton`. While the button component has a height of 2em, the variant has a different height so the original style and the variant's style are both available for use from the same file. 
+
+```css
+.root {
+    color:red;
+    background-color:blue;
+    height:2em;
+}
+
+.BigButton {
+    -st-variant: true; /* variant of root */
+    height:5em;
+}
+```
+
+> Note: Variants without an [extends directive rule](./extend-stylesheet.md) are automatically variants of the owner stylesheet `root` class.
+


### PR DESCRIPTION
and add minor language or example edits

- global selectors: removed global pseudo-class from example and added to a note
- change pseudo-classes document order
- minor English edit to pseudo-elements
- change order of variant document