### PR TITLE
Node: correct require hook not marking generated modules as esm

### DIFF
--- a/packages/node/src/stylable-module-source.ts
+++ b/packages/node/src/stylable-module-source.ts
@@ -14,7 +14,7 @@ export function generateModuleSource(
     //     i => (i.fromRelative.match(/\.st\.css$/) ? `require("${i.fromRelative}");` : '')
     // );
     return `
-Object.defineProperty(module, "__esModule", { value: true })
+Object.defineProperty(exports, "__esModule", { value: true })
 module.exports.default = require(${JSON.stringify(runtimePath)}).create(
     ${root},
     ${namespace},

--- a/packages/node/test/require-hook.spec.ts
+++ b/packages/node/test/require-hook.spec.ts
@@ -38,4 +38,10 @@ describe('require hook', () => {
             require('./fixtures/test.st.css');
         }).to.throw('Unexpected token');
     });
+
+    it('should mark the generated module as an esm module', () => {
+        attachHook();
+        const m = require('./fixtures/test.st.css');
+        expect(m.__esModule).to.equal(true);
+    });
 });


### PR DESCRIPTION
Module interop of typescript and babel looks for the '__esModule' field on exports to determine whether the original source was esm