### PR TITLE
changed string regex validator api to match other validators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export { stColor, stString, stNumber, stImage, stPercent, stSize, stCssFrag } fr
 export * from './stylable-mixins';
 export * from './stylable-optimizer';
 export * from './functions';
+export * from './state-validators';

--- a/src/pseudo-states.ts
+++ b/src/pseudo-states.ts
@@ -14,7 +14,8 @@ const valueParser = require('postcss-value-parser');
 
 /* tslint:disable:max-line-length */
 const errors = {
-    UNKNOWN_STATE_TYPE: (name: string) => `unknown pseudo-state "${name}"`,
+    UNKNOWN_STATE_USAGE: (name: string) => `unknown pseudo-state "${name}"`,
+    UNKNOWN_STATE_TYPE: (name: string, type: string) => `pseudo-state "${name}" defined with unknown type: "${type}"`,
     TOO_MANY_STATE_TYPES: (name: string, types: string[]) => `pseudo-state "${name}(${types.join(', ')})" definition must be of a single type`,
     NO_STATE_TYPE_GIVEN: (name: string) => `pseudo-state "${name}" expected a definition of a single type, but received none`,
     TOO_MANY_ARGS_IN_VALIDATOR: (name: string, validator: string, args: string[]) => `pseudo-state "${name}" expected "${validator}" validator to receive a single argument, but it received "${args.join(', ')}"`
@@ -56,7 +57,7 @@ function resolveStateType(
 
         diagnostics.warn(decl,
             errors.NO_STATE_TYPE_GIVEN(stateDefinition.value),
-            {word: decl.value});
+            { word: decl.value });
 
         return;
     }
@@ -64,7 +65,7 @@ function resolveStateType(
     if (stateDefinition.nodes.length > 1) {
         diagnostics.warn(decl,
             errors.TOO_MANY_STATE_TYPES(stateDefinition.value, listOptions(stateDefinition)),
-            {word: decl.value});
+            { word: decl.value });
     }
 
     const paramType = stateDefinition.nodes[0];
@@ -76,13 +77,21 @@ function resolveStateType(
 
     if (isCustomMapping(stateDefinition)) {
         mappedStates[stateDefinition.value] = stateType.type.trim().replace(/\\["']/g, '"');
-    } else if (paramType.type === 'function') {
+    } else if (typeof stateType === 'object' && stateType.type === 'boolean') {
+        resolveBooleanState(mappedStates, stateDefinition);
+        return;
+    } else if (paramType.type === 'function' && stateType.type in systemValidators) {
         if (paramType.nodes.length > 0) {
             resolveArguments(paramType, stateType, stateDefinition.value, diagnostics, decl);
         }
         mappedStates[stateDefinition.value] = stateType;
     } else if (stateType.type in systemValidators) {
         mappedStates[stateDefinition.value] = stateType;
+    } else {
+        diagnostics.warn(decl, errors.UNKNOWN_STATE_TYPE(
+            stateDefinition.value, paramType.value),
+            { word: paramType.value }
+        );
     }
 }
 
@@ -170,7 +179,7 @@ export function validateStateDefinition(
                                     res.errors.unshift(`pseudo-state "${stateName}" default value "${state.defaultValue}" failed validation:`);
                                     diagnostics.warn(decl,
                                         res.errors.join('\n'),
-                                        {word: decl.value});
+                                        { word: decl.value });
                                 }
                             }
 
@@ -200,7 +209,7 @@ export function validateStateArgument(
     };
 
     const { type: paramType, arguments: paramValidators } = stateAst;
-    const validator = systemValidators[stateAst.type];
+    const validator = systemValidators[paramType];
 
     try {
         if (resolvedValidations.res || validateDefinition) {
@@ -272,7 +281,7 @@ export function transformPseudoStateSelector(
 
     if (!found && rule) {
         if (nativePseudoClasses.indexOf(name) === -1) {
-            diagnostics.warn(rule, errors.UNKNOWN_STATE_TYPE(name), { word: name });
+            diagnostics.warn(rule, errors.UNKNOWN_STATE_USAGE(name), { word: name });
         }
     }
 
@@ -341,7 +350,7 @@ function resolveStateValue(
 
             diagnostics.warn(rule,
                 stateParamOutput.errors.join('\n'),
-                {word: actualParam});
+                { word: actualParam });
         }
     }
 

--- a/tests/pseudo-states.spec.ts
+++ b/tests/pseudo-states.spec.ts
@@ -43,6 +43,23 @@ describe('pseudo-states', () => {
                 });
             });
 
