### PR TITLE
Core: fix bug with double wrapped (with quotes) state parameters

### DIFF
--- a/packages/stylable/src/pseudo-states.ts
+++ b/packages/stylable/src/pseudo-states.ts
@@ -9,6 +9,7 @@ import { StylableResolver } from './stylable-resolver';
 import { groupValues, listOptions, MappedStates } from './stylable-value-parsers';
 import { valueMapping } from './stylable-value-parsers';
 import { ParsedValue, Pojo, StateParsedValue } from './types';
+import { stripQuotation } from './utils';
 
 const isVendorPrefixed = require('is-vendor-prefixed');
 const valueParser = require('postcss-value-parser');
@@ -369,8 +370,8 @@ function resolveStateValue(
 
     const selectorSuffix = stateDef.type === 'tag' ? '~' : undefined; // TODO: should be generic
 
-    const strippedParam = actualParam.replace(/['"`]+/g, '');
-    node.content = `${autoStateAttrName(name, namespace, selectorSuffix)}="${strippedParam}"`;
+    const strippedParam = stripQuotation(actualParam);
+    node.content = `${autoStateAttrName(name, namespace, selectorSuffix)}=${JSON.stringify(strippedParam)}`;
 }
 
 function resolveParam(

--- a/packages/stylable/src/pseudo-states.ts
+++ b/packages/stylable/src/pseudo-states.ts
@@ -369,7 +369,8 @@ function resolveStateValue(
 
     const selectorSuffix = stateDef.type === 'tag' ? '~' : undefined; // TODO: should be generic
 
-    node.content = `${autoStateAttrName(name, namespace, selectorSuffix)}="${actualParam}"`;
+    const strippedParam = actualParam.replace(/['"`]+/g, '');
+    node.content = `${autoStateAttrName(name, namespace, selectorSuffix)}="${strippedParam}"`;
 }
 
 function resolveParam(

--- a/packages/stylable/src/utils.ts
+++ b/packages/stylable/src/utils.ts
@@ -14,7 +14,7 @@ export const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProper
 // }
 
 export function stripQuotation(str: string) {
-    return str.replace(/^['"]|['"]$/g, '');
+    return str.replace(/^['"](.*?)['"]$/g, '$1');
 }
 
 export function filename2varname(filename: string) {

--- a/packages/stylable/tests/pseudo-states.spec.ts
+++ b/packages/stylable/tests/pseudo-states.spec.ts
@@ -596,6 +596,28 @@ describe('pseudo-states', () => {
                 });
             });
 
+            it('should strip quotation marks when transform any state parameter', () => {
+                const res = generateStylableResult({
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: state1(string);
+                            }
+                            .my-class:state1("someString") {}
+                            `
+                        }
+                    }
+                });
+
+                expect(res.meta.diagnostics.reports, 'no diagnostics reported for native states').to.eql([]);
+                expect(res).to.have.styleRules({
+                    1: '.entry--my-class[data-entry-state1="someString"] {}'
+                });
+            });
+
             describe('string', () => {
 
                 it('should transform string validator', () => {


### PR DESCRIPTION
For issue #352 