### PR TITLE
Create global namespace Stylable for types

### DIFF
--- a/matchers.d.ts
+++ b/matchers.d.ts
@@ -1,4 +1,3 @@
-
 declare module Chai {
     export interface Assertion {
         matchCSS(css: string | string[]): void;

--- a/runtime.d.ts
+++ b/runtime.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="./dist/src/types.d.ts" />
 export * from './dist/src/runtime';

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,19 +1,17 @@
 import * as postcss from 'postcss';
-
-import { Pojo } from "./types";
 import { removeUnusedRules } from "./stylable-utils";
 import { StylableMeta, SDecl, Imported } from "./stylable-processor";
 import { valueReplacer } from "./value-template";
 import { Stylable } from "./stylable";
 
-export type OverrideVars = Pojo<string>;
+export type OverrideVars = Stylable.Pojo<string>;
 export type OverrideDef = { overrideRoot: StylableMeta, overrideVars: OverrideVars };
 export interface ThemeOverrideData {
     index: number;
     path: string;
     overrideDefs: OverrideDef[];
 }
-export type ThemeEntries = Pojo<ThemeOverrideData>; // ToDo: change name to indicate path
+export type ThemeEntries = Stylable.Pojo<ThemeOverrideData>; // ToDo: change name to indicate path
 export type Process = (entry: string) => StylableMeta;
 export type Transform = (meta: StylableMeta) => StylableMeta;
 
@@ -105,7 +103,7 @@ export class Bundler {
         const outputPaths = outputMetaList.map(meta => meta.source);
 
         // index each output entry position
-        const pathToIndex = outputMetaList.reduce<Pojo<number>>((acc, meta, index) => {
+        const pathToIndex = outputMetaList.reduce<Stylable.Pojo<number>>((acc, meta, index) => {
             acc[meta.source] = index;
             return acc;
         }, {})
@@ -137,13 +135,13 @@ export class Bundler {
     //         from: this.resolvePath(_import.from)
     //     }
     // }
-    private applyOverrides(entryMeta: StylableMeta, pathToIndex: Pojo<number>, themeEntries: ThemeEntries): void {
+    private applyOverrides(entryMeta: StylableMeta, pathToIndex: Stylable.Pojo<number>, themeEntries: ThemeEntries): void {
         const outputAST = entryMeta.outputAst!;
         const outputRootSelector = getSheetNSRootSelector(entryMeta, this.stylable.delimiter);
         const isTheme = !!themeEntries[entryMeta.source];
 
         // get overrides from each overridden stylesheet 
-        const overrideInstructions = Object.keys(entryMeta.mappedSymbols).reduce<{ overrideDefs: OverrideDef[], overrideVarsPerDef: Pojo<OverrideVars> }>((acc, symbolId) => {
+        const overrideInstructions = Object.keys(entryMeta.mappedSymbols).reduce<{ overrideDefs: OverrideDef[], overrideVarsPerDef: Stylable.Pojo<OverrideVars> }>((acc, symbolId) => {
             const symbol = entryMeta.mappedSymbols[symbolId];
             let varSourceId = symbolId;
             let originMeta = entryMeta;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -5,7 +5,6 @@ import { cachedProcessFile, MinimalFS, FileProcessor } from "./cached-process-fi
 import { create } from "./runtime";
 import { StylableMeta, process } from "./stylable-processor";
 
-
 export function createGenerator(
     fs: MinimalFS = {
         readFileSync(_path: string) { return '' },
@@ -35,7 +34,7 @@ export function createGenerator(
             meta,
             transformer,
             diagnostics,
-            runtime: <Stylable.RuntimeStylesheet>create(meta.root, meta.namespace, exports, '', meta.source)
+            runtime: create(meta.root, meta.namespace, exports, '', meta.source)
         };
     }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,7 +2,7 @@ import { StylableTransformer } from "./stylable-transformer";
 import { Diagnostics } from "./diagnostics";
 import { safeParse } from "./parser";
 import { cachedProcessFile, MinimalFS, FileProcessor } from "./cached-process-file";
-import { create, RuntimeStylesheet } from "./runtime";
+import { create } from "./runtime";
 import { StylableMeta, process } from "./stylable-processor";
 
 
@@ -35,7 +35,7 @@ export function createGenerator(
             meta,
             transformer,
             diagnostics,
-            runtime: <RuntimeStylesheet>create(meta.root, meta.namespace, exports, '', meta.source)
+            runtime: <Stylable.RuntimeStylesheet>create(meta.root, meta.namespace, exports, '', meta.source)
         };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="./types.ts" />
+
 export { safeParse } from "./parser";
 export { cachedProcessFile, FileProcessor, MinimalFS, CacheItem } from "./cached-process-file";
 export { createEmptyMeta, StylableMeta, process, SDecl, SRule, StylableProcessor, StylableSymbol, ClassSymbol, ElementSymbol, Imported, ImportSymbol, VarSymbol } from "./stylable-processor";
@@ -9,4 +11,6 @@ export { createMinimalFS, File, MinimalFSSetup } from "./memory-minimal-fs";
 export { valueMapping, SBTypesParsers, stKeys } from "./stylable-value-parsers";
 export { Bundler } from "./bundle";
 export { Stylable, createInfrastructure, StylableInfrastructure } from "./stylable";
-export * from "./runtime";
+export { create } from "./runtime";
+export type Stylesheet = Stylable.Stylesheet;
+export type RuntimeStylesheet = Stylable.RuntimeStylesheet;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,3 @@
-import { CSSObject } from "./types";
-
 import * as postcss from "postcss";
 const postcssJS = require("postcss-js");
 const postcssNested = require("postcss-nested");
@@ -8,7 +6,7 @@ const safeParser = require("postcss-safe-parser");
 const postcssConfig = { parser: postcssJS };
 const processor = postcss([postcssNested]);
 
-export function cssObjectToAst(cssObject: CSSObject, sourceFile = '') {
+export function cssObjectToAst(cssObject: Stylable.CSSObject, sourceFile = '') {
     return processor.process(cssObject, {from: sourceFile, ...postcssConfig});
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,16 +1,4 @@
-
-export interface StateMap { [key: string]: boolean }
-
-export interface Stylesheet {
-    namespace: string;
-    root: string;
-    get: (localName: string) => string;
-    cssStates: (stateMapping: StateMap) => StateMap;
-}
-
-export type RuntimeStylesheet = { [key: string]: string } & { $stylesheet: Stylesheet }
-
-export function create(root: string, namespace: string, locals: { [key: string]: string } & { $stylesheet?: Stylesheet }, css: string, moduleId: string): RuntimeStylesheet {
+export function create(root: string, namespace: string, locals: { [key: string]: string } & { $stylesheet?: Stylable.Stylesheet }, css: string, moduleId: string): Stylable.RuntimeStylesheet {
     var style = null;
 
     if (css && typeof document !== 'undefined') {
@@ -27,13 +15,13 @@ export function create(root: string, namespace: string, locals: { [key: string]:
         get(localName: string) {
             return (locals as { [key: string]: string })[localName];
         },
-        cssStates(stateMapping: StateMap) {
+        cssStates(stateMapping: Stylable.StateMap) {
             return stateMapping ? Object.keys(stateMapping).reduce(function (states, key) {
                 if (stateMapping[key]) { states["data-" + namespace.toLowerCase() + "-" + key.toLowerCase()] = true; }
                 return states;
-            }, {} as StateMap) : {};
+            }, {} as Stylable.StateMap) : {};
         }
     };
 
-    return <RuntimeStylesheet>locals;
+    return <Stylable.RuntimeStylesheet>locals;
 }

--- a/src/stylable-processor.ts
+++ b/src/stylable-processor.ts
@@ -5,7 +5,6 @@ import { Diagnostics } from "./diagnostics";
 import { filename2varname, stripQuotation } from "./utils";
 import { valueMapping, SBTypesParsers, stValues, MixinValue } from "./stylable-value-parsers";
 import { matchValue, valueReplacer } from "./value-template";
-import { Pojo } from "./types";
 import { transformMatchesOnRule, CUSTOM_SELECTOR_RE } from './stylable-utils';
 const hash = require('murmurhash');
 
@@ -441,7 +440,7 @@ export class StylableProcessor {
 export interface Imported {
     from: string;
     defaultExport: string;
-    named: Pojo<string>;
+    named: Stylable.Pojo<string>;
     overrides: postcss.Declaration[];
     theme: boolean;
     rule: postcss.Rule;
@@ -496,11 +495,11 @@ export interface StylableMeta {
     imports: Imported[];
     vars: VarSymbol[];
     keyframes: postcss.AtRule[];
-    classes: Pojo<ClassSymbol>;
-    elements: Pojo<ElementSymbol>;
-    mappedSymbols: Pojo<StylableSymbol>;
+    classes: Stylable.Pojo<ClassSymbol>;
+    elements: Stylable.Pojo<ElementSymbol>;
+    mappedSymbols: Stylable.Pojo<StylableSymbol>;
     diagnostics: Diagnostics;
-    customSelectors: Pojo<string>;
+    customSelectors: Stylable.Pojo<string>;
 }
 
 export interface RefedMixin {

--- a/src/stylable-transformer.ts
+++ b/src/stylable-transformer.ts
@@ -4,7 +4,6 @@ import { FileProcessor } from "./cached-process-file";
 import { traverseNode, stringifySelector, SelectorAstNode, parseSelector } from "./selector-utils";
 import { Diagnostics } from "./diagnostics";
 import { valueMapping } from "./stylable-value-parsers";
-import { Pojo } from "./types";
 import { valueReplacer } from "./value-template";
 import { StylableResolver, CSSResolve, JSResolve } from "./postcss-resolver";
 import { cssObjectToAst } from "./parser";
@@ -20,7 +19,7 @@ export interface KeyFrameWithNode {
 
 export interface StylableResults {
     meta: StylableMeta;
-    exports: Pojo<string>;
+    exports: Stylable.Pojo<string>;
 }
 
 export interface ScopedSelectorResults {
@@ -53,7 +52,7 @@ export class StylableTransformer {
     transform(meta: StylableMeta): StylableResults {
         const ast = meta.outputAst = meta.ast.clone();
 
-        const metaExports: Pojo<string> = {};
+        const metaExports: Stylable.Pojo<string> = {};
 
         const keyframeMapping = this.scopeKeyframes(meta);
 
@@ -96,7 +95,7 @@ export class StylableTransformer {
     isChildOfAtRule(rule: postcss.Rule, atRuleName: string){
         return rule.parent && rule.parent.type === 'atrule' && rule.parent.name === atRuleName;
     }
-    exportLocalVars(meta: StylableMeta, metaExports: Pojo<string>) {
+    exportLocalVars(meta: StylableMeta, metaExports: Stylable.Pojo<string>) {
         meta.vars.forEach((varSymbol) => {
             if (metaExports[varSymbol.name]) {
                 this.diagnostics.warn(varSymbol.node, `symbol ${varSymbol.name} is already in use`, { word: varSymbol.name })
@@ -106,7 +105,7 @@ export class StylableTransformer {
             }
         });
     }
-    exportKeyframes(keyframeMapping: Pojo<KeyFrameWithNode>, metaExports: Pojo<string>) {
+    exportKeyframes(keyframeMapping: Stylable.Pojo<KeyFrameWithNode>, metaExports: Stylable.Pojo<string>) {
         Object.keys(keyframeMapping).forEach((name) => {
             if (metaExports[name] === keyframeMapping[name].value) {
                 this.diagnostics.warn(keyframeMapping[name].node, `symbol ${name} is already in use`, { word: name })
@@ -115,9 +114,9 @@ export class StylableTransformer {
             }
         });
     }
-    exportRootClass(meta: StylableMeta, metaExports: Pojo<string>) {
+    exportRootClass(meta: StylableMeta, metaExports: Stylable.Pojo<string>) {
         //TODO: move the theme root composition to the process;
-        const classExports: Pojo<string> = {};
+        const classExports: Stylable.Pojo<string> = {};
         this.handleClass(meta, { type: 'class', name: meta.mappedSymbols[meta.root].name, nodes: [] }, meta.mappedSymbols[meta.root].name, classExports);
         let scopedName = classExports[meta.mappedSymbols[meta.root].name];
         meta.imports.forEach(_import => {
@@ -129,7 +128,7 @@ export class StylableTransformer {
                     import: _import
                 });
                 if (resolved && resolved._kind === 'css') {
-                    const classExports: Pojo<string> = {};
+                    const classExports: Stylable.Pojo<string> = {};
                     this.exportRootClass(resolved.meta, classExports);
                     scopedName += ' ' + classExports[resolved.symbol.name];
                 } else {
@@ -140,7 +139,7 @@ export class StylableTransformer {
         });
         metaExports[meta.root] = scopedName;
     }
-    exportClass(meta: StylableMeta, name: string, classSymbol: ClassSymbol, metaExports: Pojo<string>) {
+    exportClass(meta: StylableMeta, name: string, classSymbol: ClassSymbol, metaExports: Stylable.Pojo<string>) {
         const scopedName = this.scope(name, meta.namespace);
         if (!metaExports[name]) {
             const extend = classSymbol ? classSymbol[valueMapping.extends] : undefined;
@@ -185,7 +184,7 @@ export class StylableTransformer {
                 }
 
                 if (finalSymbol && finalName && finalMeta && !finalSymbol[valueMapping.root]) {
-                    const classExports: Pojo<string> = {};
+                    const classExports: Stylable.Pojo<string> = {};
                     this.handleClass(finalMeta, { type: 'class', name: finalName, nodes: [] }, finalName, classExports);
                     if (classExports[finalName]) {
                         exportedClasses += ' ' + classExports[finalName];
@@ -219,7 +218,7 @@ export class StylableTransformer {
                     }
 
                     if (finalName && finalMeta) {
-                        const classExports: Pojo<string> = {};
+                        const classExports: Stylable.Pojo<string> = {};
                         this.handleClass(finalMeta, { type: 'class', name: finalName, nodes: [] }, finalName, classExports);
                         if (classExports[finalName]) {
                             exportedClasses += ' ' + classExports[finalName];
@@ -299,7 +298,7 @@ export class StylableTransformer {
     }
     scopeKeyframes(meta: StylableMeta) {
         const root = meta.outputAst!;
-        const keyframesExports: Pojo<KeyFrameWithNode> = {};
+        const keyframesExports: Stylable.Pojo<KeyFrameWithNode> = {};
         root.walkAtRules(/keyframes$/, (atRule) => {
             const name = atRule.params;
             if (!!~reservedKeyFrames.indexOf(name)) {
@@ -327,7 +326,7 @@ export class StylableTransformer {
 
         return keyframesExports;
     }
-    scopeSelector(meta: StylableMeta, selector: string, metaExports: Pojo<string>): ScopedSelectorResults {
+    scopeSelector(meta: StylableMeta, selector: string, metaExports: Stylable.Pojo<string>): ScopedSelectorResults {
         let current = meta;
         let symbol: StylableSymbol | null = null;
         let nestedSymbol: StylableSymbol | null;
@@ -415,10 +414,10 @@ export class StylableTransformer {
         };
 
     }
-    scopeRule(meta: StylableMeta, rule: postcss.Rule, metaExports: Pojo<string>): string {
+    scopeRule(meta: StylableMeta, rule: postcss.Rule, metaExports: Stylable.Pojo<string>): string {
         return this.scopeSelector(meta, rule.selector, metaExports).selector;
     }
-    handleClass(meta: StylableMeta, node: SelectorAstNode, name: string, metaExports: Pojo<string>): CSSResolve {
+    handleClass(meta: StylableMeta, node: SelectorAstNode, name: string, metaExports: Stylable.Pojo<string>): CSSResolve {
         const symbol = meta.classes[name];
         const extend = symbol ? symbol[valueMapping.extends] : undefined;
         if (!extend && symbol && symbol.alias) {
@@ -592,8 +591,8 @@ export class StylableTransformer {
     autoStateAttrName(stateName: string, namespace: string) {
         return `data-${namespace.toLowerCase()}-${stateName.toLowerCase()}`;
     }
-    cssStates(stateMapping: Pojo<boolean> | null | undefined, namespace: string) {
-        return stateMapping ? Object.keys(stateMapping).reduce((states: Pojo<boolean>, key) => {
+    cssStates(stateMapping: Stylable.Pojo<boolean> | null | undefined, namespace: string) {
+        return stateMapping ? Object.keys(stateMapping).reduce((states: Stylable.Pojo<boolean>, key) => {
             if (stateMapping[key]) { states[this.autoStateAttrName(key, namespace)] = true; }
             return states;
         }, {}) : {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,18 @@
-export declare type Pojo<T = any> = { [key: string]: T } & object;
-export declare type PartialObject<T> = Partial<T> & object;
-export declare type CSSObject = any & object;
+namespace Stylable {
+    export interface StateMap {
+        [key: string]: boolean
+    }
+
+    export interface Stylesheet {
+        namespace: string;
+        root: string;
+        get: (localName: string) => string;
+        cssStates: (stateMapping: StateMap) => StateMap;
+    }
+
+    export type RuntimeStylesheet = {[key: string]: string} & {$stylesheet: Stylesheet};
+
+    export type Pojo<T = any> = {[key: string]: T} & object;
+    export type PartialObject<T> = Partial<T> & object;
+    export type CSSObject = any & object;
+}

--- a/src/value-template.ts
+++ b/src/value-template.ts
@@ -1,13 +1,11 @@
-import { Pojo } from "./types";
-
 export const matchValue = /value\((.*?)\)/g
 
-export function valueReplacer(value: string, data: Pojo, onMatch: (value: string, name: string, match: string) => any, debug: boolean = false): string {
+export function valueReplacer(value: string, data: Stylable.Pojo, onMatch: (value: string, name: string, match: string) => any, debug: boolean = false): string {
     const result = replaceValue(value, data, onMatch, debug, []);
     return result + ((debug && result !== value) ? ` /* ${value} */` : '');
 }
 
-function replaceValue(value: string, data: Pojo, onMatch: (value: string, name: string, match: string) => any, debug:boolean, visited:string[]):string {
+function replaceValue(value: string, data: Stylable.Pojo, onMatch: (value: string, name: string, match: string) => any, debug:boolean, visited:string[]):string {
     const result = value.replace(matchValue, function (match: string, name: string) {
         const visitedIndex = visited.indexOf(name);
         if(visitedIndex !== -1) {

--- a/tests/utils/generate-test-util.ts
+++ b/tests/utils/generate-test-util.ts
@@ -1,4 +1,3 @@
-import { Pojo } from "../../src/types";
 import { cachedProcessFile, FileProcessor } from "../../src/cached-process-file";
 import { StylableMeta, process } from "../../src/stylable-processor";
 import * as postcss from 'postcss';
@@ -11,8 +10,8 @@ import { isAbsolute } from "path";
 import { Stylable } from "../../src/stylable";
 // const deindent = require('deindent');
 export interface File { content: string; mtime?: Date; namespace?: string }
-export interface InfraConfig { files: Pojo<File>, trimWS?: boolean }
-export interface Config { entry: string, files: Pojo<File>, usedFiles?: string[], trimWS?: boolean }
+export interface InfraConfig { files: Stylable.Pojo<File>, trimWS?: boolean }
+export interface Config { entry: string, files: Stylable.Pojo<File>, usedFiles?: string[], trimWS?: boolean }
 export type RequireType = (path: string) => any;
 
 export function generateInfra(config: InfraConfig, diagnostics: Diagnostics): { resolver: StylableResolver, requireModule: RequireType, fileProcessor: FileProcessor<StylableMeta> } {


### PR DESCRIPTION
Allows referencing a type in a .d.ts file without needing to use import. Furthermore, it allows us to configure a TypeScript project so that we have separate *.st.css and *.css module types, while providing RuntimeStylesheet type for imported '.st.css'. :)