### PR TITLE
Removed css headings & added to code

### DIFF
--- a/site/docs/references/class-selectors.md
+++ b/site/docs/references/class-selectors.md
@@ -8,35 +8,34 @@ You use [CSS classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_sel
 
 In **Stylable** class selectors are scoped to the [namespace](./namespace.md) of the stylesheet. 
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Page"
 .thumbnail { background:green; }
 .thumbnail:hover { background:blue; }
 .gallery:hover .thumbnail { background:red; }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Page__root .Page__thumbnail { background:green;}
 .Page__root .Page__thumbnail:hover { background:blue; }
 .Page__root .Page__gallery:hover .Page__thumbnail { background:red; }
 ```
 
-**React**
 ```jsx
-/* inside a stylable render */
+/* React - inside a stylable render */
 <div className="gallery">
     <img className="thumbnail" />
     ...
 </div>
 ```
 
-> **Notes:**  
+> **Note:**  
 > In Stylable, as you can see in these examples, `.root` as a class name is reserved for the main [root](./root.md).  
 > CSS class can also define [states](./pseudo-classes) and [extend another component](./extend-stylesheet.md).
 
-## Class Selector Export
+## Class selector export
 
 Any class defined in a Stylable stylesheet is exported as a named export and can be imported by other stylesheets using the directive `-st-named`.
 

--- a/site/docs/references/compose-css-class.md
+++ b/site/docs/references/compose-css-class.md
@@ -6,8 +6,8 @@ layout: docs
 
 Use `-st-compose` to apply a CSS class to another CSS class or to a tag selector.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Comp";
 .item {
     color: red;
@@ -18,18 +18,18 @@ Use `-st-compose` to apply a CSS class to another CSS class or to a tag selector
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Comp__item { color: red }
 .Comp__selected.Comp__item { color: green }
 ```
 
-## Multiple Classes
+## Multiple classes
 
 You can compose multiple items by order.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Comp";
 .item {
     color: red;
@@ -43,8 +43,8 @@ You can compose multiple items by order.
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Comp__item { color: red }
 .Comp__round { border-radius: 10px }
 .Comp__selected.Comp__item.Comp__round { color: green }

--- a/site/docs/references/extend-stylesheet.md
+++ b/site/docs/references/extend-stylesheet.md
@@ -1,16 +1,16 @@
 ---
 id: references/extend-stylesheet
-title: Extend Stylable stylesheet
+title: Extend Stylable Stylesheet
 layout: docs
 ---
 
 Use the `-st-extends` directive rule to extend a CSS class with another stylesheet. This enables you to style [pseudo classes](./pseudo-classes.md) and [pseudo elements](./pseudo-elements.md) of the extended stylesheet.
 
-> **Note**: `-st-extends` can be applied only to [class selectors](./class-selectors.md) and a [root selector](./root.md).
+> **Note**  
+>`-st-extends` can be applied only to [class selectors](./class-selectors.md) and a [root selector](./root.md).
 
 In this example, the stylesheet is extending the `toggle-button.css` stylesheet. The `check-btn` class has a `label`, which is a custom pseudo-element, and can be `toggled`, a custom pseudo-class. 
 
-**CSS API**
 ```css
 /* page.st.css */
 @namespace "Page"
@@ -26,16 +26,15 @@ In this example, the stylesheet is extending the `toggle-button.css` stylesheet.
 .check-btn:toggled::label { color:red; } /* style pseudo element label when check-box is toggled */
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Page__root .Page__check-btn.ToggleButton__root { background: white; }
 .Page__root .Page__check-btn.ToggleButton__root .ToggleButton__label { color: green; }
 .Page__root .Page__check-btn.ToggleButton__root[data-ToggleButton-toggled] .ToggleButton__label { color: red; }
 ```
 
-**React**
 ```jsx
-/* Page component uses toggle-button component */
+/* React - Page component uses toggle-button component */
 import ToggleButton from './toggle-button';
 /* inside a stylable render */
 <div>

--- a/site/docs/references/global-selectors.md
+++ b/site/docs/references/global-selectors.md
@@ -8,22 +8,23 @@ In **Stylable**, selectors are scoped to the stylesheet. But what if you want to
 
 In this example `.classB` and `.classC` are not scoped to `Comp` but are part of the selector query.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Comp";
 .classA :global(.classB > .classC) .classD:hover {
     color: red;
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Comp__root .Comp__classA .classB > .classC .Comp__classD:hover {
     color: red;
 }
 ```
 
-> **Note**: You can also use global to keep pseudo-classes native. You can describe them using the syntax below where `classA` is scoped and `:selected` is native.
+> **Note**   
+>You can also use global to keep pseudo-classes native. You can describe them using the syntax below where `classA` is scoped and `:selected` is native.
 >
 > ```css
 > .classA:global(:selected) {

--- a/site/docs/references/imports.md
+++ b/site/docs/references/imports.md
@@ -12,7 +12,7 @@ You use the **Stylable** syntax beginning with `-st-` for the `:import` config:
 * `-st-default:` Imports the default export of the module named in `-st-from:`. Use with the name by which to identify the imported value in the scoped stylesheet.
 * `-st-named:` List of the named exports to import into the local scoped stylesheet from the file named in `-st-from:`.
 
-> **Note**:
+> **Note**  
 > * `:import` is a Stylable directive and not a selector.
 > * Using `import` as part of a complex selector or inside a CSS ruleset does not import.
 > * Multiple imports may conflict and the last one in the file wins.
@@ -23,16 +23,16 @@ You use the **Stylable** syntax beginning with `-st-` for the `:import` config:
 
 Import the `toggle-button.css` stylesheet from a local location. Assign the name `ToggleButton` to the default export of that stylesheet for use in this scoped stylesheet.
 
-**CSS API**
 ```css
+/* CSS */
 :import {
     -st-from: './toggle-button.css';
     -st-default: ToggleButton;
 }
 ```
 
-**ES6 equivalent**
 ```js
+/* ES6 equivalent */
 import ToggleButton from './toggle-button.css';
 ```
 
@@ -40,16 +40,16 @@ import ToggleButton from './toggle-button.css';
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. These named exports are now imported into this scoped stylesheet.
 
-**CSS API**
 ```css
+/* CSS */
 :import {
     -st-from: "./my-mixins";
     -st-named: gridMixin, tooltipMixin;
 }
 ```
 
-**ES6 equivalent**
 ```js
+/* ES6 equivalent */
 import { gridMixin, tooltipMixin } from "./my-mixins";
 ```
 
@@ -57,16 +57,16 @@ import { gridMixin, tooltipMixin } from "./my-mixins";
 
 The values `gridMixin` and `tooltipMixin` are imported from the local JavaScript module `my-mixins.js`. `gridMixin` is used as is and `tooltipMixin` has been renamed for use in this scoped stylesheet as ```tooltip```. These mixins should be referred to as `gridMixin` and `tooltip` in this stylesheet.
 
-**CSS API**
 ```css
+/* CSS */
 :import {
     -st-from: "./my-mixins";
     -st-named: gridMixin, tooltipMixin as tooltip;
 }
 ```
 
-**ES6 equivalent**
 ```js
+/* ES6 equivalent */
 import { gridMixin, tooltipMixin as tooltip } from "./my-mixins";
 ```
 
@@ -78,7 +78,7 @@ When importing another stylesheet the default represent the root of the styleshe
 
 * [Tag selectors](./tag-selectors.md)
 * [Extend a stylesheet](./extend-stylesheet.md)
-* [Import variables](./variables.md#Import variables.md)
+* [Import variables](./variables.md#Import variables)
 * [Import classes](./class-selectors.md#import-classes.md)
 * [Mixins](./mixin-syntax.md)
 * [Component Variants](../guides/component-variants.md) and [Shared Classes](../guides/shared-classes.md)

--- a/site/docs/references/imports.md
+++ b/site/docs/references/imports.md
@@ -78,7 +78,7 @@ When importing another stylesheet the default represent the root of the styleshe
 
 * [Tag selectors](./tag-selectors.md)
 * [Extend a stylesheet](./extend-stylesheet.md)
-* [Import variables](./variables.md#Import variables)
-* [Import classes](./class-selectors.md#import-classes.md)
+* [Import variables](./variables.md#import-variables)
+* [Import classes](./class-selectors.md#import-classes)
 * [Mixins](./mixin-syntax.md)
 * [Component Variants](../guides/component-variants.md) and [Shared Classes](../guides/shared-classes.md)

--- a/site/docs/references/mixin-syntax.md
+++ b/site/docs/references/mixin-syntax.md
@@ -14,8 +14,8 @@ Here are some use cases where you can use mixins with other **Stylable** feature
 
 The value `textTooltip` of the external file `my-mixins` is imported. The class selector `.submit-button` uses the mixin syntax and applies parameters. In this case, to wait `300` milliseconds to display the `data-tooltip` hover text on the button. 
 
-**CSS API**
 ```css
+/* CSS */
 :import {
     -st-from: "./my-mixins";
     -st-names: textTooltip;
@@ -29,8 +29,9 @@ The value `textTooltip` of the external file `my-mixins` is imported. The class 
 
 You can use mixins with parameters, without parameters, and with multiple mixins.
 
-**CSS API**
+
 ```css
+/* CSS */
 .a {
     /* no parameters */
     -st-mixin: noParams;
@@ -47,8 +48,9 @@ You can use mixins with parameters, without parameters, and with multiple mixins
 
 Any parameter you add to the mixin is considered a string.
 
-**CSS API**
+
 ```css
+/* CSS */
 .a {
     -st-mixin: mix(300, xxx); /* ["300", "xxx"] */
 }
@@ -71,8 +73,9 @@ Mixins can add CSS declarations to the CSS rule set to which they are applied:
 * Any selectors that are appended as a result of the mixin are added directly after the rule set that the mixin was applied to.
 * Multiple mixins are applied according to the order that they are specified.
 
-**CSS API**
+
 ```css
+/* CSS */
 .a {
     color: red;
     -st-mixin: golden;
@@ -83,8 +86,8 @@ Mixins can add CSS declarations to the CSS rule set to which they are applied:
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .a {
     color: red;
     color: gold; /* added by golden */

--- a/site/docs/references/namespace.md
+++ b/site/docs/references/namespace.md
@@ -4,22 +4,22 @@ title: Namespace
 layout: docs
 ---
 
-When you use **Stylable** your classes are automatically namespaced to that stylesheet. Each stylesheet has a single [root](./root.md).
+When you use **Stylable**, your classes are automatically namespaced to that stylesheet. Each stylesheet has a single [root](./root.md).
 
 ## Manual Namespace
 
 When you develop your application in **Stylable**, you can manually namespace classes so you can more easily identify them when they are displayed in the CSS output. You do this in your **Stylable** stylesheet by adding the syntax `@namespace` to provide better display names to your classes.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "my-gallery";
 .root { color: red; }
 ``` 
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .my-gallery__root { color: red; }
 ```
 
-> **Note**:  
+> **Note**    
 > Because `@namespace` is not unique, the scoped name may still have a suffix added to it to make it unique.

--- a/site/docs/references/pseudo-classes.md
+++ b/site/docs/references/pseudo-classes.md
@@ -1,6 +1,6 @@
 ---
 id: references/pseudo-classes
-title: Pseudo-classes
+title: Pseudo-Classes
 layout: docs
 ---
 
@@ -20,7 +20,6 @@ The `-st-states` directive rule can be defined only for simple selectors like [t
 
 To define custom states for a simple selector, you tell **Stylable** the list of possible custom states that the CSS declaration may be given. You can then target the states in the context of the selector. In this example `toggled` and `loading` are added to the root selector and then assigned different colors. 
 
-**CSS API**
 ```css
 /* example1.st.css */
 @namespace "Example1"
@@ -32,21 +31,20 @@ To define custom states for a simple selector, you tell **Stylable** the list of
 .root:loading:toggled { color: blue; }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Example1__root[data-Example1-toggled] { color: red; }
 .Example1__root[data-Example1-loading] { color: green; }
 .Example1__root[data-Example1-loading][data-Example1-toggled] { color: blue; }
 ```
 
-> **Note**:  
+> **Note**    
 > You can also override the behavior of native pseudo-classes. This can enable you to write [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill) for forthcoming CSS pseudo-classes to ensure that when you define a name for a custom pseudo-class, if there are clashes with a new CSS pseudo-class in the future, your app's behavior does not change. We don't recommend you to override an existing CSS pseudo-class unless you want to drive your teammates insane.
 
 ## Extend external stylesheet
 
 You can extend another imported stylesheet and inherit its custom pseudo-classes. In this example the value `Comp1`is imported from the `example1.css` stylesheet and extended by `.media-button`. The custom pseudo-classes `toggled` and `selected` are defined to be used on the `media-button` component. 
 
-**CSS API**
 ```css
 /* example2.st.css */
 @namespace "Example2"
@@ -64,8 +62,8 @@ You can extend another imported stylesheet and inherit its custom pseudo-classes
 .media-button:toggled { color: gold; } /* included in Example1 but overridden by Example2 */
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Example1__root[data-Example1-toggled] { color: red; }
 .Example1__root[data-Example1-loading] { color: green; }
 .Example2__root .Example2__media-button:hover { border: 0.2em solid black; } /* native hover - not declared */
@@ -78,7 +76,6 @@ You can extend another imported stylesheet and inherit its custom pseudo-classes
 
 You can use this feature to define states even if the existing components you are targeting are not based on **Stylable**. In this example, `toggled` and `loading` are defined on the root class with their custom implementation. .Stylable generates selectors using custom `data-*` attributes. The CSS output uses the custom implementation defined in `-st-states` rather then its default generated `data-*` attributes.
 
-**CSS API**
 ```css
 /* example-custom.st.css */
 @namespace "ExampleCustom"
@@ -89,13 +86,13 @@ You can use this feature to define states even if the existing components you ar
 .root:loading { color: green; }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .ExampleCustom__root.on { color: red; }
 .ExampleCustom__root[data-spinner] { color: green; }
 ```
 
-> **Note**:  
+> **Note**    
 > When writing custom mappping, ensure your custom selector targets a simple selector, and not a CSS child selector.
 
 ## Enable custom pseudo-classes

--- a/site/docs/references/pseudo-elements.md
+++ b/site/docs/references/pseudo-elements.md
@@ -1,6 +1,6 @@
 ---
 id: references/pseudo-elements
-title: Pseudo-elements
+title: Pseudo-Elements
 layout: docs
 ---
 
@@ -12,7 +12,6 @@ Any [CSS class](./class-selectors.md) is accessible as a pseudo-element of an [e
 
 When you define a CSS class inside a component, in this case a `play-button` in a `VideoPlayer`, that class may be targeted as a pseudo-element of any class that extends the component `VideoPlayer`.
 
-**CSS API**
 ```css
 /* video-player.st.css */
 @namespace "VideoPlayer"
@@ -29,8 +28,9 @@ Use `::` to access an internal part of a component after a [custom tag selector]
 
 In this example, you [import](./imports.md) a `VideoPlayer` component into your stylesheet, and style an internal part called `play-button` overriding its original styling.
 
-**CSS API**
+
 ```css
+/* CSS */
 @namespace "Page"
 :import {
     -st-from: './video-player.st.css';
@@ -45,15 +45,15 @@ In this example, you [import](./imports.md) a `VideoPlayer` component into your 
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Page__root .Page__main-video.VideoPlayer__root .VideoPlayer__play-button {
     background: green;
     color: purple;
 }
 ```
 
-> **Note**:  
+> **Note**    
 > Custom pseudo elements are not limited to the end of a selector like native pseudo-elements, and they can be chained. For example, you can access the label of a navigation button from a gallery: `.my-gallery::nav-btn::label`.
 
 
@@ -65,7 +65,6 @@ In this example, the class `play-button` is available from the original componen
 
 The `page.css` stylesheet can then extend `super-video-player.css` and on the `.main-player` class, style `play-button` differently.
 
-**CSS API**
 ```css
 /* super-video-player.st.css */
 @namespace "SuperVideoPlayer"
@@ -96,25 +95,24 @@ The `page.css` stylesheet can then extend `super-video-player.css` and on the `.
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .SuperVideoPlayer__root.VideoPlayer__root .VideoPlayer__play-button { color: gold; }
 .Page__root .Page__main-player.SuperVideoPlayer__root .VideoPlayer__play-button { color: silver; }
 ```
-
 
 
 ## Override custom pseudo-elements
 
 You can use CSS classes to override extended pseudo-elements. 
 
-> **Note**:  
+> **Note**    
 > You can also override native pseudo-elements using **Stylable's** custom pseudo-elements but this is not recommended as it can lead to code that's confusing and hard to maintain.
 
 In this example, `root` extends `VideoPlayer` and so any class placed on the `root` overrides the pseudo-element.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "SuperVideoPlayer"
 :import {
     -st-from: './video-player.css';
@@ -128,11 +126,11 @@ In this example, `root` extends `VideoPlayer` and so any class placed on the `ro
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .SuperVideoPlayer__root.VideoPlayer__root .SuperVideoPlayer__play-button { color: gold; }
 ```
 
-> **Note**:  
+> **Note**    
 > Overriding pseudo-elements changes the targeting in the overriding stylesheet and not in the stylesheet being extended.
 

--- a/site/docs/references/root.md
+++ b/site/docs/references/root.md
@@ -12,16 +12,16 @@ You can apply default styling and behavior to the component on the root class it
 
 The `root` class is added automatically to root in [react integration](react-integration.md). No need to write `className="root"`.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Comp";
 .root { background: red; } /* set component background to red */
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Comp__root { background: red; }
 ```
 
-> **Note**:  
+> **Note**    
 > Root can also define [states](./pseudo-classes) and [extend another component](./extend-stylesheet.md).

--- a/site/docs/references/tag-selectors.md
+++ b/site/docs/references/tag-selectors.md
@@ -8,32 +8,31 @@ Like CSS [type selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_
 
 Tag selectors are **not** scoped themselves. Other selectors used with a tag selector can be scoped. For example if a [class selector](./class-selectors.md) is used with a tag selector, the class is scoped and the tag selector is not.  [Root](./root.md) is always added and is always scoped. The matching qualified name of a tag selector can therefore target any element in the subtree of the component. 
 
-> **Note**: In the future we may add scoped tag selectors which will require Stylable to include additional [DOM integration](./react-integration.md). 
+> **Note**  
+>In the future we may add scoped tag selectors which will require Stylable to include additional [DOM integration](./react-integration.md). 
 
 ## Native Element
 
 Targeting a native element matches any element with the same tag name that is found in a prefix selector. The prefix selector could be a class selector or the root.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Page"
 form { background: green; }
 .side-bar:hover form { background: red; }
 ```
 
-**CSS OUTPUT**
 ```css
-/* form is not namespaced - affects any nested form */
+/* CSS output - form is not namespaced - affects any nested form */
 .Page__root form { background: green; } 
 .Page__root.side-bar:hover form { background: red; }
 ```
 
-> **Note**:  
+> **Note**    
 > `form` is not namespaced.
 
-**React**
 ```jsx
-/* inside a stylable component render */
+/* React - inside a stylable component render */
 <div className="gallery">
     <div className="side-bar">
         <form></form> /* green background and red while hovering parent */
@@ -46,8 +45,8 @@ form { background: green; }
 
 When the value of a stylesheet is [imported](./imports.md) with a **capital first letter**, it can be used as a component tag selector.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Page"
 :import{
     -st-from: "./toggle-button.st.css";
@@ -57,16 +56,15 @@ ToggleButton { background: green; }
 .side-bar:hover ToggleButton { background: red; }
 ```
 
-**CSS OUTPUT**
 ```css
-/* ToggleButton is not namespaced - affects any nested toggle button */
+/* CSS output - ToggleButton is not namespaced - affects any nested toggle button */
 .Page__root .ToggleButton__root { background: green; }
 .Page__root .Page__root.side-bar:hover .ToggleButton__root { background: red; }
 ```
 
-**React Implementation**
+
 ```jsx
-/* Button component implements toggle-button.css */
+/* React implementation - button component implements toggle-button.css */
 import ToggleButton from './toggle-button';
 /* inside a stylable render */
 <div className="gallery">

--- a/site/docs/references/theme.md
+++ b/site/docs/references/theme.md
@@ -4,11 +4,12 @@ title: Theme
 layout: docs
 ---
 
-Used in the [top part of an application](../guides/stylable-application.md#Apply component library theme) and to [create a theme](../guides/stylable-component-library.md#Theme) for a component library.
+You can use theming at the [top level of an application](../guides/stylable-application.md#Apply component library theme) and to [create a theme](../guides/stylable-component-library.md#Theme) for a component library.
 
 When [importing](./imports.md) a stylesheet use`-st-theme` directive to add its look and feel to your stylesheet. Any CSS definitions written inside the imported stylesheet will output to the final CSS.
 
 ```css
+/* CSS */
 @namespace "project";
 :import {
     -st-theme: true;
@@ -21,6 +22,7 @@ When [importing](./imports.md) a stylesheet use`-st-theme` directive to add its 
 Any [shared classes](../guides/shared-classes.md) and [component variants](../guides/component-variants.md) defined at the theme level can be overridden in our stylesheet, by simply redefining them.
 
 ```css
+/* CSS */
 @namespace "project";
 :import {
     -st-theme: true;
@@ -43,6 +45,7 @@ Any [shared classes](../guides/shared-classes.md) and [component variants](../gu
 Any variable defined in a theme file can be overridden. every CSS declaration that use that variable will be overridden under our stylesheet.
 
 ```css
+/* CSS */
 @namespace "project";
 :import {
     -st-theme: true;

--- a/site/docs/references/variables.md
+++ b/site/docs/references/variables.md
@@ -6,15 +6,15 @@ layout: docs
 
 Use variables to define common values to be used across the stylesheet and so they can be exposed for sharing and theming.
 
-> **Note**:  
+> **Note**    
 > Variables are scoped to the specific stylesheet and do not conflict with variables from another stylesheet.
 
 ## Use in stylesheet
 
 Use the syntax `:vars` to define variables, and apply them with a `value()`:
 
-**CSS** 
 ```css
+/* CSS */
 @namespace "Example1";
 :vars {
     color1: red;
@@ -26,8 +26,8 @@ Use the syntax `:vars` to define variables, and apply them with a `value()`:
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output */
 .Example1__root {
     color: red; /* color1 */
     background: green; /* color2 */
@@ -38,8 +38,8 @@ Use the syntax `:vars` to define variables, and apply them with a `value()`:
 
 Any var defined in a stylesheet is exported as a named export and can be [imported](./imports.md) by other stylesheets.
 
-**CSS**
 ```css
+/* CSS */
 @namespace "Example2";
 :import {
     -st-from: "./example1.css"; /* Example1 stylesheet */
@@ -53,8 +53,8 @@ Any var defined in a stylesheet is exported as a named export and can be [import
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Example2__root {
     border: 10px solid red; /* color1 */
 }
@@ -63,15 +63,16 @@ Any var defined in a stylesheet is exported as a named export and can be [import
 }
 ```
 
-> **Note** Imported variables are not exported from the stylesheet that has imported them. They can be exported only from the stylesheet where they are declared.
+> **Note**  
+>Imported variables are not exported from the stylesheet that has imported them. They can be exported only from the stylesheet where they are declared.
 
 
-## Composing variables
+## Compose variables
 
 You can set the value of a variable using another variable.
 
-**CSS API**
 ```css
+/* CSS */
 @namespace "Example3";
 :import {
     -st-from: "./example1.css"; /* Example1 stylesheet */
@@ -85,8 +86,8 @@ You can set the value of a variable using another variable.
 }
 ```
 
-**CSS OUTPUT**
 ```css
+/* CSS output*/
 .Example3__root {
     border: 10px solid red; /* 10px solid {color1} */
 }


### PR DESCRIPTION
Reference Docs:
Added /* CSS */ and "/* CSS output */ to code examples that didn't have css file names
Added /* React integration */ where relevant
Plus misc fixes to note style and headings