### PR TITLE
Added a 'getLogicModule' option to the snapshot plugin

### DIFF
--- a/packages/webpack-extensions/package.json
+++ b/packages/webpack-extensions/package.json
@@ -13,7 +13,7 @@
     "lint": "run-p lint:src lint:test",
     "lint:src": "tslint --project src",
     "lint:test": "tslint --project test",
-    "test": "mocha -r typescript-support \"test/**/*.spec.ts?(x)\" --watch-extensions ts,tsx"
+    "test": "mocha --timeout 10000 -r typescript-support \"test/**/*.spec.ts?(x)\" --watch-extensions ts,tsx"
   },
   "dependencies": {
     "@stylable/core": "^0.1.7",

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -14,7 +14,11 @@ const {
 export interface HTMLSnapshotPluginOptions {
     outDir: string;
     render: (componentModule: any, component: any) => string | false;
-    // TODO: Comment this
+    /**
+     * Logic that decides which module to import the stylable component from. For
+     * example, if you have more than one file that imports a certain style, you may
+     * want to build a specific one
+     */
     moduleFilterLogic?: (stylableModule: any) => any;
 }
 

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -14,14 +14,18 @@ const {
 export interface HTMLSnapshotPluginOptions {
     outDir: string;
     render: (componentModule: any, component: any) => string | false;
+    moduleFilterLogic?: (stylableModule: any) => webpack.Module[];
 }
 
 export class HTMLSnapshotPlugin {
     private outDir: string;
     private render: (componentModule: any, component: any) => string | false;
+    private options: Partial<HTMLSnapshotPluginOptions>;
+
     constructor(options: Partial<HTMLSnapshotPluginOptions>) {
         this.outDir = options.outDir || '';
         this.render = options.render || (() => false);
+        this.options = options;
     }
     public apply(compiler: webpack.Compiler) {
         compiler.hooks.thisCompilation.tap('HTMLSnapshotPlugin', compilation => {
@@ -34,7 +38,9 @@ export class HTMLSnapshotPlugin {
         });
     }
     public async snapShotStylableModule(compilation: webpack.compilation.Compilation, module: any) {
-        const component = getCSSComponentLogicModule(module);
+        const component = this.options.moduleFilterLogic
+        ? this.options.moduleFilterLogic(module) : getCSSComponentLogicModule(module);
+
         if (!component) {
             return;
         }

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -25,12 +25,12 @@ export interface HTMLSnapshotPluginOptions {
 export class HTMLSnapshotPlugin {
     private outDir: string;
     private render: (componentModule: any, component: any) => string | false;
-    private stylesheetFilterLogic: (stylableModule: any) => any;
+    private stylesheetLogicFilter: (stylableModule: any) => any;
 
     constructor(options: Partial<HTMLSnapshotPluginOptions>) {
         this.outDir = options.outDir || '';
         this.render = options.render || (() => false);
-        this.stylesheetFilterLogic = options.stylesheetLogicFilter
+        this.stylesheetLogicFilter = options.stylesheetLogicFilter
         ? options.stylesheetLogicFilter : getCSSComponentLogicModule;
     }
     public apply(compiler: webpack.Compiler) {
@@ -44,7 +44,7 @@ export class HTMLSnapshotPlugin {
         });
     }
     public async snapShotStylableModule(compilation: webpack.compilation.Compilation, module: any) {
-        const component = this.stylesheetFilterLogic(module);
+        const component = this.stylesheetLogicFilter(module);
 
         if (!component) {
             return;

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -14,18 +14,19 @@ const {
 export interface HTMLSnapshotPluginOptions {
     outDir: string;
     render: (componentModule: any, component: any) => string | false;
-    moduleFilterLogic?: (stylableModule: any) => webpack.Module[];
+    // TODO: Comment this
+    moduleFilterLogic?: (stylableModule: any) => any;
 }
 
 export class HTMLSnapshotPlugin {
     private outDir: string;
     private render: (componentModule: any, component: any) => string | false;
-    private options: Partial<HTMLSnapshotPluginOptions>;
+    private moduleFilterLogic: (stylableModule: any) => any;
 
     constructor(options: Partial<HTMLSnapshotPluginOptions>) {
         this.outDir = options.outDir || '';
         this.render = options.render || (() => false);
-        this.options = options;
+        this.moduleFilterLogic = options.moduleFilterLogic ? options.moduleFilterLogic : getCSSComponentLogicModule;
     }
     public apply(compiler: webpack.Compiler) {
         compiler.hooks.thisCompilation.tap('HTMLSnapshotPlugin', compilation => {
@@ -38,8 +39,7 @@ export class HTMLSnapshotPlugin {
         });
     }
     public async snapShotStylableModule(compilation: webpack.compilation.Compilation, module: any) {
-        const component = this.options.moduleFilterLogic
-        ? this.options.moduleFilterLogic(module) : getCSSComponentLogicModule(module);
+        const component = this.moduleFilterLogic(module);
 
         if (!component) {
             return;

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -19,18 +19,19 @@ export interface HTMLSnapshotPluginOptions {
      * example, if you have more than one file that imports a certain style, you may
      * want to build a specific one
      */
-    moduleFilterLogic?: (stylableModule: any) => any;
+    stylesheetLogicFilter?: (stylableModule: any) => any;
 }
 
 export class HTMLSnapshotPlugin {
     private outDir: string;
     private render: (componentModule: any, component: any) => string | false;
-    private moduleFilterLogic: (stylableModule: any) => any;
+    private stylesheetFilterLogic: (stylableModule: any) => any;
 
     constructor(options: Partial<HTMLSnapshotPluginOptions>) {
         this.outDir = options.outDir || '';
         this.render = options.render || (() => false);
-        this.moduleFilterLogic = options.moduleFilterLogic ? options.moduleFilterLogic : getCSSComponentLogicModule;
+        this.stylesheetFilterLogic = options.stylesheetLogicFilter
+        ? options.stylesheetLogicFilter : getCSSComponentLogicModule;
     }
     public apply(compiler: webpack.Compiler) {
         compiler.hooks.thisCompilation.tap('HTMLSnapshotPlugin', compilation => {
@@ -43,7 +44,7 @@ export class HTMLSnapshotPlugin {
         });
     }
     public async snapShotStylableModule(compilation: webpack.compilation.Compilation, module: any) {
-        const component = this.moduleFilterLogic(module);
+        const component = this.stylesheetFilterLogic(module);
 
         if (!component) {
             return;

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -15,23 +15,22 @@ export interface HTMLSnapshotPluginOptions {
     outDir: string;
     render: (componentModule: any, component: any) => string | false;
     /**
-     * Logic that decides which module to import the stylable component from. For
-     * example, if you have more than one file that imports a certain style, you may
-     * want to build a specific one
+     * By default, gets component logic related to the stylesheet being imported. E.g., you
+     * have stylesheet `a.st.css`, which is imported by a few files. By default, this method
+     * will attempt to find `a.tsx`.
      */
-    stylesheetLogicFilter?: (stylableModule: any) => any;
+    getLogicModule?: (stylableModule: any) => any;
 }
 
 export class HTMLSnapshotPlugin {
     private outDir: string;
     private render: (componentModule: any, component: any) => string | false;
-    private stylesheetLogicFilter: (stylableModule: any) => any;
+    private getLogicModule: (stylableModule: any) => any;
 
     constructor(options: Partial<HTMLSnapshotPluginOptions>) {
         this.outDir = options.outDir || '';
         this.render = options.render || (() => false);
-        this.stylesheetLogicFilter = options.stylesheetLogicFilter
-        ? options.stylesheetLogicFilter : getCSSComponentLogicModule;
+        this.getLogicModule = options.getLogicModule || getCSSComponentLogicModule;
     }
     public apply(compiler: webpack.Compiler) {
         compiler.hooks.thisCompilation.tap('HTMLSnapshotPlugin', compilation => {
@@ -44,7 +43,7 @@ export class HTMLSnapshotPlugin {
         });
     }
     public async snapShotStylableModule(compilation: webpack.compilation.Compilation, module: any) {
-        const component = this.stylesheetLogicFilter(module);
+        const component = this.getLogicModule(module);
 
         if (!component) {
             return;

--- a/packages/webpack-plugin/src/stylable-module-helpers.js
+++ b/packages/webpack-plugin/src/stylable-module-helpers.js
@@ -87,7 +87,6 @@ function getCSSComponentLogicModule(stylableModule) {
             );
         })
         .map(({ module }) => module);
-
     const set = new Set(views);
     if (set.size > 1) {
         throw new Error(

--- a/packages/webpack-plugin/src/stylable-module-helpers.js
+++ b/packages/webpack-plugin/src/stylable-module-helpers.js
@@ -86,9 +86,8 @@ function getCSSComponentLogicModule(stylableModule) {
                 _module.resource.slice(0, -path.extname(_module.resource).length) === name
             );
         })
-        .map(({ module }) => {
-            return module;
-        });
+        .map(({ module }) => module);
+
     const set = new Set(views);
     if (set.size > 1) {
         throw new Error(

--- a/packages/webpack-plugin/src/stylable-module-helpers.js
+++ b/packages/webpack-plugin/src/stylable-module-helpers.js
@@ -86,7 +86,9 @@ function getCSSComponentLogicModule(stylableModule) {
                 _module.resource.slice(0, -path.extname(_module.resource).length) === name
             );
         })
-        .map(({ module }) => module);
+        .map(({ module }) => {
+            return module;
+        });
     const set = new Set(views);
     if (set.size > 1) {
         throw new Error(


### PR DESCRIPTION
Add the ability for users of the `HTMLSnapshot Plugin` to customize which component logic file associated with a specific stylesheet.