### PR TITLE
Core: Add warning for CSS mixin without named params

### DIFF
--- a/packages/stylable/src/stylable-utils.ts
+++ b/packages/stylable/src/stylable-utils.ts
@@ -158,7 +158,7 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule>(
     // keyframes on class mixin?
 
     const prefixType = parseSelector(selectorPrefix).nodes[0].nodes[0];
-    const containsPrefix = containsMatchInFistChunk.bind(null, prefixType);
+    const containsPrefix = containsMatchInFirstChunk.bind(null, prefixType);
     const mixinRoot = mixinTarget ? mixinTarget : postcss.root();
 
     root.nodes!.forEach(node => {
@@ -291,7 +291,7 @@ function destructiveReplaceNode(
     return ast;
 }
 
-function containsMatchInFistChunk(prefixType: SelectorAstNode, selectorNode: SelectorAstNode) {
+function containsMatchInFirstChunk(prefixType: SelectorAstNode, selectorNode: SelectorAstNode) {
     let isMatch = false;
     traverseNode(selectorNode, node => {
         if (node.type === 'operator' || node.type === 'spacing') {

--- a/packages/stylable/tests/diagnostics.spec.ts
+++ b/packages/stylable/tests/diagnostics.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/native-reserved-lists';
 import { safeParse } from '../src/parser';
 import { process, processorWarnings } from '../src/stylable-processor';
+import { valueParserWarnings } from '../src/stylable-value-parsers';
 import { Config, generateFromMock } from './utils/generate-test-util';
 const deindent = require('deindent');
 import {
@@ -288,6 +289,21 @@ describe('diagnostics: warnings and errors', () => {
                 `, [{ message: 'unknown mixin: "myMixin"', file: 'main.css' }]);
             });
 
+            it('should return a warning for a CSS mixin using un-named params', () => {
+                expectWarnings(`
+                    .mixed {
+                        color: red;
+                    }
+                    .gaga{
+                        |-st-mixin: mixed($1$)|;
+                    }
+
+                `, [{
+                    message: valueParserWarnings.CSS_MIXIN_FORCE_NAMED_PARAMS(),
+                    file: 'main.css'
+                }]);
+            });
+
             it('should add error when can not append css mixins', () => {
                 const config = {
                     entry: '/main.css',
@@ -410,7 +426,7 @@ describe('diagnostics: warnings and errors', () => {
                     }
                 };
                 expectWarningsFromTransform(config,
-                    [{ message: 'value can not be a string (remove quotes?)', file: '/main.css' }]);
+                    [{ message: valueParserWarnings.VALUE_CANNOT_BE_STRING(), file: '/main.css' }]);
             });
         });
 
@@ -1003,7 +1019,7 @@ describe('diagnostics: warnings and errors', () => {
                 }
             };
             expectWarningsFromTransform(config,
-                [{ message: 'value can not be a string (remove quotes?)', file: '/main.st.css' }]);
+                [{ message: valueParserWarnings.VALUE_CANNOT_BE_STRING(), file: '/main.st.css' }]);
         });
 
     });


### PR DESCRIPTION
Trying to use a CSS mixin without a named parameter will now issue a warning:
```css
:vars {
    myColor: red;
}
.mixed {
    color: value(myColor);
}
.someClass {
    -st-mixin: mixed(666);
}
```

Warning: `CSS mixins must use named parameters (e.g. "func(name value, [name value, ...])")`

Correct example:
```css
...
.someClass {
    -st-mixin: mixed(myColor 666);
}
```