### PR TITLE
Added 'paint()' property to native-reserved-lists

### DIFF
--- a/packages/core/src/native-reserved-lists.ts
+++ b/packages/core/src/native-reserved-lists.ts
@@ -117,6 +117,7 @@ export const nativeFunctionsDic = {
     'matrix3d': true,
     'minmax': true,
     'opacity': true,
+    'paint': true,
     'perspective': true,
     'polygon': true,
     'radial-gradient': true,


### PR DESCRIPTION
Fixes warning for native css paint() property.

Resolves #561.