### PR TITLE
replaced StateMap and Stylesheet interface declaration with type declaration

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,7 +1,7 @@
 
-export interface StateMap { [key: string]: boolean }
+export type StateMap = { [key: string]: boolean }
 
-export interface Stylesheet {
+export type Stylesheet = {
     namespace: string;
     root: string;
     get: (localName: string) => string;


### PR DESCRIPTION
Hi. 
I am trying to create stylable stateless component

```tsx
import * as React from 'react';
import {SBStateless} from 'stylable-react-component';
import styles from './styles.st.css';

export const MyComponent = SBStateless(
    (props) => {
        return (...);
    },
    styles
);
```

But I receive error like

`error TS4023: Exported variable 'MyComponent' has or is using name 'Stylesheet' from external module "...PATH.../node_modules/stylable/dist/src/runtime" but cannot be named.`

I made some research and found this [issue](https://github.com/Microsoft/TypeScript/issues/5711), which said that I either have to add explicit import of `Stylesheet` in my component or let compiler add type declaration automatically.
I prefer the second option but this require the update type declaration. As far I know, `type` and `interface` has only different that `type` will not create actual alias name, so compiler could use this.