### PR TITLE
Core: lowercase default imports now warn about the correct node

### DIFF
--- a/packages/stylable/src/stylable-processor.ts
+++ b/packages/stylable/src/stylable-processor.ts
@@ -431,6 +431,13 @@ export class StylableProcessor {
                     break;
                 case valueMapping.default:
                     importObj.defaultExport = decl.value;
+
+                    if (!isCompRoot(importObj.defaultExport) && importObj.from.match(/\.css$/)) {
+                        this.diagnostics.warn(
+                            decl,
+                            processorWarnings.DEFAULT_IMPORT_IS_LOWER_CASE(),
+                            { word: importObj.defaultExport });
+                    }
                     break;
                 case valueMapping.named:
                     importObj.named = parseNamed(decl.value);
@@ -443,14 +450,6 @@ export class StylableProcessor {
                     break;
             }
         });
-
-        if (importObj.defaultExport && !isCompRoot(importObj.defaultExport) && importObj.from.match(/\.css$/)) {
-            this.diagnostics.warn(
-                rule,
-                processorWarnings.DEFAULT_IMPORT_IS_LOWER_CASE(),
-                { word: importObj.defaultExport }
-            );
-        }
 
         if (!importObj.theme) {
             importObj.overrides.forEach(decl => {

--- a/packages/stylable/tests/diagnostics.spec.ts
+++ b/packages/stylable/tests/diagnostics.spec.ts
@@ -471,10 +471,10 @@ describe('diagnostics: warnings and errors', () => {
 
             it('should return warning when default import is defined with a lowercase first letter', () => {
                 expectWarnings(`
-                    |:import{
+                    :import{
                         -st-from:"./file.st.css";
-                        -st-default: $theme$;
-                    }|
+                        |-st-default: $theme$;|
+                    }
                 `, [{ message: processorWarnings.DEFAULT_IMPORT_IS_LOWER_CASE(), file: 'main.css' }]);
             });
 


### PR DESCRIPTION
Previously, warnings about lower case default imports from component stylesheets would warn about the entire import rule (see issue #357).

Now, they target the `-st-default` declaration specifically, leading to more precise warnings in the stylable-intelligence extension.