### PR TITLE
dom-test-kit: extract package from core testing utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repository is a `mono-repo` containing multiple `packages` that together co
 |Package Name|Published Name|Latest Version|Description|
 |------------|--------------|:------------:|-----------|
 |[e2e-test-kit](./packages/e2e-test-kit)|`@stylable/e2e-test-kit`|[![npm version](https://img.shields.io/npm/v/@stylable/e2e-test-kit.svg)](https://www.npmjs.com/package/@stylable/e2e-test-kit)|`webpack` project runner used for `E2E` testing |
+|[dom-test-kit](./packages/dom-test-kit)|`@stylable/dom-test-kit`|[![npm version](https://img.shields.io/npm/v/@stylable/dom-test-kit.svg)](https://www.npmjs.com/package/@stylable/dom-test-kit)|Stylable DOM related testing utils |
 |[cli](./packages/cli)|`@stylable/cli`|[![npm version](https://img.shields.io/npm/v/@stylable/cli.svg)](https://www.npmjs.com/package/@stylable/cli)|Used for managing Stylable stylesheets in a project|
 |[react-scripts](./packages/react-scripts)|`@stylable/react-scripts`|[![npm version](https://img.shields.io/npm/v/@stylable/react-scripts.svg)](https://www.npmjs.com/package/@stylable/react-scripts)|`create-react-app` boilerplate generator scripts|
 |[stylable.io](./packages/stylable.io)|unpublished to `npm`|-|source for [stylable.io](http://stylable.io)|

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/cli.svg)](https://www.npmjs.com/package/@stylable/cli)
 
-`@stylable/cli` is a low-level utility used for working with **Stylable** projects directly.
+`@stylable/cli` is a low-level utility used for working with Stylable projects directly.
 
 - Build and transform stylesheets into JavaScript modules
 - Generate an entry index file to help consume a published project

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stylable/cli",
   "version": "1.0.7",
+  "description": "A low-level utility used for working with Stylable projects",
   "main": "dist/build.js",
   "types": "dist/build.d.ts",
   "bin": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ Follow these instructions in order to run Stylable in development mode, this all
 Stylable's workflow contains two main parts that together perform the CSS transpilation.
 
 - `stylable-processor` - Parses each `stylesheet` separately into its own AST ([abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree), extracting the required data without any resolution of dependencies in other files.
-- `stylable-transformer` - Processes each stylesheeet using the previously created data including other file dependencies. Transforms our Stylable CSS into vanilla CSS.
+- `stylable-transformer` - Processes each stylesheet using the previously created data including other file dependencies. Transforms our Stylable CSS into vanilla CSS.
 
 ## License
 

--- a/packages/core/tests/utils/test-utils.ts
+++ b/packages/core/tests/utils/test-utils.ts
@@ -1,3 +1,2 @@
-export * from './generate-test-util';
-export * from './stylable-dom-util';
 export * from './ast-matchers';
+export * from './generate-test-util';

--- a/packages/dom-test-kit/LICENSE
+++ b/packages/dom-test-kit/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017, Wix.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Wix.com Ltd. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/dom-test-kit/README.md
+++ b/packages/dom-test-kit/README.md
@@ -2,33 +2,49 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/dom-test-kit.svg)](https://www.npmjs.com/package/stylable/dom-test-kit)
 
-`@stylable/dom-test-kit` is at the center of how Stylable operates. It provides the basic capabilities required for Stylable to parse stylesheets and transform their output to valid plain CSS.
+`@stylable/dom-test-kit` is comprised of a single class named `StylableDOMUtil` which exposes several DOM related testing utilities.
 
-## How to use
+## Example
+```css
+/* style.st.css */
+.root {}
 
-The `@stylable/dom-test-kit` exposes a single class named `StylableDOMUtil`, and from that class, several testing utilities are available:
+.part {
+    -st-states: loading;
+}
+```
+```ts
+/* test.ts */
+import { StylableDOMUtil } from '@stylable/dom-test-kit';
+import style from './my-component.st.css';
 
-#### `select(selector?: string, element?: QueryElement): Element | null` -
-Select the first `element` in the DOM that matches the provided Stylable selector.
+const domUtil = new StylableDOMUtil(style);
+const partElement = domUtil.select(style.part);
 
-#### `selectAll(selector?: string, element?: QueryElement): Element[] | null` -
-Select all `elements` in the DOM that match the provided Stylable selector.
+domUtil.hasStyleState(partElement, 'loading');
+```
 
-#### `scopeSelector(selector?: string): string` -
+## What does it do?
+
+> Note: currently all of the provided utilities support only simplified Stylable selectors, consisting only of `class` and `pseudo-class` selectors.
+
+### `constructor(style: RuntimeStylesheet, root?: Element)`
+Initialize the `StylableDOMUtil` by providing a source stylesheet that would function as the base for all testing utilities. You may pass a DOM root element to serve as the default entry point for the `select` methods,
+
+### `select(selector?: string, element?: Element): Element | null`
+Select the first `element` in the DOM that matches the provided Stylable `selector`.
+
+### `selectAll(selector?: string, element?: Element): Element[] | null`
+Select all `elements` in the DOM that match the provided Stylable `selector`.
+
+### `scopeSelector(selector?: string): string`
 Transforms a Stylable `selector` to its target vanilla CSS.
 
-#### `hasStyleState(element: StateElement, stateName: string, param: StateValue = true): boolean` -
+### `hasStyleState(element: Element, stateName: string, param: StateValue = true): boolean`
 Check whether the provided `element` has the corresponding state set. This method can also receive a third optional param to validate the state active value.
 
-#### `getStyleState(element: StateElement, stateName: string): string | null` -
+### `getStyleState(element: Element, stateName: string): string | null`
 Get an `element` state value if exists, `null` if it does not.
-
-#### `getStateDataAttrKey(state: string, param: StateValue = true` -
-Transform a Stylable `state` to its target DOM attribute key.
-
-#### `getStateDataAttr(state: string, param: StateValue = true): string` -
-Transform a Stylable `state` to its target DOM attribute and value.
-
 
 ## License
 

--- a/packages/dom-test-kit/README.md
+++ b/packages/dom-test-kit/README.md
@@ -1,0 +1,35 @@
+# @stylable/dom-test-kit
+
+[![npm version](https://img.shields.io/npm/v/@stylable/dom-test-kit.svg)](https://www.npmjs.com/package/stylable/dom-test-kit)
+
+`@stylable/dom-test-kit` is at the center of how Stylable operates. It provides the basic capabilities required for Stylable to parse stylesheets and transform their output to valid plain CSS.
+
+## How to use
+
+The `@stylable/dom-test-kit` exposes a single class named `StylableDOMUtil`, and from that class, several testing utilities are available:
+
+#### `select(selector?: string, element?: QueryElement): Element | null` -
+Select the first `element` in the DOM that matches the provided Stylable selector.
+
+#### `selectAll(selector?: string, element?: QueryElement): Element[] | null` -
+Select all `elements` in the DOM that match the provided Stylable selector.
+
+#### `scopeSelector(selector?: string): string` -
+Transforms a Stylable `selector` to its target vanilla CSS.
+
+#### `hasStyleState(element: StateElement, stateName: string, param: StateValue = true): boolean` -
+Check whether the provided `element` has the corresponding state set. This method can also receive a third optional param to validate the state active value.
+
+#### `getStyleState(element: StateElement, stateName: string): string | null` -
+Get an `element` state value if exists, `null` if it does not.
+
+#### `getStateDataAttrKey(state: string, param: StateValue = true` -
+Transform a Stylable `state` to its target DOM attribute key.
+
+#### `getStateDataAttr(state: string, param: StateValue = true): string` -
+Transform a Stylable `state` to its target DOM attribute and value.
+
+
+## License
+
+Copyright (c) 2017 Wix.com Ltd. All Rights Reserved. Use of this source code is governed by a [BSD license](./LICENSE).

--- a/packages/dom-test-kit/package.json
+++ b/packages/dom-test-kit/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@stylable/dom-test-kit",
+  "version": "0.1.0",
+  "description": "Stylable DOM testing utilities",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "webpack-dev-server --hot --inline",
+    "clean": "rimraf ./dist",
+    "test": "yarn test:node",
+    "test:node": "mocha \"./tests/**/*.spec.ts\" --watch-extensions ts --require typescript-support",
+    "lint": "tslint --project ./tsconfig.json",
+    "prepack": "yarn build"
+  },
+  "dependencies": {
+    "@stylable/core": "^0.1.7",
+    "@stylable/runtime": "^0.1.7"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "engines": {
+    "node": ">=8"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "git@github.com:wix/stylable.git",
+  "author": "Wix.com",
+  "license": "BSD-3-Clause"
+}

--- a/packages/dom-test-kit/src/index.ts
+++ b/packages/dom-test-kit/src/index.ts
@@ -1,0 +1,1 @@
+export * from './stylable-dom-util';

--- a/packages/dom-test-kit/src/stylable-dom-util.ts
+++ b/packages/dom-test-kit/src/stylable-dom-util.ts
@@ -1,13 +1,19 @@
 import { parseSelector, stringifySelector, traverseNode } from '@stylable/core';
 import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
 
+export interface PartialElement {
+    querySelector: typeof Element.prototype.querySelector;
+    querySelectorAll: typeof Element.prototype.querySelectorAll;
+    getAttribute: typeof Element.prototype.getAttribute;
+}
+
 export class StylableDOMUtil {
     constructor(private style: RuntimeStylesheet, private root?: Element) { }
-    public select(selector?: string, element?: Element): Element | null {
+    public select(selector?: string, element?: PartialElement): Element | null {
         const el = (element || this.root);
         return el ? el.querySelector(this.scopeSelector(selector)) : null;
     }
-    public selectAll(selector?: string, element?: Element): Element[] | null {
+    public selectAll(selector?: string, element?: PartialElement): Element[] | null {
         const el = (element || this.root);
         return el ? Array.prototype.slice.call(
             el.querySelectorAll(this.scopeSelector(selector))
@@ -18,7 +24,7 @@ export class StylableDOMUtil {
             return this.scopeSelector('.root');
         }
         const ast = parseSelector(selector);
-        traverseNode(ast, node => {
+        traverseNode(ast, (node: any) => {
             if (node.type === 'class') {
                 node.name = this.style[node.name] || node.name;
             } else if (node.type === 'pseudo-class') {
@@ -34,13 +40,13 @@ export class StylableDOMUtil {
         });
         return stringifySelector(ast);
     }
-    public hasStyleState(element: Element, stateName: string, param: StateValue = true): boolean {
+    public hasStyleState(element: PartialElement, stateName: string, param: StateValue = true): boolean {
         const { stateKey, styleState } = this.getStateDataAttrKey(stateName, param);
         const actual = element.getAttribute(stateKey);
         return String(styleState[stateKey]) === actual;
     }
 
-    public getStyleState(element: Element, stateName: string): string | null {
+    public getStyleState(element: PartialElement, stateName: string): string | null {
         const { stateKey } = this.getStateDataAttrKey(stateName);
         return element.getAttribute(stateKey);
     }

--- a/packages/dom-test-kit/src/stylable-dom-util.ts
+++ b/packages/dom-test-kit/src/stylable-dom-util.ts
@@ -1,6 +1,10 @@
 import { parseSelector, stringifySelector, traverseNode } from '@stylable/core';
 import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
 
+export interface StateElement {
+    getAttribute: typeof Element.prototype.getAttribute;
+}
+
 export interface QueryElement {
     querySelector: typeof Element.prototype.querySelector;
     querySelectorAll: typeof Element.prototype.querySelectorAll;
@@ -39,19 +43,13 @@ export class StylableDOMUtil {
         });
         return stringifySelector(ast);
     }
-    public hasStyleState(
-        element: { getAttribute: typeof Element.prototype.getAttribute },
-        stateName: string, param: StateValue = true
-    ): boolean {
+    public hasStyleState(element: StateElement, stateName: string, param: StateValue = true): boolean {
         const { stateKey, styleState } = this.getStateDataAttrKey(stateName, param);
         const actual = element.getAttribute(stateKey);
         return String(styleState[stateKey]) === actual;
     }
 
-    public getStyleState(
-        element: { getAttribute: typeof Element.prototype.getAttribute },
-        stateName: string
-    ): string | null {
+    public getStyleState(element: StateElement, stateName: string): string | null {
         const { stateKey } = this.getStateDataAttrKey(stateName);
         return element.getAttribute(stateKey);
     }

--- a/packages/dom-test-kit/src/stylable-dom-util.ts
+++ b/packages/dom-test-kit/src/stylable-dom-util.ts
@@ -1,5 +1,5 @@
+import { parseSelector, stringifySelector, traverseNode } from '@stylable/core';
 import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
-import { parseSelector, stringifySelector, traverseNode } from '../../src/selector-utils';
 
 export interface QueryElement {
     querySelector: typeof Element.prototype.querySelector;

--- a/packages/dom-test-kit/src/stylable-dom-util.ts
+++ b/packages/dom-test-kit/src/stylable-dom-util.ts
@@ -1,22 +1,13 @@
 import { parseSelector, stringifySelector, traverseNode } from '@stylable/core';
 import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
 
-export interface StateElement {
-    getAttribute: typeof Element.prototype.getAttribute;
-}
-
-export interface QueryElement {
-    querySelector: typeof Element.prototype.querySelector;
-    querySelectorAll: typeof Element.prototype.querySelectorAll;
-}
-
 export class StylableDOMUtil {
-    constructor(private style: RuntimeStylesheet, private root?: QueryElement) { }
-    public select(selector?: string, element?: QueryElement): Element | null {
+    constructor(private style: RuntimeStylesheet, private root?: Element) { }
+    public select(selector?: string, element?: Element): Element | null {
         const el = (element || this.root);
         return el ? el.querySelector(this.scopeSelector(selector)) : null;
     }
-    public selectAll(selector?: string, element?: QueryElement): Element[] | null {
+    public selectAll(selector?: string, element?: Element): Element[] | null {
         const el = (element || this.root);
         return el ? Array.prototype.slice.call(
             el.querySelectorAll(this.scopeSelector(selector))
@@ -43,13 +34,13 @@ export class StylableDOMUtil {
         });
         return stringifySelector(ast);
     }
-    public hasStyleState(element: StateElement, stateName: string, param: StateValue = true): boolean {
+    public hasStyleState(element: Element, stateName: string, param: StateValue = true): boolean {
         const { stateKey, styleState } = this.getStateDataAttrKey(stateName, param);
         const actual = element.getAttribute(stateKey);
         return String(styleState[stateKey]) === actual;
     }
 
-    public getStyleState(element: StateElement, stateName: string): string | null {
+    public getStyleState(element: Element, stateName: string): string | null {
         const { stateKey } = this.getStateDataAttrKey(stateName);
         return element.getAttribute(stateKey);
     }

--- a/packages/dom-test-kit/tests/stylable-dom-util.spec.ts
+++ b/packages/dom-test-kit/tests/stylable-dom-util.spec.ts
@@ -45,7 +45,7 @@ describe('stylable-dom-utils', () => {
                 state = styleState;
                 return 'true';
             };
-            expect(util.hasStyleState({ getAttribute }, 'loading')).to.equal(true);
+            expect(util.hasStyleState(({ getAttribute } as Element), 'loading')).to.equal(true);
             expect(state).to.equal('data-ns-loading');
         });
 
@@ -55,7 +55,7 @@ describe('stylable-dom-utils', () => {
                 state = styleState;
                 return 'true';
             };
-            expect(util.getStyleState({ getAttribute }, 'loading')).to.equal('true');
+            expect(util.getStyleState(({ getAttribute } as Element), 'loading')).to.equal('true');
             expect(state).to.equal('data-ns-loading');
         });
     });

--- a/packages/dom-test-kit/tests/stylable-dom-util.spec.ts
+++ b/packages/dom-test-kit/tests/stylable-dom-util.spec.ts
@@ -1,6 +1,6 @@
 import { create } from '@stylable/runtime';
 import { expect } from 'chai';
-import { StylableDOMUtil } from './stylable-dom-util';
+import { StylableDOMUtil } from '../src';
 
 describe('stylable-dom-utils', () => {
 

--- a/packages/dom-test-kit/tests/stylable-dom-util.spec.ts
+++ b/packages/dom-test-kit/tests/stylable-dom-util.spec.ts
@@ -1,6 +1,6 @@
 import { create } from '@stylable/runtime';
 import { expect } from 'chai';
-import { StylableDOMUtil } from '../src';
+import { PartialElement, StylableDOMUtil } from '../src';
 
 describe('stylable-dom-utils', () => {
 
@@ -45,7 +45,7 @@ describe('stylable-dom-utils', () => {
                 state = styleState;
                 return 'true';
             };
-            expect(util.hasStyleState(({ getAttribute } as Element), 'loading')).to.equal(true);
+            expect(util.hasStyleState(({ getAttribute } as PartialElement), 'loading')).to.equal(true);
             expect(state).to.equal('data-ns-loading');
         });
 
@@ -55,7 +55,7 @@ describe('stylable-dom-utils', () => {
                 state = styleState;
                 return 'true';
             };
-            expect(util.getStyleState(({ getAttribute } as Element), 'loading')).to.equal('true');
+            expect(util.getStyleState(({ getAttribute } as PartialElement), 'loading')).to.equal('true');
             expect(state).to.equal('data-ns-loading');
         });
     });

--- a/packages/dom-test-kit/tsconfig.json
+++ b/packages/dom-test-kit/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "modules",
+    "**/*~~.ts"
+  ],
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": [
+      "es2015",
+      "dom"    
+    ],
+    "outDir": "./dist",
+    "types": [
+      "node",
+      "mocha"
+    ],
+    "noUnusedLocals": false
+  }
+}

--- a/packages/dom-test-kit/tslint.json
+++ b/packages/dom-test-kit/tslint.json
@@ -1,0 +1,35 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "interface-name": false,
+        "trailing-comma": {
+            "options": {
+                "multiline": "never",
+                "singleline": "never"
+            }
+        },
+        "arrow-parens": {
+            "options": [
+                "ban-single-arg-parens"
+            ]
+        },
+        "variable-name": false,
+        "forin": false,
+        "quotemark": {
+            "options": [
+                "single",
+                "avoid-escape"
+            ]
+        },
+        "no-var-requires": false,
+        "no-console": false,
+        "no-bitwise": false,
+        "object-literal-sort-keys": false,
+        "no-shadowed-variable": false
+    },
+    "rulesDirectory": []
+}

--- a/packages/dom-test-kit/webpack.config.js
+++ b/packages/dom-test-kit/webpack.config.js
@@ -1,0 +1,34 @@
+const testFiles = require('glob').sync("./tests/**/*.spec.ts");
+const first = testFiles.shift();
+const withMochaLoader = [`mocha-loader!${first}`].concat(testFiles);
+
+module.exports = {
+    mode: 'development',
+    entry: {
+        tests: withMochaLoader
+    },
+    output: {
+        filename: '[name].bundle.js'
+    },
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js']
+    },
+    node: {
+        fs: 'empty'
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                loader: 'ts-loader',
+                options: {
+                    compilerOptions: {
+                        declaration: false,
+                        declarationMap: false
+                    }
+                }
+            }
+        ]
+    }
+}
+

--- a/packages/e2e-test-kit/README.md
+++ b/packages/e2e-test-kit/README.md
@@ -2,10 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/e2e-test-kit.svg)](https://www.npmjs.com/package/@stylable/e2e-test-kit)
 
-`@stylable/e2e-test-kit` serves as a collection of tools to help test **Stylable** components and applications. It offers various capabilities to bundle, run and test your project in memory, or in the browser.
-
+`@stylable/e2e-test-kit` serves as a collection of tools to help test Stylable components and applications. It offers various capabilities to bundle, run and test your project in memory, or in the browser.
 ## Installation
-This package is still a work-in-progress within the **Stylable** mono-repo. Once it matures, further details will be added here.
+This package is still a work-in-progress within the Stylable mono-repo. Once it matures, further details will be added here.
 
 ## Usage
 

--- a/packages/e2e-test-kit/package.json
+++ b/packages/e2e-test-kit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stylable/e2e-test-kit",
   "version": "1.0.14",
+  "description": "A collection of tools to help test Stylable components and applications from end-to-end",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -2,14 +2,14 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/jest.svg)](https://www.npmjs.com/package/@stylable/jest)
 
-`@stylable/jest` is a simple integration that allows testing your **Stylable**  React components using [Jest](https://jestjs.io/). 
+`@stylable/jest` is a simple integration that allows testing your Stylable React components using [Jest](https://jestjs.io/). 
 
 ## Installation
-This package is still a work-in-progress within the **Stylable** mono-repo. Once it matures, further details will be added here.
+This package is still a work-in-progress within the Stylable mono-repo. Once it matures, further details will be added here.
 
 ## Usage
 
-Use the `process` utility imported from `@stylable/jest` to configure your Jest setup to support **Stylable** stylesheets, turning them into resolvable modules.
+Use the `process` utility imported from `@stylable/jest` to configure your Jest setup to support Stylable stylesheets, turning them into resolvable modules.
 
 > Note: Jest should also be configured to ignore `.st.css` files in its transformations.
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stylable/jest",
   "version": "0.1.7",
+  "description": "Test your Stylable React components using Jest",
   "main": "dist/jest.js",
   "types": "dist/jest.d.ts",
   "scripts": {

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/node.svg)](https://www.npmjs.com/package/@stylable/node)
 
-`@stylable/node` is a simple integration that allows integrating **Stylable** into your node application. The most common use-case is server-side rendering.
+`@stylable/node` is a simple integration that allows integrating Stylable into your node application. The most common use-case is server-side rendering.
 
 ## Installation
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stylable/node",
   "version": "0.1.8",
+  "description": "Integrate Stylable into your node application.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stylable/node",
   "version": "0.1.8",
-  "description": "Integrate Stylable into your node application.",
+  "description": "Integrate Stylable into your node application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -2,13 +2,15 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/react-scripts.svg)](https://www.npmjs.com/package/@stylable/react-scripts)
 
-A fork of [react-scripts](https://github.com/facebook/create-react-app/tree/next/packages/react-scripts), with the following changes:
+A fork of [react-scripts](https://github.com/facebook/create-react-app/tree/next/packages/react-scripts) used tailored for quick and easy creation of Stylable projects.
+
+## Major changes from `react-scripts`
 - Uses TypeScript instead of Babel, configured to work with Webpack's tree-shaking and dynamic chunks on import();
 - Adds built-in support for [Stylable](http://stylable.io/).
 
-# Getting started
+## Getting started
 
-This is the quickest way to get a **Stylable** project up and running. It is an opinionated boilerplate that uses TypeScript and **Stylable** instead of css-loader
+This is the quickest way to get a Stylable project up and running. It is an opinionated boilerplate that uses TypeScript and Stylable instead of css-loader
 
 In your terminal, run:
 ```

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stylable/react-scripts",
   "version": "0.1.7",
-  "description": "like react-scripts, but with stylable and typescript built-in",
+  "description": "Like react-scripts, but with stylable and typescript built-in",
   "bin": {
     "stylable-scripts": "./bin/stylable-scripts.js"
   },

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -10,7 +10,7 @@ End-users will usually not add this package directly as a dependency themselves,
 `@stylable/runtime` exposes two methods, `Stylesheet` and `Renderer`.
 
 ### Stylesheet 
-The stylesheet function is returned when importing a **Stylable** stylesheet. It is used for creating the DOM-attributes required for CSS to be applied.
+The stylesheet function is returned when importing a Stylable stylesheet. It is used for creating the DOM-attributes required for CSS to be applied.
 
 ```ts
 style(className: string, states?: StateMap, props: InheritedAttributes)

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stylable/runtime",
   "version": "0.1.7",
+  "description": "Stylable runtime DOM integration",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",

--- a/packages/webpack-extensions/package.json
+++ b/packages/webpack-extensions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stylable/webpack-extensions",
   "version": "0.1.9",
+  "description": "Experimental Stylable webpack plugins",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/webpack-plugin.svg)](https://www.npmjs.com/package/@stylable/webpack-plugin)
 
-The Stylable Webpack Plugin (for Webpack version 4x) is the main build utility for [Stylable](https://stylable.io/). It supports both development and production modes, providing various configurations that can be tweaked according to your specific needs. It enables loading Stylable files (`.st.css`) from local projects or imported from a 3rd party source (for example, NPM node modules).
+`@stylable/webpack-plugin` (for webpack `v4.x`) is the main build utility for [Stylable](https://stylable.io/). It supports both development and production modes, providing various configurations that can be tweaked according to your specific needs. It enables loading Stylable files (`.st.css`) from local projects or imported from a 3rd party source (for example, NPM node modules).
 
 ## Getting started
 Install `@stylable/webpack-plugin` as a dev dependency in your local project.


### PR DESCRIPTION
Exposes `StylableDOMUtil` used for Stylable related DOM testing
- DOM selection / targetting 
- Stylable selector transformation/scoping
- Custom state resolvers