### PR TITLE
Add diagnostics for unscoped elements and imported classes

### DIFF
--- a/packages/stylable/src/selector-utils.ts
+++ b/packages/stylable/src/selector-utils.ts
@@ -1,3 +1,4 @@
+import * as postcss from 'postcss';
 const tokenizer = require('css-selector-tokenizer');
 
 export interface SelectorAstNode {
@@ -237,4 +238,12 @@ export function fixChunkOrdering(selectorNode: SelectorAstNode, prefixType: Sele
         }
         return undefined;
     });
+}
+
+export function isChildOfAtRule(rule: postcss.Rule, atRuleName: string) {
+    return rule.parent && rule.parent.type === 'atrule' && rule.parent.name === atRuleName;
+}
+
+export function isCompRoot(name: string) {
+    return name.charAt(0).match(/[A-Z]/);
 }

--- a/packages/stylable/src/selector-utils.ts
+++ b/packages/stylable/src/selector-utils.ts
@@ -75,23 +75,11 @@ export function createChecker(types: Array<string | string[]>) {
     };
 }
 
-export function isSpacing(node: SelectorAstNode) {
-    return node.type === 'spacing';
-}
-
-export function isElement(node: SelectorAstNode) {
-    return node.type === 'element';
-}
-
-export function isClass(node: SelectorAstNode) {
-    return node.type === 'class';
-}
-
 export function isGlobal(node: SelectorAstNode) {
     return node.type === 'nested-pseudo-class' && node.name === 'global';
 }
 
-export function createRootAfterSpaceChecker(ast: SelectorAstNode, rootName: string) {
+export function isRootValid(ast: SelectorAstNode, rootName: string) {
     let isValid = true;
 
     traverseNode(ast, (node, index, nodes) => {
@@ -101,14 +89,14 @@ export function createRootAfterSpaceChecker(ast: SelectorAstNode, rootName: stri
         if (node.type === 'class' && node.name === rootName) {
             let isLastScopeGlobal = false;
             for (let i = 0; i < index; i++) {
-                const p = nodes[i];
-                if (isGlobal(p)) {
+                const part = nodes[i];
+                if (isGlobal(part)) {
                     isLastScopeGlobal = true;
                 }
-                if (isSpacing(p) && !isLastScopeGlobal) {
+                if (part.type === 'spacing' && !isLastScopeGlobal) {
                     isValid = false;
                 }
-                if (isElement(p) || (isClass(p) && p.value !== 'root')) {
+                if (part.type === 'element' || (part.type === 'class' && part.value !== 'root')) {
                     isLastScopeGlobal = false;
                 }
             }

--- a/packages/stylable/src/stylable-transformer.ts
+++ b/packages/stylable/src/stylable-transformer.ts
@@ -11,7 +11,7 @@ import {
     transformPseudoStateSelector,
     validateStateDefinition
 } from './pseudo-states';
-import { parseSelector, SelectorAstNode, stringifySelector, traverseNode } from './selector-utils';
+import { isChildOfAtRule, parseSelector, SelectorAstNode, stringifySelector, traverseNode } from './selector-utils';
 import { appendMixins } from './stylable-mixins';
 import { removeSTDirective } from './stylable-optimizer';
 import {
@@ -131,7 +131,7 @@ export class StylableTransformer {
         const keyframeMapping = this.scopeKeyframes(ast, meta);
 
         ast.walkRules((rule: SRule) => {
-            if (this.isChildOfAtRule(rule, 'keyframes')) { return; }
+            if (isChildOfAtRule(rule, 'keyframes')) { return; }
             rule.selector = this.scopeRule(meta, rule, scopeRoot, metaExports);
         });
 
@@ -180,10 +180,6 @@ export class StylableTransformer {
             this.exportLocalVars(meta, metaExports, variableOverride);
             this.exportKeyframes(keyframeMapping, metaExports);
         }
-
-    }
-    public isChildOfAtRule(rule: postcss.Rule, atRuleName: string) {
-        return rule.parent && rule.parent.type === 'atrule' && rule.parent.name === atRuleName;
     }
     public exportLocalVars(meta: StylableMeta, metaExports: Pojo<string>, variableOverride?: Pojo<string>) {
         meta.vars.forEach(varSymbol => {

--- a/packages/stylable/tests/diagnostics.spec.ts
+++ b/packages/stylable/tests/diagnostics.spec.ts
@@ -243,32 +243,38 @@ describe('diagnostics: warnings and errors', () => {
     describe('structure', () => {
 
         describe('root', () => {
-            it('should return warning for ".root" after selector', () => {
+            it('should return warning for ".root" after a selector', () => {
                 expectWarnings(`
                     |.gaga .root|{}
-                `, [{ message: '.root class cannot be used after spacing', file: 'main.css' }]);
+                `, [{ message: processorWarnings.ROOT_AFTER_SPACING(), file: 'main.css' }]);
             });
 
             it('should return warning for ".root" after global and local classes', () => {
                 expectWarnings(`
                     |:global(*) .x .root|{}
                 `, [
-                    { message: '.root class cannot be used after spacing', file: 'main.css' }
+                    { message: processorWarnings.ROOT_AFTER_SPACING(), file: 'main.css' }
                 ]);
             });
 
-            it('should return warning for ".root" after global and element', () => {
+            it('should return warning for ".root" after a global and element', () => {
                 expectWarnings(`
                     |:global(*) div .root|{}
                 `, [
                     { message: processorWarnings.UNSCOPED_ELEMENT('div'), file: 'main.css' },
-                    { message: '.root class cannot be used after spacing', file: 'main.css' }
+                    { message: processorWarnings.ROOT_AFTER_SPACING(), file: 'main.css' }
                 ]);
             });
 
-            it('should not return warning for ".root" after global selector', () => {
+            it('should not return warning for ".root" after a global selector', () => {
                 expectWarnings(`
                     :global(*) .root{}
+                `, []);
+            });
+
+            it('should not return warning for ".root" after a complex global selector', () => {
+                expectWarnings(`
+                    :global(body[dir="rtl"] > header) .root {}
                 `, []);
             });
         });
@@ -858,7 +864,7 @@ describe('diagnostics: warnings and errors', () => {
                 ]);
             });
 
-            it('should warn when using imported element', () => {
+            it('should warn when using imported element with no root scoping', () => {
                 expectWarnings(`
                     :import {
                         -st-from: "./blah.st.css";

--- a/packages/stylable/tests/utils/diagnostics.ts
+++ b/packages/stylable/tests/utils/diagnostics.ts
@@ -9,6 +9,7 @@ export interface Diagnostic {
     message: string;
     file: string;
     skipLocationCheck?: boolean;
+    skip?: boolean;
 }
 
 export function findTestLocations(css: string) {
@@ -49,6 +50,8 @@ export function expectWarnings(css: string, warnings: Diagnostic[]) {
     const res = process(root);
 
     res.diagnostics.reports.forEach((report, i) => {
+        if (warnings[i].skip) { return; }
+
         expect(report.message).to.equal(warnings[i].message);
         expect(report.node.source.start, 'start').to.eql(source.start);
         if (source.word !== null) {


### PR DESCRIPTION
Very basic example can be seen here - for a more thorough review see tests use case.

Should warn:
```css
:import {
    -st-from: "./blah.st.css";
    -st-named: blah;
}

.blah {}
```

```css
button {}
```

Should not warn:
```css
:import {
    -st-from: "./blah.st.css";
    -st-named: blah;
}
.root {}
.root .blah {}
```

```css
.root button {}

```