+            it('should support explicit boolean state definition', () => {
+                const res = processSource(`
+                    .root {
+                        -st-states: state1(boolean);
+                    }
+                `, { from: 'path/to/style.css' });
+
+                expect(res.diagnostics.reports.length, 'no reports').to.eql(0);
+
+                expect(res.classes).to.containSubset({
+                    root: {
+                        [valueMapping.states]: {
+                            state1: null
+                        }
+                    }
+                });
+            });
         });
 
         describe('advanced type', () => {
@@ -77,6 +94,17 @@ describe('pseudo-states', () => {
                 `, [{
                         // tslint:disable-next-line:max-line-length
                         message: 'pseudo-state "state1" expected "contains" validator to receive a single argument, but it received "one, two"',
+                        file: 'main.css'
+                    }]);
+            });
+
+            it('should warn when encountering an unknown type', () => {
+                expectWarnings(`
+                    .my-class {
+                        |-st-states: state1( $unknown$ )|;
+                    }
+                `, [{
+                        message: 'pseudo-state "state1" defined with unknown type: "unknown"',
                         file: 'main.css'
                     }]);
             });
@@ -147,7 +175,7 @@ describe('pseudo-states', () => {
                 it('with a regex validator', () => {
                     const res = processSource(`
                         .root {
-                            -st-states: state1(string("^user"));
+                            -st-states: state1( string( regex("^user") ));
                         }
                     `, { from: 'path/to/style.css' });
 
@@ -158,7 +186,10 @@ describe('pseudo-states', () => {
                             [valueMapping.states]: {
                                 state1: {
                                     type: 'string',
-                                    arguments: ['^user']
+                                    arguments: [{
+                                        name: 'regex',
+                                        args: ['^user']
+                                    }]
                                 }
                             }
                         }
@@ -225,7 +256,7 @@ describe('pseudo-states', () => {
                 it('with a nested validator and a regex validator', () => {
                     const res = processSource(`
                         .root {
-                            -st-states: state1(string("^user", contains(user)));
+                            -st-states: state1(string( regex("^user"), contains(user) ));
                         }
                     `, { from: 'path/to/style.css' });
 
@@ -237,7 +268,10 @@ describe('pseudo-states', () => {
                                 state1: {
                                     type: 'string',
                                     arguments: [
-                                        '^user',
+                                        {
+                                            name: 'regex',
+                                            args: ['^user']
+                                        },
                                         {
                                             name: 'contains',
                                             args: ['user']
@@ -511,6 +545,27 @@ describe('pseudo-states', () => {
                 });
             });
 
+            it('should support explicitly defined boolean state type', () => {
+                const res = generateStylableResult({
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: state1(boolean);
+                            }
+                            .my-class:state1 {}
+                            `
+                        }
+                    }
+                });
+
+                expect(res.meta.diagnostics.reports, 'no diagnostics reported for native states').to.eql([]);
+                expect(res).to.have.styleRules({
+                    1: '.entry--my-class[data-entry-state1] {}'
+                });
+            });
         });
 
         describe('advanced type / validation', () => {
@@ -625,7 +680,7 @@ describe('pseudo-states', () => {
                                     namespace: 'entry',
                                     content: `
                                     .my-class {
-                                        -st-states: state1( string("^user") );
+                                        -st-states: state1( string( regex("^user") ));
                                     }
                                     .my-class:state1(userName) {}
                                     `
@@ -647,7 +702,7 @@ describe('pseudo-states', () => {
                                     namespace: 'entry',
                                     content: `
                                     .my-class {
-                                        -st-states: state1( string("^user") );
+                                        -st-states: state1( string( regex("^user") ));
                                     }
                                     |.my-class:state1(failingParameter)| {}
                                     `
@@ -752,7 +807,7 @@ describe('pseudo-states', () => {
                                     namespace: 'entry',
                                     content: `
                                     .my-class {
-                                        -st-states: state1(string("^user", minLength(3), maxLength(5)));
+                                        -st-states: state1( string( regex("^user"), minLength(3), maxLength(5) ));
                                     }
                                     .my-class:state1(user) {}
                                     `
@@ -830,7 +885,7 @@ describe('pseudo-states', () => {
                                     namespace: 'entry',
                                     content: `
                                     .my-class {
-                                        -st-states: state1(string(maxLength(3), "^case"));
+                                        -st-states: state1( string( maxLength(3), regex("^case") ));
                                     }
                                     |.my-class:state1($user$)| {}
                                     `
@@ -873,9 +928,6 @@ describe('pseudo-states', () => {
                             ].join('\n'),
                             file: '/entry.st.css'
                         }]);
-                        // expect(res).to.have.styleRules({
-                        //     0: '.entry--my-class[data-entry-state1="passedValue"] {}'
-                        // });
                     });
                 });
             });
@@ -953,6 +1005,30 @@ describe('pseudo-states', () => {
                     expect(res).to.have.styleRules({
                         1: '.entry--my-class[data-entry-state1="blah"] {}'
                     });
+                });
+
+                it('should warn when trying to use an unknown number validator', () => {
+                    const config = {
+                        entry: `/entry.st.css`,
+                        files: {
+                            '/entry.st.css': {
+                                namespace: 'entry',
+                                content: `
+                                .my-class {
+                                    |-st-states: $state1( number( missing() ))$|;
+                                }
+                                `
+                            }
+                        }
+                    };
+
+                    const res = expectWarningsFromTransform(config, [{
+                        message: [
+                            'pseudo-state "state1" default value "" failed validation:',
+                            'encountered unknown number validator "missing"'
+                        ].join('\n'),
+                        file: '/entry.st.css'
+                    }]);
                 });
 
                 describe('specific validators', () => {


### PR DESCRIPTION
- also added tests for unknown state types
- support explicit boolean state definition, e.g.
`-st-states: myState(boolean);`