### PR TITLE
"duplicate module namespace" severity change from error to warning

### DIFF
--- a/packages/webpack-plugin/src/StylableWebpackPlugin.js
+++ b/packages/webpack-plugin/src/StylableWebpackPlugin.js
@@ -130,7 +130,7 @@ class StylableWebpackPlugin {
                             !this.options.unsafeMuteDiagnostics.DUPLICATE_MODULE_NAMESPACE &&
                             usageMapping[module.buildInfo.stylableMeta.namespace]
                         ) {
-                            compilation.errors.push(
+                            compilation.warnings.push(
                                 new Error(
                                     `Duplicate module namespace: ${
                                         module.buildInfo.stylableMeta.namespace

--- a/packages/webpack-plugin/test/e2e/unsafe-mute-diagnostics.spec.ts
+++ b/packages/webpack-plugin/test/e2e/unsafe-mute-diagnostics.spec.ts
@@ -15,5 +15,6 @@ describe(`(${project})`, () => {
     it('should build a project with no errors (duplicate namespace) when muted', async () => {
         await projectRunner.bundle();
         expect(projectRunner.getBuildErrorMessages().length).to.equal(0);
+        expect(projectRunner.getBuildWarningMessages().length).to.equal(0);
     });
 });


### PR DESCRIPTION
Lowering the severity of this error so that it will not break the build process. Graceful behavior should remain, despite increased bundle size.