### PR TITLE
cross-document change to example format

### DIFF
--- a/_docs/references/class-selectors.md
+++ b/_docs/references/class-selectors.md
@@ -6,20 +6,20 @@ In **Stylable** class selectors are scoped to the [namespace](./namespace.md) of
 
 ### CSS API:
 ```css
-@namespace "Gallery"
-.thumbnail{ background:green; }
-.thumbnail:hover{ background:blue; }
-.gallery:hover .thumbnail{ background:red; }
+@namespace "Page"
+.thumbnail { background:green; }
+.thumbnail:hover { background:blue; }
+.gallery:hover .thumbnail { background:red; }
 ```
 
 ### CSS OUTPUT:
 ```css
-.Gallery__root .Gallery__thumbnail{ background:green;}
-.Gallery__root .Gallery__thumbnail:hover{ background:blue; }
-.Gallery__root .Gallery__gallery:hover .Gallery__thumbnail{ background:red; }
+.Page__root .Page__thumbnail { background:green;}
+.Page__root .Page__thumbnail:hover { background:blue; }
+.Page__root .Page__gallery:hover .Page__thumbnail { background:red; }
 ```
 
-### React
+### React:
 ```jsx
 /* inside a stylable render */
 <div className="gallery">
@@ -36,12 +36,12 @@ In **Stylable** class selectors are scoped to the [namespace](./namespace.md) of
 
 Any class defined in a Stylable stylesheet is exported as a named export and can be imported by other stylesheets using the directive `-st-named`.
 
-### Usage
+### Example
 
 ```css
 /* button.st.css */
 @namespace "Button"
-.root{ background:green; }
+.root { background:green; }
 .icon { border: 2px solid black; } 
 .label { font-size: 20px; } 
 ```

--- a/_docs/references/extend-stylesheet.md
+++ b/_docs/references/extend-stylesheet.md
@@ -8,28 +8,28 @@ Use the `-st-extends` directive rule to extend a CSS class with another styleshe
 ```css
 /* page.st.css */
 @namespace "Page"
