### PR TITLE
[WIP] Refactor namespacing hash mechanism

### DIFF
--- a/packages/stylable-node/package.json
+++ b/packages/stylable-node/package.json
@@ -10,6 +10,7 @@
     "test": "mocha -r typescript-support \"test/**/*.spec.ts?(x)\" --watch-extensions ts,tsx --project \"./test/tsconfig.json\""
   },
   "dependencies": {
+    "find-config": "^1.0.0",
     "stylable": "^5.4.10",
     "stylable-runtime": "^1.0.6"
   },

--- a/packages/stylable-node/src/resolveNamespace.ts
+++ b/packages/stylable-node/src/resolveNamespace.ts
@@ -1,0 +1,11 @@
+import { dirname, relative } from 'path';
+import { processNamespace } from 'stylable';
+const findConfig = require('find-config');
+
+export const resolveNamespace: typeof processNamespace = (namespace, source) => {
+    const configPath = findConfig('package.json', { cwd: dirname(source) });
+    const config = require(configPath);
+    const fromRoot = relative(dirname(configPath), source);
+    console.log(namespace, fromRoot, config.name + '@' + config.version);
+    return '!!!';
+};

--- a/packages/stylable-webpack-plugin/src/StylableWebpackPlugin.js
+++ b/packages/stylable-webpack-plugin/src/StylableWebpackPlugin.js
@@ -62,6 +62,7 @@ class StylableWebpackPlugin {
       "--",
       meta => { // TODO: move to stylable as param. 
         if (this.options.optimize.shortNamespaces) {
+          resolveNamespace(meta.namespace, meta.source);
           meta.namespace = stylable.optimizer.namespaceOptimizer.getNamespace(
             meta,
             compiler.context,
@@ -333,3 +334,15 @@ class StylableWebpackPlugin {
 }
 
 module.exports = StylableWebpackPlugin;
+
+
+
+const { dirname, relative } = require('path');
+
+const resolveNamespace = (namespace, source) => {
+    const configPath = findConfig('package.json', { cwd: dirname(source) });
+    const config = require(configPath);
+    const fromRoot = relative(dirname(configPath), source);
+    console.log(namespace, fromRoot, config.name + '@' + config.version);
+    return '!!!';
+};


### PR DESCRIPTION
In order to achieve a unique hash, Stylable currently uses the absolute path of a file as a seed.
This would cause the same project being built on two different machines (with different paths) to yield different target code.

This PR updates the mechanism to use:
- Path to the nearest `package.json`
- Package name
- Package version