### PR TITLE
Annie/css heading fixes

### DIFF
--- a/docs/references/class-selectors.md
+++ b/docs/references/class-selectors.md
@@ -4,7 +4,7 @@ You use [CSS classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_sel
 
 In **Stylable** class selectors are scoped to the [namespace](./namespace.md) of the stylesheet. 
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Page"
 .thumbnail { background:green; }
@@ -12,14 +12,14 @@ In **Stylable** class selectors are scoped to the [namespace](./namespace.md) of
 .gallery:hover .thumbnail { background:red; }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Page__root .Page__thumbnail { background:green;}
 .Page__root .Page__thumbnail:hover { background:blue; }
 .Page__root .Page__gallery:hover .Page__thumbnail { background:red; }
 ```
 
-### React:
+**React**
 ```jsx
 /* inside a stylable render */
 <div className="gallery">

--- a/docs/references/compose-css-class.md
+++ b/docs/references/compose-css-class.md
@@ -2,7 +2,7 @@
 
 Use `-st-compose` to apply a CSS class to another CSS class or to a tag selector.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Comp";
 .item {
@@ -14,7 +14,7 @@ Use `-st-compose` to apply a CSS class to another CSS class or to a tag selector
 }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Comp__item { color: red }
 .Comp__selected.Comp__item { color: green }
@@ -24,7 +24,7 @@ Use `-st-compose` to apply a CSS class to another CSS class or to a tag selector
 
 You can compose multiple items by order.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Comp";
 .item {
@@ -39,7 +39,7 @@ You can compose multiple items by order.
 }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Comp__item { color: red }
 .Comp__round { border-radius: 10px }

--- a/docs/references/extend-stylesheet.md
+++ b/docs/references/extend-stylesheet.md
@@ -6,7 +6,7 @@ Use the `-st-extends` directive rule to extend a CSS class with another styleshe
 
 In this example, the stylesheet is extending the `toggle-button.css` stylesheet. The `check-btn` class has a `label`, which is a custom pseudo-element, and can be `toggled`, a custom pseudo-class. 
 
-### CSS API:
+**CSS API**
 ```css
 /* page.st.css */
 @namespace "Page"
@@ -22,14 +22,14 @@ In this example, the stylesheet is extending the `toggle-button.css` stylesheet.
 .check-btn:toggled::label { color:red; } /* style pseudo element label when check-box is toggled */
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Page__root .Page__check-btn.ToggleButton__root { background: white; }
 .Page__root .Page__check-btn.ToggleButton__root .ToggleButton__label { color: green; }
 .Page__root .Page__check-btn.ToggleButton__root[data-ToggleButton-toggled] .ToggleButton__label { color: red; }
 ```
 
-### React
+**React**
 ```jsx
 /* Page component uses toggle-button component */
 import ToggleButton from './toggle-button';

--- a/docs/references/global-selectors.md
+++ b/docs/references/global-selectors.md
@@ -4,7 +4,7 @@ In **Stylable**, selectors are scoped to the stylesheet. But what if you want to
 
 In this example `.classB` and `.classC` are not scoped to `Comp` but are part of the selector query.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Comp";
 .classA :global(.classB > .classC) .classD:hover {
@@ -12,7 +12,7 @@ In this example `.classB` and `.classC` are not scoped to `Comp` but are part of
 }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Comp__root .Comp__classA .classB > .classC .Comp__classD:hover {
     color: red;

--- a/docs/references/imports.md
+++ b/docs/references/imports.md
@@ -15,7 +15,7 @@ You use the **Stylable** syntax beginning with `-st-` for the `:import` config:
 
 ## Import Basic usage
 
-#### Import the default export of a local reference stylesheet for use in the scoped stylesheet
+### Import the default export of a local reference stylesheet for use in the scoped stylesheet
 
 Import the `toggle-button.css` stylesheet from a local location. Assign the name `ToggleButton` to the default export of that stylesheet for use in this scoped stylesheet.
 
@@ -32,7 +32,7 @@ Import the `toggle-button.css` stylesheet from a local location. Assign the name
 import ToggleButton from './toggle-button.css';
 ```
 
-#### Import named exports from a local JS module
+### Import named exports from a local JS module
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. These named exports are now imported into this scoped stylesheet.
 
@@ -49,7 +49,7 @@ The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript
 import { gridMixin, tooltipMixin } from "./my-mixins";
 ```
 
-#### Import named exports from a local JS module and locally refer to one of the export values as a different name
+### Import named exports from a local JS module and locally refer to one of the export values as a different name
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. `gridMixin` is used as is and `tooltipMixin` has been renamed for use in this scoped stylesheet as ```tooltip```. These mixins should be referred to as `gridMixin` and `tooltip` in this stylesheet.
 
@@ -70,7 +70,7 @@ import { gridMixin, tooltipMixin as tooltip } from "./my-mixins";
 
 When importing another stylesheet the default represent the root of the stylesheet, and named imports represent vars and classes.
 
- ## Usage
+## Usage
 
 * [Tag selectors](./tag-selectors.md)
 * [Extend a stylesheet](./extend-stylesheet.md)

--- a/docs/references/imports.md
+++ b/docs/references/imports.md
@@ -19,7 +19,7 @@ You use the **Stylable** syntax beginning with `-st-` for the `:import` config:
 
 Import the `toggle-button.css` stylesheet from a local location. Assign the name `ToggleButton` to the default export of that stylesheet for use in this scoped stylesheet.
 
-### CSS API:
+**CSS API**
 ```css
 :import {
     -st-from: './toggle-button.css';
@@ -27,7 +27,7 @@ Import the `toggle-button.css` stylesheet from a local location. Assign the name
 }
 ```
 
-### ES6 equivalent:
+**ES6 equivalent**
 ```js
 import ToggleButton from './toggle-button.css';
 ```
@@ -36,7 +36,7 @@ import ToggleButton from './toggle-button.css';
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. These named exports are now imported into this scoped stylesheet.
 
-### CSS API:
+**CSS API**
 ```css
 :import {
     -st-from: "./my-mixins";
@@ -44,7 +44,7 @@ The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript
 }
 ```
 
-### ES6 equivalent:
+**ES6 equivalent**
 ```js
 import { gridMixin, tooltipMixin } from "./my-mixins";
 ```
@@ -53,7 +53,7 @@ import { gridMixin, tooltipMixin } from "./my-mixins";
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. `gridMixin` is used as is and `tooltipMixin` has been renamed for use in this scoped stylesheet as ```tooltip```. These mixins should be referred to as `gridMixin` and `tooltip` in this stylesheet.
 
-### CSS API:
+**CSS API**
 ```css
 :import {
     -st-from: "./my-mixins";
@@ -61,7 +61,7 @@ The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript
 }
 ```
 
-### ES6 equivalent:
+**ES6 equivalent**
 ```js
 import { gridMixin, tooltipMixin as tooltip } from "./my-mixins";
 ```

--- a/docs/references/mixin-syntax.md
+++ b/docs/references/mixin-syntax.md
@@ -11,7 +11,7 @@ Here are some use cases where you can use mixins with other **Stylable** feature
 
 The value `textTooltip` of the external file `my-mixins` is imported. The class selector `.submit-button` uses the mixin syntax and applies parameters. In this case, to wait `300` milliseconds to display the `data-tooltip` hover text on the button. 
 
-### CSS API:
+**CSS API**
 ```css
 :import {
     -st-from: "./my-mixins";
@@ -26,7 +26,7 @@ The value `textTooltip` of the external file `my-mixins` is imported. The class 
 
 You can use mixins with parameters, without parameters, and with multiple mixins.
 
-### CSS API:
+**CSS API**
 ```css
 .a {
     /* no parameters */
@@ -44,7 +44,7 @@ You can use mixins with parameters, without parameters, and with multiple mixins
 
 Any parameter you add to the mixin is considered a string.
 
-### CSS API:
+**CSS API**
 ```css
 .a {
     -st-mixin: mix(300, xxx); /* ["300", "xxx"] */
@@ -68,7 +68,7 @@ Mixins can add CSS declarations to the CSS rule set to which they are applied:
 * Any selectors that are appended as a result of the mixin are added directly after the rule set that the mixin was applied to.
 * Multiple mixins are applied according to the order that they are specified.
 
-### CSS API:
+**CSS API**
 ```css
 .a {
     color: red;
@@ -80,7 +80,7 @@ Mixins can add CSS declarations to the CSS rule set to which they are applied:
 }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .a {
     color: red;

--- a/docs/references/namespace.md
+++ b/docs/references/namespace.md
@@ -6,13 +6,13 @@ When you use **Stylable** your classes are automatically namespaced to that styl
 
 When you develop your application in **Stylable**, you can manually namespace classes so you can more easily identify them when they are displayed in the CSS output. You do this in your **Stylable** stylesheet by adding the syntax `@namespace` to provide better display names to your classes.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "my-gallery";
 .root { color: red; }
 ``` 
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .my-gallery__root { color: red; }
 ```

--- a/docs/references/pseudo-classes.md
+++ b/docs/references/pseudo-classes.md
@@ -16,7 +16,7 @@ The `-st-states` directive rule can be defined only for simple selectors like [t
 
 To define custom states for a simple selector, you tell **Stylable** the list of possible custom states that the CSS declaration may be given. You can then target the states in the context of the selector. In this example `toggled` and `loading` are added to the root selector and then assigned different colors. 
 
-### CSS API:
+**CSS API**
 ```css
 /* example1.st.css */
 @namespace "Example1"
@@ -28,7 +28,7 @@ To define custom states for a simple selector, you tell **Stylable** the list of
 .root:loading:toggled { color: blue; }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Example1__root[data-Example1-toggled] { color: red; }
 .Example1__root[data-Example1-loading] { color: green; }
@@ -42,7 +42,7 @@ To define custom states for a simple selector, you tell **Stylable** the list of
 
 You can extend another imported stylesheet and inherit its custom pseudo-classes. In this example the value `Comp1`is imported from the `example1.css` stylesheet and extended by `.media-button`. The custom pseudo-classes `toggled` and `selected` are defined to be used on the `media-button` component. 
 
-### CSS API:
+**CSS API**
 ```css
 /* example2.st.css */
 @namespace "Example2"
@@ -60,7 +60,7 @@ You can extend another imported stylesheet and inherit its custom pseudo-classes
 .media-button:toggled { color: gold; } /* included in Example1 but overridden by Example2 */
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Example1__root[data-Example1-toggled] { color: red; }
 .Example1__root[data-Example1-loading] { color: green; }
@@ -74,7 +74,7 @@ You can extend another imported stylesheet and inherit its custom pseudo-classes
 
 You can use this feature to define states even if the existing components you are targeting are not based on **Stylable**. In this example, `toggled` and `loading` are defined on the root class with their custom implementation. .Stylable generates selectors using custom `data-*` attributes. The CSS output uses the custom implementation defined in `-st-states` rather then its default generated `data-*` attributes.
 
-### CSS API:
+**CSS API**
 ```css
 /* example-custom.st.css */
 @namespace "ExampleCustom"
@@ -85,7 +85,7 @@ You can use this feature to define states even if the existing components you ar
 .root:loading { color: green; }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .ExampleCustom__root.on { color: red; }
 .ExampleCustom__root[data-spinner] { color: green; }

--- a/docs/references/pseudo-elements.md
+++ b/docs/references/pseudo-elements.md
@@ -9,7 +9,7 @@ Any [CSS class](./class-selectors.md) is accessible as a pseudo-element of an [e
 
 When you define a CSS class inside a component, in this case a `play-button` in a `VideoPlayer`, that class may be targeted as a pseudo-element of any class that extends the component `VideoPlayer`.
 
-### CSS API:
+**CSS API**
 ```css
 /* video-player.st.css */
 @namespace "VideoPlayer"
@@ -26,7 +26,7 @@ Use `::` to access an internal part of a component after a [custom tag selector]
 
 In this example, you [import](./imports.md) a `VideoPlayer` component into your stylesheet, and style an internal part called `play-button` overriding its original styling.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Page"
 :import {
@@ -42,7 +42,7 @@ In this example, you [import](./imports.md) a `VideoPlayer` component into your 
 }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Page__root .Page__main-video.VideoPlayer__root .VideoPlayer__play-button {
     background: green;
@@ -62,7 +62,7 @@ In this example, the class `play-button` is available from the original componen
 
 The `page.css` stylesheet can then extend `super-video-player.css` and on the `.main-player` class, style `play-button` differently.
 
-### CSS API:
+**CSS API**
 ```css
 /* super-video-player.st.css */
 @namespace "SuperVideoPlayer"
@@ -93,7 +93,7 @@ The `page.css` stylesheet can then extend `super-video-player.css` and on the `.
 }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: gold; }
 .Page__root .Page__main-player.SuperVideoPlayer__root .VideoPlayer__play-button { color: silver; }
@@ -110,7 +110,7 @@ You can use CSS classes to override extended pseudo-elements.
 
 In this example, `root` extends `VideoPlayer` and so any class placed on the `root` overrides the pseudo-element.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "SuperVideoPlayer"
 :import {
@@ -125,7 +125,7 @@ In this example, `root` extends `VideoPlayer` and so any class placed on the `ro
 }
 ```
 
-### CSS OUTPUT
+**CSS OUTPUT**
 ```css
 .SuperVideoPlayer__root.VideoPlayer__root .SuperVideoPlayer__play-button { color: gold; }
 ```

--- a/docs/references/root.md
+++ b/docs/references/root.md
@@ -8,13 +8,13 @@ You can apply default styling and behavior to the component on the root class it
 
 The `root` class is added automatically to root in [react integration](react-integration.md). No need to write `className="root"`.
 
-## CSS API:
+**CSS API**
 ```css
 @namespace "Comp";
 .root { background: red; } /* set component background to red */
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Comp__root { background: red; }
 ```

--- a/docs/references/tag-selectors.md
+++ b/docs/references/tag-selectors.md
@@ -10,14 +10,14 @@ Tag selectors are **not** scoped themselves. Other selectors used with a tag sel
 
 Targeting a native element matches any element with the same tag name that is found in a prefix selector. The prefix selector could be a class selector or the root.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Page"
 form { background: green; }
 .side-bar:hover form { background: red; }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 /* form is not namespaced - affects any nested form */
 .Page__root form { background: green; } 
@@ -27,7 +27,7 @@ form { background: green; }
 > **Note**:  
 > `form` is not namespaced.
 
-### React:
+**React**
 ```jsx
 /* inside a stylable component render */
 <div className="gallery">
@@ -42,7 +42,7 @@ form { background: green; }
 
 When the value of a stylesheet is [imported](./imports.md) with a **capital first letter**, it can be used as a component tag selector.
 
-### CSS API:
+**CSS API**
 ```css
 @namespace "Page"
 :import{
@@ -53,14 +53,14 @@ ToggleButton { background: green; }
 .side-bar:hover ToggleButton { background: red; }
 ```
 
-### CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 /* ToggleButton is not namespaced - affects any nested toggle button */
 .Page__root .ToggleButton__root { background: green; }
 .Page__root .Page__root.side-bar:hover .ToggleButton__root { background: red; }
 ```
 
-### React Implementation:
+**React Implementation**
 ```jsx
 /* Button component implements toggle-button.css */
 import ToggleButton from './toggle-button';

--- a/docs/references/theme.md
+++ b/docs/references/theme.md
@@ -14,7 +14,7 @@ When [importing](./imports.md) a stylesheet use`-st-theme` directive to add its 
 
 ## Override classes
 
-Any [shared classes](../guides/shared-classes.ms) and [component variants](../guides/component-variants.md) defined at the theme level can be overridden in our stylesheet, by simply redefining them:
+Any [shared classes](../guides/shared-classes.ms) and [component variants](../guides/component-variants.md) defined at the theme level can be overridden in our stylesheet, by simply redefining them.
 
 ```css
 @namespace "project";

--- a/docs/references/variables.md
+++ b/docs/references/variables.md
@@ -9,7 +9,7 @@ Use variables to define common values to be used across the stylesheet and so th
 
 Use the syntax `:vars` to define variables, and apply them with a `value()`:
 
-CSS 
+**CSS** 
 ```css
 @namespace "Example1";
 :vars {
@@ -22,7 +22,7 @@ CSS
 }
 ```
 
-CSS OUTPUT:
+**CSS OUTPUT**
 ```css
 .Example1__root {
     color: red; /* color1 */
@@ -34,7 +34,7 @@ CSS OUTPUT:
 
 Any var defined in a stylesheet is exported as a named export and can be [imported](./imports.md) by other stylesheets.
 
-CSS
+**CSS**
 ```css
 @namespace "Example2";
 :import {
@@ -49,7 +49,7 @@ CSS
 }
 ```
 
-CSS OUTPUT
+**CSS OUTPUT**
 ```css
 .Example2__root {
     border: 10px solid red; /* color1 */
@@ -66,7 +66,7 @@ CSS OUTPUT
 
 You can set the value of a variable using another variable.
 
-CSS API
+**CSS API**
 ```css
 @namespace "Example3";
 :import {
@@ -81,7 +81,7 @@ CSS API
 }
 ```
 
-CSS OUTPUT
+**CSS OUTPUT**
 ```css
 .Example3__root {
     border: 10px solid red; /* 10px solid {color1} */


### PR DESCRIPTION
In GitBooks, the CSS & CSS OUTPUT headings looked bad. Fixed them all.