-:import{
-    -st-from: "./toggle-button.css";
+:import {
+    -st-from: "./toggle-button.st.css";
     -st-default: ToggleButton;
 }
-.check-btn{
-    -st-extends:ToggleButton;
-    background:white;
+.check-btn {
+    -st-extends: ToggleButton;
+    background: white;
 }
-.check-btn::label{ color:green; } /* style pseudo element label */
-.check-btn:toggled::label{ color:red; } /* style pseudo element label when check-box is toggled */
+.check-btn::label { color:green; } /* style pseudo element label */
+.check-btn:toggled::label { color:red; } /* style pseudo element label when check-box is toggled */
 ```
 
 ### CSS OUTPUT:
 ```css
-.Page__root .Page__root.check-btn.ToggleButton__root{ background:white;}
-.Page__root .Page__root.check-btn.ToggleButton__root .ToggleButton__label{ color:green; }
-.Page__root .Page__root.check-btn.ToggleButton__root[data-toggle-button-toggled] .ToggleButton__label{ color:red; }
+.Page__root .Page__check-btn.ToggleButton__root { background: white; }
+.Page__root .Page__check-btn.ToggleButton__root .ToggleButton__label { color: green; }
+.Page__root .Page__check-btn.ToggleButton__root[data-ToggleButton-toggled] .ToggleButton__label { color: red; }
 ```
 
 ### React
 ```jsx
-/* CheckButton component implements toggle-button.css */
+/* Page component uses toggle-button component */
 import ToggleButton from './toggle-button';
 /* inside a stylable render */
 <div>

--- a/_docs/references/global-selectors.md
+++ b/_docs/references/global-selectors.md
@@ -2,29 +2,27 @@
 
 In **Stylable**, selectors are scoped to the stylesheet. But what if you want to target global or other selectors that are not scoped? You can use the `:global()` directive selector. 
 
-In this example `.classB` and `.classC` are not scoped to `App` but are part of the selector query.
+In this example `.classB` and `.classC` are not scoped to `Comp` but are part of the selector query.
 
-CSS input
+### CSS API:
 ```css
-@namespace "App";
+@namespace "Comp";
 .classA :global(.classB > .classC) .classD:hover {
     color: red;
 }
-
 ```
 
-CSS output
+### CSS OUTPUT:
 ```css
-.App__root .App__classA .classB > .classC .App__classD:hover {
+.Comp__root .Comp__classA .classB > .classC .Comp__classD:hover {
     color: red;
 }
 ```
 
-> **Note**: While we don't recommend it, you can also use global to keep pseudo-classes native. You can describe them using the syntax below where `classA` is scoped and `:selected` is native.
+> **Note**: You can also use global to keep pseudo-classes native. You can describe them using the syntax below where `classA` is scoped and `:selected` is native.
 >
 > ```css
 > .classA:global(:selected) {
 >     color: red;
 > }
 > ```
-

--- a/_docs/references/imports.md
+++ b/_docs/references/imports.md
@@ -19,6 +19,7 @@ You use the **Stylable** syntax beginning with `-st-` for the `:import` config:
 
 Import the `toggle-button.css` stylesheet from a local location. Assign the name `ToggleButton` to the default export of that stylesheet for use in this scoped stylesheet.
 
+### CSS API:
 ```css
 :import {
     -st-from: './toggle-button.css';
@@ -26,7 +27,7 @@ Import the `toggle-button.css` stylesheet from a local location. Assign the name
 }
 ```
 
-ES6 equivalent
+### ES6 equivalent:
 ```js
 import ToggleButton from './toggle-button.css';
 ```
@@ -35,15 +36,15 @@ import ToggleButton from './toggle-button.css';
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. These named exports are now imported into this scoped stylesheet.
 
+### CSS API:
 ```css
-:import{
-    -st-from:"./my-mixins";
+:import {
+    -st-from: "./my-mixins";
     -st-named: gridMixin, tooltipMixin;
 }
 ```
 
-**ES6 equivalent**
-
+### ES6 equivalent:
 ```js
 import { gridMixin, tooltipMixin } from "./my-mixins";
 ```
@@ -52,15 +53,15 @@ import { gridMixin, tooltipMixin } from "./my-mixins";
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. `gridMixin` is used as is and `tooltipMixin` has been renamed for use in this scoped stylesheet as ```tooltip```. These mixins should be referred to as `gridMixin` and `tooltip` in this stylesheet.
 
+### CSS API:
 ```css
-:import{
-    -st-from:"./my-mixins";
+:import {
+    -st-from: "./my-mixins";
     -st-named: gridMixin, tooltipMixin as tooltip;
 }
 ```
 
-**ES6 equivalent**
-
+### ES6 equivalent:
 ```js
 import { gridMixin, tooltipMixin as tooltip } from "./my-mixins";
 ```

--- a/_docs/references/mixin-syntax.md
+++ b/_docs/references/mixin-syntax.md
@@ -12,13 +12,13 @@ Here are some use cases where you can use mixins with other **Stylable** feature
 
 The value `textTooltip` of the external file `my-mixins` is imported. The class selector `.submit-button` uses the mixin syntax and applies parameters. In this case, to wait `300` milliseconds to display the `data-tooltip` hover text on the button. 
 
-CSS API:
+### CSS API:
 ```css
-:import{
+:import {
     -st-from: "./my-mixins";
     -st-names: textTooltip;
 }
-.submit-button{
+.submit-button {
     -st-mixin: textTooltip(300, data-tooltip); /* apply mixin */
 }
 ```
@@ -27,16 +27,17 @@ CSS API:
 
 You can use mixins with parameters, without parameters, and with multiple mixins.
 
+### CSS API:
 ```css
-.a{
+.a {
     /* no parameters */
     -st-mixin: noParams;
 }
-.b{
+.b {
     /* multiple parameters */
     -st-mixin: multiParams(param1, param2);
 }
-.c{
+.c {
     /* apply multiple mixins */
     -st-mixin: noParams, multiParams(param1, param2);
 }
@@ -44,6 +45,7 @@ You can use mixins with parameters, without parameters, and with multiple mixins
 
 Any parameter you add to the mixin is considered a string.
 
+### CSS API:
 ```css
 .a {
     -st-mixin: mix(300, xxx); /* ["300", "xxx"] */
@@ -67,31 +69,31 @@ Mixins can add CSS declarations to the CSS rule set to which they are applied:
 * Any selectors that are appended as a result of the mixin are added directly after the rule set that the mixin was applied to.
 * Multiple mixins are applied according to the order that they are specified.
 
-CSS API:
+### CSS API:
 ```css
-.a{
-    color:red;
+.a {
+    color: red;
     -st-mixin: golden;
-    background:white;
+    background: white;
 }
-.a:hover{
-    background:white;
+.a:hover {
+    background: white;
 }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
-.a{
-    color:red;
-    color:gold; /* added by golden */
-    background:black; /* added by golden */
-    background:white;
+.a {
+    color: red;
+    color: gold; /* added by golden */
+    background: black; /* added by golden */
+    background: white;
 }
-.a:hover{
-    color:black; /* added by golden */
-    background:gold; /* added by golden */
+.a:hover {
+    color: black; /* added by golden */
+    background: gold; /* added by golden */
 }
-.a:hover{
-    background:white;
+.a:hover {
+    background: white;
 }
 ```

--- a/_docs/references/namespace.md
+++ b/_docs/references/namespace.md
@@ -6,15 +6,16 @@ When you use **Stylable** your classes are automatically namespaced to that styl
 
 When you develop your application in **Stylable**, you can manually namespace classes so you can more easily identify them when they are displayed in the CSS output. You do this in your **Stylable** stylesheet by adding the syntax `@namespace` to provide better display names to your classes.
 
-CSS API
+### CSS API:
 ```css
 @namespace "my-gallery";
 .root { color: red; }
 ``` 
 
-CSS OUTPUT
+### CSS OUTPUT:
 ```css
-.my-gallery__root { color: red }
+.my-gallery__root { color: red; }
 ```
 
-> Note: Because `@namespace` is not unique, the scoped name may still have a suffix added to it to make it unique.
+> **Note**:  
+> Because `@namespace` is not unique, the scoped name may still have a suffix added to it to make it unique.

--- a/_docs/references/pseudo-classes.md
+++ b/_docs/references/pseudo-classes.md
@@ -16,79 +16,79 @@ The `-st-states` directive rule can be defined only for simple selectors like [t
 
 To define custom states for a simple selector, you tell **Stylable** the list of possible custom states that the CSS declaration may be given. You can then target the states in the context of the selector. In this example `toggled` and `loading` are added to the root selector and then assigned different colors. 
 
-CSS API:
+### CSS API:
 ```css
+/* example1.st.css */
 @namespace "Example1"
-.root{
+.root {
     -st-states: toggled, loading;
 }
-.root:toggled { color:red; }
-.root:loading { color:green; }
-.root:loading:toggled { color:blue; }
+.root:toggled { color: red; }
+.root:loading { color: green; }
+.root:loading:toggled { color: blue; }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
-.Example1__root[data-example1-toggled] { color:red; }
-.Example1__root[data-example1-loading] { color:green; }
-.Example1__root[data-example1-loading][data-example1-toggled] { color:blue; }
+.Example1__root[data-Example1-toggled] { color: red; }
+.Example1__root[data-Example1-loading] { color: green; }
+.Example1__root[data-Example1-loading][data-Example1-toggled] { color: blue; }
 ```
 
 > **Note**:  
 > You can also override the behavior of native pseudo-classes. This can enable you to write [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill) for forthcoming CSS pseudo-classes to ensure that when you define a name for a custom pseudo-class, if there are clashes with a new CSS pseudo-class in the future, your app's behavior does not change. We don't recommend you to override an existing CSS pseudo-class unless you want to drive your teammates insane.
 
-
 ## Extend external stylesheet
 
 You can extend another imported stylesheet and inherit its custom pseudo-classes. In this example the value `Comp1`is imported from the `example1.css` stylesheet and extended by `.media-button`. The custom pseudo-classes `toggled` and `selected` are defined to be used on the `media-button` component. 
 
-CSS API:
+### CSS API:
 ```css
+/* example2.st.css */
 @namespace "Example2"
 :import {
-    -st-from: "./example1.css"; /* Example1 */
+    -st-from: "./example1.st.css";
     -st-default: Comp1;
 }
 .media-button {
     -st-extends: Comp1;
     -st-states: toggled, selected;
 }
-.media-button:hover { border:10px solid black; } /* native CSS because no custom declaration*/
-.media-button:loading { color:silver; } /* from Example1 */
-.media-button:selected { color:salmon; } /* from Example2 */
-.media-button:toggled { color:gold;} /* included in Example1 but overridden by Example2 */
+.media-button:hover { border: 10px solid black; } /* native CSS because no custom declaration*/
+.media-button:loading { color: silver; } /* from Example1 */
+.media-button:selected { color: salmon; } /* from Example2 */
+.media-button:toggled { color: gold; } /* included in Example1 but overridden by Example2 */
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
-
-.Example1__root[data-example1-toggled]{ color:red; }
-.Example1__root[data-example1-loading]{ color:green; }
-.Example2__root .Example2__root.media-button:hover { border:10px solid black; } /* native hover - not declared */
-.Example2__root .Example2__root.media-button[data-example1-loading] { color:silver; } /* loading scoped to Example1 - only one to declare */
-.Example2__root .Example2__root.media-button[data-example2-selected] { color:salmon; } /* selected scoped to Example2 - only one to declare */
-.Example2__root .Example2__root.media-button[data-example2-toggled] { color:gold;} /* toggled scoped to Example2 - last to declare */
+.Example1__root[data-Example1-toggled] { color: red; }
+.Example1__root[data-Example1-loading] { color: green; }
+.Example2__root .Example2__media-button:hover { border: 10px solid black; } /* native hover - not declared */
+.Example2__root .Example2__media-button[data-Example1-loading] { color: silver; } /* loading scoped to Example1 - only one to declare */
+.Example2__root .Example2__media-button[data-Example2-selected] { color: salmon; } /* selected scoped to Example2 - only one to declare */
+.Example2__root .Example2__media-button[data-Example2-toggled] { color: gold;} /* toggled scoped to Example2 - last to declare */
 ```
 
 ## Map custom pseudo-classes
 
 You can use this feature to define states even if the existing components you are targeting are not based on **Stylable**. In this example, `toggled` and `loading` are defined on the root class with their custom implementation. In the CSS output,instead of the default behavior in **Stylable** of generating the `data-*` attributes to target states, it uses the custom implementation defined in the source. 
 
-CSS API:
+### CSS API:
 ```css
-/* example-custom.css */
+/* example-custom.st.css */
 @namespace "ExampleCustom"
-.root{
+.root {
     -st-states: toggled(".on"), loading("[data-spinner]");
 }
-.root:toggled { color:red; }
-.root:loading { color:green; }
+.root:toggled { color: red; }
+.root:loading { color: green; }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
-.ExampleCustom__root.on { color:red; }
-.ExampleCustom__root[data-spinner] { color:green; }
+.ExampleCustom__root.on { color: red; }
+.ExampleCustom__root[data-spinner] { color: green; }
 ```
 
 > Note: custom mapping should define selector that target one element (no CSS child elements) 

--- a/_docs/references/pseudo-elements.md
+++ b/_docs/references/pseudo-elements.md
@@ -9,14 +9,14 @@ Any [CSS class](./class-selectors.md) is accessible as a pseudo-element of an [e
 
 When you define a CSS class `play-button` inside the component `VideoPlayer`, that class may be targeted as a pseudo-element of any class that extends `VideoPlayer`.
 
-CSS API
+### CSS API:
 ```css
 /* video-player.st.css */
 @namespace "VideoPlayer"
 .root {}
 .play-button { 
-    background:black; 
-    color:white;
+    background: black; 
+    color: white;
 }
 ```
 
@@ -26,28 +26,27 @@ Use `::` to access an internal part of a component after a [custom tag selector]
 
 You can [import](./imports.md) a `VideoPlayer` component into your stylesheet, and style an internal called `play-button`:
 
-CSS API
+### CSS API:
 ```css
 @namespace "Page"
 :import {
-    -st-from: './video-player.css';
+    -st-from: './video-player.st.css';
     -st-default: VideoPlayer;
 }
-.Page__root.main-video {
+.main-video {
     -st-extends: VideoPlayer; /* define main-video as VideoPlayer */
 }
-.Page__root.main-video::play-button { /* override main-video play button */
+.main-video::play-button { /* override main-video play button */
     background: green;
     color: purple;
 }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
-/* namespaced to the stylesheet */
-.Page__root .Page__root.main-video.VideoPlayer__root .VideoPlayer__play-button {
-    background:green;
-    color:purple;
+.Page__root .Page__main-video.VideoPlayer__root .VideoPlayer__play-button {
+    background: green;
+    color: purple;
 }
 ```
 
@@ -59,15 +58,15 @@ CSS OUTPUT:
 
 When stylesheet [root](./root.md) extends another stylesheet, pseudo-elements are automatically exposed on the extending stylesheet and available inline:
 
-CSS API
+### CSS API:
 ```css
-/* super-video-player.css */
+/* super-video-player.st.css */
 @namespace "SuperVideoPlayer"
 :import {
-    -st-from: './video-player.css';
+    -st-from: './video-player.st.css';
     -st-default: VideoPlayer;
 }
-.root{
+.root {
     -st-extends: VideoPlayer;
 }
 .root::play-button {
@@ -76,10 +75,10 @@ CSS API
 ```
 
 ```css
-/* page.css */
+/* page.st.css */
 @namespace "Page"
 :import {
-    -st-from: './super-video-player.css';
+    -st-from: './super-video-player.st.css';
     -st-default: SuperVideoPlayer;
 }
 .main-player {
@@ -90,27 +89,27 @@ CSS API
 }
 ```
 
-CSS OUTPUT
+### CSS OUTPUT:
 ```css
-.SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: gold }
-.Page__root .Page__root.main-player.SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: silver }
+.SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: gold; }
+.Page__root .Page__main-player.SuperVideoPlayer__root .VideoPlayer__play-button { color: silver; }
 ```
 
-> **Note**:
+> **Note**:  
 > With this mechanism you can override native pseudo-elements. For example, if one of your classes is called `.first-line`, accessing it as `.class::first-line` would override the native behavior. This can lead to code that's confusing and hard to maintain.
 
 ## Override custom pseudo-elements
 
 You may use CSS classes normally to override extended pseudo-elements. In the example below, our root extends `VideoPlayer` and so any class placed on the root will override the pseudo-element.
 
-CSS API
+### CSS API:
 ```css
 @namespace "SuperVideoPlayer"
 :import {
     -st-from: './video-player.css';
     -st-default: VideoPlayer;
 }
-.root{
+.root {
     -st-extends: VideoPlayer;
 }
 .play-button { /* override VideoPlayer play-button */
@@ -120,11 +119,9 @@ CSS API
 
 CSS OUTPUT
 ```css
-.SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: gold }
-.Page__root .SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: silver }
-
+.SuperVideoPlayer__root.VideoPlayer__root .SuperVideoPlayer__play-button { color: gold; }
 ```
 
-> **Note**: 
+> **Note**:  
 > Overriding pseudo-elements only changes the manner which the CSS uses to match those pseudo-elements. It does not change the extended component view output.
 

--- a/_docs/references/root.md
+++ b/_docs/references/root.md
@@ -8,15 +8,16 @@ You can apply default styling and behavior to the component on the root class it
 
 The `root` class is added automatically to root in [react integration](react-integration.md). No need to write `className="root"`.
 
-CSS API:
+## CSS API:
 ```css
-.root{ background:red; } /* set component background to red */
+@namespace "Comp";
+.root { background: red; } /* set component background to red */
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
-/* Namespaced to the stylesheet */
-.root{ background:red;}
+.Comp__root { background: red; }
 ```
 
-> **Note**: Root can also define [states](./pseudo-classes) and [extend another component](./extend-stylesheet.md).
+> **Note**:  
+> Root can also define [states](./pseudo-classes) and [extend another component](./extend-stylesheet.md).

--- a/_docs/references/tag-selectors.md
+++ b/_docs/references/tag-selectors.md
@@ -11,38 +11,25 @@ Tag selectors are **not** scoped themselves. Other selectors used with a tag sel
 Targeting a native element matches any element with the same tag name that is found in a prefix selector. The prefix selector could be a class selector or the root.
 
 ### CSS API:
-
 ```css
-@namepsace "Page"
-form {background:green;}
-```
-
-### CSS OUTPUT:
-
-```css
-/* form is not namespaced */
-.Page__root form {background:green;} 
-```
-
-### CSS API:
-
-```css
-@namepsace "Page"
-form {background:green;}
-.side-bar:hover form {background:red; }
+@namespace "Page"
+form { background: green; }
+.side-bar:hover form { background: red; }
 ```
 
 ### CSS OUTPUT:
 ```css
-/* form is not namespaced */
-.Page__root form {background:green;} 
-.Page__root.side-bar:hover form {background:red; }
+/* form is not namespaced - affects any nested form */
+.Page__root form { background: green; } 
+.Page__root.side-bar:hover form { background: red; }
 ```
 
-### React
+> **Note**:  
+> `form` is not namespaced.
 
+### React:
 ```jsx
-/* inside a stylable render */
+/* inside a stylable component render */
 <div className="gallery">
     <div className="side-bar">
         <form></form> /* green background and red while hovering parent */
@@ -59,18 +46,18 @@ When the value of a stylesheet is [imported](./imports.md) with a **capital firs
 ```css
 @namespace "Page"
 :import{
-    -st-from: "./toggle-button.css";
+    -st-from: "./toggle-button.st.css";
     -st-default: ToggleButton;
 }
-ToggleButton {background:green;}
-.side-bar:hover ToggleButton {background:red;}
+ToggleButton { background: green; }
+.side-bar:hover ToggleButton { background: red; }
 ```
 
 ### CSS OUTPUT:
 ```css
-/* namespaced to the stylesheet - .toggleButton is not namespaced */
-.Page__root ToggleButton {background:green;}
-.Page__root .Page__root.side-bar:hover ToggleButton {background:red;}
+/* ToggleButton is not namespaced - affects any nested toggle button */
+.Page__root .ToggleButton__root { background: green; }
+.Page__root .Page__root.side-bar:hover .ToggleButton__root { background: red; }
 ```
 
 ### React Implementation:

--- a/_docs/references/variables.md
+++ b/_docs/references/variables.md
@@ -9,7 +9,7 @@ Use variables to define common values to be used across the stylesheet and are e
 
 Use `:vars` to define variables, and apply them with the `value()`:
 
-CSS API:
+### CSS API:
 ```css
 @namespace "Example1";
 :vars {
@@ -22,7 +22,7 @@ CSS API:
 }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
 .Example1__root {
     color: red; /* color1 */
@@ -34,8 +34,7 @@ CSS OUTPUT:
 
 Any var defined in stylesheet is exported as a named export and can be imported by other stylesheets:
 
-CSS API:
-
+### CSS API:
 ```css
 @namespace "Example2";
 :import {
@@ -46,17 +45,17 @@ CSS API:
     border: 10px solid value(color1);
 }
 .root:hover {
-    border:10px solid value(color2);
+    border: 10px solid value(color2);
 }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
 .Example2__root {
     border: 10px solid red; /* color1 */
 }
 .Example2__root:hover {
-    border:10px solid green; /* color2 */
+    border: 10px solid green; /* color2 */
 }
 ```
 
@@ -67,14 +66,14 @@ CSS OUTPUT:
 
 You can set the value of a variable using another variable.
 
-CSS API:
+### CSS API:
 ```css
 @namespace "Example3";
 :import {
     -st-from: "./example1.css"; /* Example1 stylesheet */
     -st-named: color1, color2;
 }
-:vars{
+:vars {
     border1: 10px solid value(color1); /* use color1 in a complex value */
 }
 .root {
@@ -82,7 +81,7 @@ CSS API:
 }
 ```
 
-CSS OUTPUT:
+### CSS OUTPUT:
 ```css
 .Example3__root {
     border: 10px solid red; /* 10px solid {color1} */

--- a/_docs/references/variants.md
+++ b/_docs/references/variants.md
@@ -20,7 +20,6 @@ Then to use the variant, you can use any of the extension methods available for 
 The `.cancelButton` class is defined as a variant using `-st-variant: true`. Then used in the `Form` stylsheet.
 
 ### CSS API:
-
 ```css
 /* button.st.css */
 @namespace "Button"
@@ -58,12 +57,12 @@ The `.cancelButton` class is defined as a variant using `-st-variant: true`. The
 }
 ```
 
-### CSS Output:
-
+### CSS OUTPUT:
 ```css
-.Button__root.Button__cancelButton { color: red } /* from variant */
-.Button__root.Button__cancelButton:hover { color: pink } /* from variant */
-.Form__root .Form__cancel.Button__cancelButton { color: gold }
+.Button__root { color: blue; } /* base button */
+.Button__root.Button__cancelButton { color: red; } /* from variant */
+.Button__root.Button__cancelButton:hover { color: pink; } /* from variant */
+.Form__root .Form__cancel.Button__cancelButton { color: gold; }
 
 /* Note that bigBorder is not in the output since it is not in use */
 ```


### PR DESCRIPTION
changed a bit the example format, to one we think is more instructive. we've added namespacing to all examples, and it reflects in the output.