### PR TITLE
Centralize scripts global types usage 

### DIFF
--- a/packages/stylable-jest/test/jest.spec.ts
+++ b/packages/stylable-jest/test/jest.spec.ts
@@ -8,7 +8,7 @@ describe('jest process', () => {
     it('should process stylable sources', () => {
         const filename = path.join(__dirname, 'fixtures', 'test.st.css');
         const content = fs.readFileSync(filename, 'utf8');
-        const module = evalNode(process(content, filename), filename);
+        const module = evalNode(process(content, filename), filename).default;
 
         expect(module.root).to.equal(`${module.$namespace}--root`);
         expect(module.test).to.equal(`${module.$namespace}--test`);

--- a/packages/stylable-node/src/stylable-module-source.ts
+++ b/packages/stylable-node/src/stylable-module-source.ts
@@ -13,7 +13,8 @@ export function generateModuleSource(stylableResult: StylableResults, injectCSS:
     //     i => (i.fromRelative.match(/\.st\.css$/) ? `require("${i.fromRelative}");` : '')
     // );
     return `
-module.exports = require(${JSON.stringify(runtimePath)}).create(
+Object.defineProperty(module, "__esModule", { value: true })
+module.exports.default = require(${JSON.stringify(runtimePath)}).create(
     ${root},
     ${namespace},
     ${localsExports},

--- a/packages/stylable-node/test/require-hook.spec.ts
+++ b/packages/stylable-node/test/require-hook.spec.ts
@@ -13,7 +13,7 @@ describe('require hook', () => {
 
     it('should work on .st.css', () => {
         attachHook();
-        const m = require('./fixtures/test.st.css');
+        const m = require('./fixtures/test.st.css').default;
         expect(m.root).to.equal(m.$namespace + '--root');
         expect(m.test).to.equal(m.$namespace + '--test');
     });

--- a/packages/stylable-scripts/template/src/globals.d.ts
+++ b/packages/stylable-scripts/template/src/globals.d.ts
@@ -1,30 +1,4 @@
-type StateValue = boolean | number | string;
-
-interface StateMap {
-    [stateName: string]: StateValue;
-}
-
-interface AttributeMap {
-    className?: string
-    [attributeName: string]: StateValue | undefined
-}
-
-interface InheritedAttributes {
-    className?: string
-    [props: string]: any
-}
-
-type RuntimeStylesheet = {
-    (className: string, states: StateMap, inheritedAttributes?: InheritedAttributes): AttributeMap
-    $root: string,
-    $namespace: string,
-    $depth: number,
-    $id: string | number,
-    $css?: string,
-
-    $get(localName: string): string | undefined;
-    $cssStates(stateMapping?: StateMap | null): StateMap;
-} & { [localName: string]: string }
+type RuntimeStylesheet = import('stylable-runtime').RuntimeStylesheet;
 
 declare module '*.st.css' {
     const stylesheet: RuntimeStylesheet;


### PR DESCRIPTION
`stylable-scripts` global `.d.ts` definitions now import their definitions from  `stylable-runtime`.

Also correct `stylable-node` exported stylesheet type to `default`.