### PR TITLE
fix webpack plugins api

### DIFF
--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -88,7 +88,9 @@ export class StylableWebpackPlugin {
         this.stylable = stylable;
     }
     public injectPlugins(compiler: webpack.Compiler) {
-        this.options.plugins!.forEach(plugin => plugin.apply(compiler));
+        if(this.options.plugins) {
+            this.options.plugins.forEach(plugin => plugin.apply(compiler, this));
+        }
     }
     public injectStylableRuntimeInfo(compiler: webpack.Compiler) {
         compiler.hooks.compilation.tap(StylableWebpackPlugin.name, compilation => {

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -15,7 +15,7 @@ export interface StylableWebpackPluginOptions {
     runtimeMode: 'isolated' | 'shared' | 'external';
     globalRuntimeId: string;
     bootstrap: {
-        autoInit: boolean,
+        autoInit: boolean;
         getAutoInitModule?: any;
         globalInjection?: (p: string) => string;
     };
@@ -37,8 +37,10 @@ export interface StylableWebpackPluginOptions {
     unsafeMuteDiagnostics: {
         DUPLICATE_MODULE_NAMESPACE: boolean;
     };
-    afterTransform?: ((results: StylableResults, module: StylableModule, stylable: Stylable) => void) | null;
-    plugins?: Array<(this: webpack.Compiler, ...p: any[]) => void>;
+    afterTransform?:
+        | ((results: StylableResults, module: StylableModule, stylable: Stylable) => void)
+        | null;
+    plugins?: Array<{ apply: (compiler: webpack.Compiler, stylablePlugin: any) => void }>;
     resolveNamespace?(): string;
     requireModule(path: string): any;
 }
@@ -50,7 +52,9 @@ export interface StylableGeneratorOptions {
     afterTransform: any;
 }
 
-export type ShallowPartial<T> = {[P in keyof T]?: T[P] extends new() => any ? T[P] : Partial<T[P]>};
+export type ShallowPartial<T> = {
+    [P in keyof T]?: T[P] extends new () => any ? T[P] : Partial<T[P]>
+};
 
 export interface CalcResult {
     depth: number;
@@ -69,12 +73,12 @@ export interface StylableModule extends webpack.Module {
     request: string;
     loaders: webpack.NewLoader[];
     buildInfo: {
-        optimize: StylableWebpackPluginOptions['optimize']
+        optimize: StylableWebpackPluginOptions['optimize'];
         isImportedByNonStylable: boolean;
         runtimeInfo: CalcResult;
         stylableMeta: StylableMeta;
-        usageMapping: Record<string, boolean>
-        usedStylableModules: StylableModule[]
+        usageMapping: Record<string, boolean>;
+        usedStylableModules: StylableModule[];
     };
     originalSource(): string;
 }


### PR DESCRIPTION
Adds missing second parameter for additional plugin integration into `@stylable/webpack-plugin`. This was caused by a mistake during the conversion of the project to TypeScript.