### PR TITLE
@stylable/jest: ensure generated module uses own copy of runtime

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -11,7 +11,8 @@
     "test": "mocha -r typescript-support \"test/**/*.spec.ts?(x)\" --watch-extensions ts,tsx --project \"./test/tsconfig.json\""
   },
   "dependencies": {
-    "@stylable/node": "^0.1.11"
+    "@stylable/node": "^0.1.11",
+    "@stylable/runtime": "^0.1.8"
   },
   "files": [
     "dist"

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -9,5 +9,5 @@ export const process = stylableModuleFactory(
     },
     // ensure the generated module points to our own @stylable/runtime copy
     // this allows @stylable/jest to be used as part of a globally installed CLI
-    require.resolve('@stylable/runtime/package.json')
+    require.resolve('@stylable/runtime')
 );

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -1,7 +1,13 @@
 import { stylableModuleFactory } from '@stylable/node';
 import * as fs from 'fs';
-export const process = stylableModuleFactory({
-    fileSystem: fs,
-    requireModule: require,
-    projectRoot: ''
-});
+
+export const process = stylableModuleFactory(
+    {
+        fileSystem: fs,
+        requireModule: require,
+        projectRoot: ''
+    },
+    // ensure the generated module points to our own @stylable/runtime copy
+    // this allows @stylable/jest to be used as part of a globally installed CLI
+    require.resolve('@stylable/runtime/package.json')
+);


### PR DESCRIPTION
allows @stylable/jest to be used as part of a globally installed CLI