### PR TITLE
Fix bug causing global classes to be optimized in production mode

### DIFF
--- a/packages/core/src/optimizer/classname-optimizer.ts
+++ b/packages/core/src/optimizer/classname-optimizer.ts
@@ -9,10 +9,10 @@ export class StylableClassNameOptimizer {
             names: {}
         };
     }
-    public rewriteSelector(selector: string) {
+    public rewriteSelector(selector: string, globals: Pojo<boolean> = {}) {
         const ast = parseSelector(selector);
         traverseNode(ast, node => {
-            if (node.type === 'class') {
+            if (node.type === 'class' && !globals[node.name]) {
                 if (!this.context.names[node.name]) {
                     this.generateName(node.name);
                 }
@@ -24,9 +24,14 @@ export class StylableClassNameOptimizer {
     public generateName(name: string) {
         return (this.context.names[name] = 's' + Object.keys(this.context.names).length);
     }
-    public optimizeAstAndExports(ast: postcss.Root, exported: Pojo<string>, classes = Object.keys(exported)) {
+    public optimizeAstAndExports(
+        ast: postcss.Root,
+        exported: Pojo<string>,
+        classes = Object.keys(exported),
+        globals: Pojo<boolean> = {}
+    ) {
         ast.walkRules(rule => {
-            rule.selector = this.rewriteSelector(rule.selector);
+            rule.selector = this.rewriteSelector(rule.selector, globals);
         });
         classes.forEach(originName => {
             if (exported[originName]) {

--- a/packages/core/src/optimizer/stylable-optimizer.ts
+++ b/packages/core/src/optimizer/stylable-optimizer.ts
@@ -48,7 +48,8 @@ export class StylableOptimizer {
             this.classNameOptimizer.optimizeAstAndExports(
                 outputAst,
                 jsExports,
-                Object.keys(meta.classes)
+                Object.keys(meta.classes),
+                meta.globals
             );
         }
     }

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -23,6 +23,7 @@ export class StylableMeta {
     public parent?: StylableMeta;
     public transformDiagnostics: Diagnostics | null;
     public scopes: postcss.AtRule[];
+    public globals: Pojo<boolean> = {};
     constructor(public ast: postcss.Root, public diagnostics: Diagnostics) {
         const rootSymbol: ClassSymbol = {
             _kind: 'class',

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -131,9 +131,9 @@ export class StylableTransformer {
     }
     public transform(meta: StylableMeta): StylableResults {
         const metaExports: Pojo<string> = {};
-        const ast = meta.outputAst = meta.ast.clone();
+        const ast = this.resetTransformProperties(meta);
         this.transformAst(ast, meta, metaExports);
-        this.transformGlobals(ast);
+        this.transformGlobals(ast, meta);
         meta.transformDiagnostics = this.diagnostics;
         const result = { meta, exports: metaExports };
 
@@ -344,16 +344,30 @@ export class StylableTransformer {
 
         return keyframesExports;
     }
-    public transformGlobals(ast: postcss.Root) {
+    public addGlobalsToMeta(selectorAst: SelectorAstNode[], meta?: StylableMeta) {
+        if (!meta) { return; }
+
+        for (const ast of selectorAst) {
+            traverseNode(ast, inner => {
+                if (inner.type === 'class') {
+                    meta.globals[inner.name] = true;
+                }
+            });
+        }
+    }
+    public transformGlobals(ast: postcss.Root, meta: StylableMeta) {
         ast.walkRules(r => {
             const selectorAst = parseSelector(r.selector);
             traverseNode(selectorAst, node => {
                 if (node.type === 'nested-pseudo-class' && node.name === 'global') {
+                    this.addGlobalsToMeta([node], meta);
                     node.type = 'selector';
                     return true;
                 }
                 return undefined;
             });
+            // this.addGlobalsToMeta([selectorAst], meta);
+
             r.selector = stringifySelector(selectorAst);
         });
     }
@@ -395,17 +409,19 @@ export class StylableTransformer {
                         originSymbol = symbol;
                     }
                 } else if (type === 'class') {
-                    const next = this.handleClass(current, node, name, metaExports, rule);
+                    const next = this.handleClass(current, node, name, metaExports, rule, originMeta);
                     originSymbol = current.classes[name];
                     symbol = next.symbol;
                     current = next.meta;
                 } else if (type === 'element') {
-                    const next = this.handleElement(current, node, name);
+                    const next = this.handleElement(current, node, name, originMeta);
                     originSymbol = current.elements[name];
                     symbol = next.symbol;
                     current = next.meta;
                 } else if (type === 'pseudo-element') {
-                    const next = this.handlePseudoElement(current, node, name, selectorNode, addedSelectors, rule);
+                    const next = this.handlePseudoElement(
+                        current, node, name, selectorNode, addedSelectors, rule, originMeta
+                    );
                     originSymbol = current.classes[name];
                     meta = current;
                     symbol = next.symbol;
@@ -427,7 +443,7 @@ export class StylableTransformer {
                         type: 'class',
                         nodes: [],
                         name: origin.name
-                    }, origin.name);
+                    }, origin.name, undefined, undefined, originMeta.parent);
                     originSymbol = current.classes[origin.name];
                     symbol = next.symbol;
                     current = next.meta;
@@ -502,7 +518,8 @@ export class StylableTransformer {
         node: SelectorAstNode,
         name: string,
         metaExports?: Pojo<string>,
-        rule?: postcss.Rule): CSSResolve {
+        rule?: postcss.Rule,
+        originMeta?: StylableMeta): CSSResolve {
 
         const symbol = meta.classes[name];
         const extend = symbol ? symbol[valueMapping.extends] : undefined;
@@ -514,6 +531,7 @@ export class StylableTransformer {
                     node.before = '';
                     node.type = 'selector';
                     node.nodes = globalMappedNodes;
+                    this.addGlobalsToMeta(globalMappedNodes, originMeta);
                 } else {
                     node.name = this.exportClass(next.meta, next.symbol.name, next.symbol, metaExports);
                 }
@@ -548,6 +566,7 @@ export class StylableTransformer {
             node.before = '';
             node.type = 'selector';
             node.nodes = symbol[valueMapping.global] || [];
+            this.addGlobalsToMeta(globalMappedNodes!, originMeta);
         } else {
             node.name = scopedName;
         }
@@ -578,7 +597,7 @@ export class StylableTransformer {
 
         return { _kind: 'css', meta, symbol };
     }
-    public handleElement(meta: StylableMeta, node: SelectorAstNode, name: string) {
+    public handleElement(meta: StylableMeta, node: SelectorAstNode, name: string, originMeta?: StylableMeta) {
         const tRule = meta.elements[name] as StylableSymbol;
         const extend = tRule ? meta.mappedSymbols[name] : undefined;
         const next = this.resolver.deepResolve(extend);
@@ -587,6 +606,7 @@ export class StylableTransformer {
                 node.before = '';
                 node.type = 'selector';
                 node.nodes = next.symbol[valueMapping.global] || [];
+                this.addGlobalsToMeta(node.nodes, originMeta);
             } else {
                 node.type = 'class';
                 node.name = this.scope(next.symbol.name, next.meta.namespace);
@@ -604,7 +624,8 @@ export class StylableTransformer {
         name: string,
         selectorNode: SelectorAstNode,
         addedSelectors: AdditionalSelector[],
-        rule?: postcss.Rule): CSSResolve {
+        rule?: postcss.Rule,
+        originMeta?: StylableMeta): CSSResolve {
 
         let next: JSResolve | CSSResolve | null;
 
@@ -666,6 +687,7 @@ export class StylableTransformer {
                 if (symbol[valueMapping.global]) {
                     node.type = 'selector';
                     node.nodes = symbol[valueMapping.global] || [];
+                    this.addGlobalsToMeta(node.nodes, originMeta);
                 } else {
                     if (symbol.alias && !symbol[valueMapping.extends]) {
                         if (next && next.meta && next.symbol) {
@@ -702,6 +724,10 @@ export class StylableTransformer {
     }
     public scope(name: string, namespace: string, delimiter: string = this.delimiter) {
         return namespace ? namespace + delimiter + name : name;
+    }
+    private resetTransformProperties(meta: StylableMeta) {
+        meta.globals = {};
+        return meta.outputAst = meta.ast.clone();
     }
 }
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -443,7 +443,7 @@ export class StylableTransformer {
                         type: 'class',
                         nodes: [],
                         name: origin.name
-                    }, origin.name, undefined, undefined, originMeta.parent);
+                    }, origin.name, undefined, undefined, originMeta);
                     originSymbol = current.classes[origin.name];
                     symbol = next.symbol;
                     current = next.meta;

--- a/packages/core/tests/stylable-transformer/global.spec.ts
+++ b/packages/core/tests/stylable-transformer/global.spec.ts
@@ -108,13 +108,14 @@ describe('Stylable postcss transform (Global)', () => {
                     content: `
                         :import {
                             -st-from: "./mixin.st.css";
-                            -st-named: test;
+                            -st-named: test, mix;
                         }
                         .root {}
                         .test {}
                         .x { -st-global: '.a .b'; }
                         :global(.c .d) {}
                         :global(.e) {}
+                        .mixIntoMe { -st-mixin: mix; }
                     `
                 },
                 '/mixin.st.css': {
@@ -123,6 +124,8 @@ describe('Stylable postcss transform (Global)', () => {
                         .test {
                             -st-global: ".global-test";
                         }
+
+                        .mix :global(.global-test2) {}
                     `
                 }
             }
@@ -130,6 +133,7 @@ describe('Stylable postcss transform (Global)', () => {
 
         expect(meta.globals).to.eql({
             'global-test': true,
+            'global-test2': true,
             'a': true,
             'b': true,
             'c': true,
@@ -140,5 +144,7 @@ describe('Stylable postcss transform (Global)', () => {
         expect((meta.outputAst!.nodes![2] as postcss.Rule).selector).to.equal('.a .b');
         expect((meta.outputAst!.nodes![3] as postcss.Rule).selector).to.equal('.c .d');
         expect((meta.outputAst!.nodes![4] as postcss.Rule).selector).to.equal('.e');
+        expect((meta.outputAst!.nodes![5] as postcss.Rule).selector).to.equal('.style--mixIntoMe');
+        expect((meta.outputAst!.nodes![6] as postcss.Rule).selector).to.equal('.style--mixIntoMe .global-test2');
     });
 });

--- a/packages/core/tests/stylable-transformer/global.spec.ts
+++ b/packages/core/tests/stylable-transformer/global.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as postcss from 'postcss';
-import { generateStylableRoot } from '../utils/generate-test-util';
+import { generateStylableResult, generateStylableRoot } from '../utils/generate-test-util';
 
 describe('Stylable postcss transform (Global)', () => {
 
@@ -96,5 +96,49 @@ describe('Stylable postcss transform (Global)', () => {
 
         expect((result.nodes![1] as postcss.Rule).selector).to.equal('.btn .style--root');
 
+    });
+
+    it('should register to all global classes to "meta.globals"', () => {
+
+        const { meta } = generateStylableResult({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'style',
+                    content: `
+                        :import {
+                            -st-from: "./mixin.st.css";
+                            -st-named: test;
+                        }
+                        .root {}
+                        .test {}
+                        .x { -st-global: '.a .b'; }
+                        :global(.c .d) {}
+                        :global(.e) {}
+                    `
+                },
+                '/mixin.st.css': {
+                    namespace: 'mixin',
+                    content: `
+                        .test {
+                            -st-global: ".global-test";
+                        }
+                    `
+                }
+            }
+        });
+
+        expect(meta.globals).to.eql({
+            'global-test': true,
+            'a': true,
+            'b': true,
+            'c': true,
+            'd': true,
+            'e': true
+        });
+        expect((meta.outputAst!.nodes![1] as postcss.Rule).selector).to.equal('.global-test');
+        expect((meta.outputAst!.nodes![2] as postcss.Rule).selector).to.equal('.a .b');
+        expect((meta.outputAst!.nodes![3] as postcss.Rule).selector).to.equal('.c .d');
+        expect((meta.outputAst!.nodes![4] as postcss.Rule).selector).to.equal('.e');
     });
 });

--- a/packages/webpack-plugin/test/e2e/optimizations.spec.ts
+++ b/packages/webpack-plugin/test/e2e/optimizations.spec.ts
@@ -36,20 +36,25 @@ describe(`(${project})`, () => {
             {
                 id: './src/index.st.css',
                 depth: '3',
-                css: '.s0[data-o0-x]{font-family:MyFont}.s1{background:#00f}'
+                // tslint:disable-next-line: max-line-length
+                css: '.global1{background:grey}.global1 .global2{font-size:20px}.s0[data-o0-x]{font-family:MyFont}.s1{background:#00f}'
             }
         ]);
     });
 
     it('css is working', async () => {
         const { page } = await projectRunner.openInBrowser();
-        const { fontFamily, backgroundColor, exports } = await page.evaluate(() => {
-            return {
-                backgroundColor: getComputedStyle(document.body).backgroundColor,
-                fontFamily: getComputedStyle(document.documentElement!).fontFamily,
-                exports: Object.getPrototypeOf((window as any).stylableIndex)
-            };
-        });
+        const { fontFamily, backgroundColor, exports, global1ClassColor, global2ClassColor } = await page.evaluate(
+            () => {
+                return {
+                    backgroundColor: getComputedStyle(document.body).backgroundColor,
+                    fontFamily: getComputedStyle(document.documentElement!).fontFamily,
+                    exports: Object.getPrototypeOf((window as any).stylableIndex),
+                    global1ClassColor: getComputedStyle(document.querySelector('.global1')!).backgroundColor,
+                    global2ClassColor: getComputedStyle(document.querySelector('.global2')!).fontSize
+                };
+            }
+        );
 
         expect(exports.$namespace).to.eql('o0');
         expect(exports.myValue).to.eql('red');
@@ -59,5 +64,8 @@ describe(`(${project})`, () => {
 
         expect(backgroundColor).to.eql('rgb(0, 0, 255)');
         expect(fontFamily).to.eql('MyFont');
+
+        expect(global1ClassColor).to.eql('rgb(128, 128, 128)');
+        expect(global2ClassColor).to.eql('20px');
     });
 });

--- a/packages/webpack-plugin/test/e2e/projects/optimizations/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/optimizations/src/index.js
@@ -6,3 +6,13 @@ const states = index.$cssStates({ x: true });
 Object.keys(states).forEach(attr => {
     document.documentElement.setAttribute(attr, states[attr]);
 });
+
+const div = document.createElement('div');
+div.className = 'global1';
+
+const global2 = document.createElement('div');
+global2.className = 'global2';
+global2.textContent = 'Globals Here!!!';
+div.appendChild(global2);
+
+document.body.appendChild(div);

--- a/packages/webpack-plugin/test/e2e/projects/optimizations/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/optimizations/src/index.st.css
@@ -7,6 +7,14 @@
     myValue: red;
 }
 
+:global(.global1) {
+    background: rgb(128,128,128)
+}
+
+:global(.global1 .global2) {
+    font-size: 20px
+}
+
 .root {
     -st-states: /*x state*/ x;
 }


### PR DESCRIPTION
Behavior after fixing the bug:
```css
/* entry.st.css */
.root {}          // optimized
.part {}          // optimized
:global(.a) {}    // not optimized
:global(.b .c) {} // not optimized
```
