### PR TITLE
Edits to extend-stylesheet

### DIFF
--- a/_docs/references/extend-stylesheet.md
+++ b/_docs/references/extend-stylesheet.md
@@ -1,10 +1,13 @@
 # Extend Stylable stylesheet
 
-Use the `-st-extends` directive rule to extend a CSS class with another stylesheet, in order to be able to describe styling of [pseudo classes](./pseudo-classes.md) and [pseudo elements](./pseudo-elements.md) of the extended stylesheet.
+Use the `-st-extends` directive rule to extend a CSS class with another stylesheet. This enables you to style [pseudo classes](./pseudo-classes.md) and [pseudo elements](./pseudo-elements.md) of the extended stylesheet.
 
-> *Note*: `-st-extends` may only be applied to [class selector](./class-selectors.md) and [root selector](./root.md).
+> **Note**: `-st-extends` can be applied only to [class selectors](./class-selectors.md) and [root selector](./root.md).
+
+In this example, this stylesheet is extending the `toggle-button.css` stylesheet. The `.check-btn` class has a `label`, a custom [pseudo-element](./pseudo-elements.md), and can be `toggled`, a custom [pseudo class](./pseudo-classes.md).
 
 CSS API:
+
 ```css
 :import{
     -st-from: "./toggle-button.css";
@@ -19,6 +22,7 @@ CSS API:
 ```
 
 CSS OUTPUT:
+
 ```css
 /* namespaced to the stylesheet */
 .root .check-btn.toggle-button_root{ background:white;}


### PR DESCRIPTION
The React code example doesn't seem to include anything about the pseudo-element or the pseudo-class. Should it?