### PR TITLE
Add Legacy runtime API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cjs
 .history
 .DS_Store
 runtime.lib.js
+runtime-legacy.lib.js
 
 # Created by the extension "VS Live Share"
 .vs

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -11,6 +11,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
+    "@stylable/core": "^2.0.9",
     "@stylable/module-utils": "^2.0.10",
     "@stylable/runtime": "^2.0.6"
   },

--- a/packages/jest/src/index-legacy.ts
+++ b/packages/jest/src/index-legacy.ts
@@ -1,0 +1,8 @@
+import { processFactory } from './jest';
+
+export const process = processFactory(
+    {},
+    {
+        runtimePath: require.resolve('@stylable/runtime/cjs/index-legacy')
+    }
+);

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -6,7 +6,7 @@ export function processFactory(
     stylableConfig?: Partial<StylableConfig>,
     factoryOptions?: Partial<Options>
 ) {
-    stylableModuleFactory(
+    return stylableModuleFactory(
         {
             fileSystem: fs,
             requireModule: require,

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -1,13 +1,22 @@
-import { stylableModuleFactory } from '@stylable/module-utils';
+import { StylableConfig } from '@stylable/core';
+import { Options, stylableModuleFactory } from '@stylable/module-utils';
 import fs from 'fs';
 
-export const process = stylableModuleFactory(
-    {
-        fileSystem: fs,
-        requireModule: require,
-        projectRoot: ''
-    },
-    // ensure the generated module points to our own @stylable/runtime copy
-    // this allows @stylable/jest to be used as part of a globally installed CLI
-    { runtimePath: require.resolve('@stylable/runtime') }
-);
+export function processFactory(
+    stylableConfig?: Partial<StylableConfig>,
+    factoryOptions?: Partial<Options>
+) {
+    stylableModuleFactory(
+        {
+            fileSystem: fs,
+            requireModule: require,
+            projectRoot: '',
+            ...stylableConfig
+        },
+        // ensure the generated module points to our own @stylable/runtime copy
+        // this allows @stylable/jest to be used as part of a globally installed CLI
+        { runtimePath: require.resolve('@stylable/runtime'), ...factoryOptions }
+    );
+}
+
+export const process = processFactory();

--- a/packages/module-utils/src/module-factory.ts
+++ b/packages/module-utils/src/module-factory.ts
@@ -6,6 +6,7 @@ export interface Options {
     runtimeStylesheetId: 'module' | 'namespace';
     injectCSS: boolean;
     renderableOnly: boolean;
+    legacyRuntime: boolean;
 }
 
 export function stylableModuleFactory(
@@ -14,11 +15,14 @@ export function stylableModuleFactory(
         runtimePath = '@stylable/runtime',
         runtimeStylesheetId = 'module',
         injectCSS = true,
-        renderableOnly = false
+        renderableOnly = false,
+        legacyRuntime
     }: Partial<Options> = {}
 ) {
     const stylable = Stylable.create(stylableOptions);
-
+    if (legacyRuntime && runtimePath === '@stylable/runtime') {
+        runtimePath = '@stylable/runtime/cjs/index-legacy.js';
+    }
     return function stylableToModule(source: string, path: string) {
         const res = stylable.transform(source, path);
         return generateModuleSource(

--- a/packages/module-utils/src/module-factory.ts
+++ b/packages/module-utils/src/module-factory.ts
@@ -21,7 +21,7 @@ export function stylableModuleFactory(
 ) {
     const stylable = Stylable.create(stylableOptions);
     if (legacyRuntime && runtimePath === '@stylable/runtime') {
-        runtimePath = '@stylable/runtime/cjs/index-legacy.js';
+        runtimePath = '@stylable/runtime/cjs/index-legacy';
     }
     return function stylableToModule(source: string, path: string) {
         const res = stylable.transform(source, path);

--- a/packages/module-utils/test/index.spec.ts
+++ b/packages/module-utils/test/index.spec.ts
@@ -40,7 +40,23 @@ describe('Module Factory', () => {
             }
         });
     });
+    it('should create a module with legacy runtime', () => {
+        const testFile = path.join(path.resolve('/'), '/entry.st.css');
+        const { fs, factory, evalStylableModule } = moduleFactoryTestKit(
+            {
+                [testFile]: '.root {}'
+            },
+            { injectCSS: false, legacyRuntime: true }
+        );
 
+        const moduleSource = factory(fs.readFileSync(testFile, 'utf8'), testFile);
+
+        const exports: any = evalStylableModule(moduleSource, testFile);
+
+        expect(exports('root')).to.eql({
+            className: 'entry__root'
+        });
+    });
     it('should create a module with cross file use', () => {
         const rootPath = path.resolve('/');
         const testFile = path.join(rootPath, '/entry.st.css');
@@ -88,18 +104,20 @@ describe('Module Factory', () => {
         const moduleSource = factory(fs.readFileSync(testFile, 'utf8'), testFile);
 
         const exports = evalStylableModule(moduleSource, testFile);
-        expect(Object.keys(exports as {}).sort()).to.eql([
-            'namespace',
-            'classes',
-            'keyframes',
-            'vars',
-            'stVars',
-            'cssStates',
-            'style',
-            'st',
-            '$id',
-            '$depth',
-            '$css'
-        ].sort());
+        expect(Object.keys(exports as {}).sort()).to.eql(
+            [
+                'namespace',
+                'classes',
+                'keyframes',
+                'vars',
+                'stVars',
+                'cssStates',
+                'style',
+                'st',
+                '$id',
+                '$depth',
+                '$css'
+            ].sort()
+        );
     });
 });

--- a/packages/module-utils/test/test-kit.ts
+++ b/packages/module-utils/test/test-kit.ts
@@ -21,7 +21,7 @@ export function evalStylableModule<T = unknown>(source: string, fullPath: string
         if (id === '@stylable/runtime') {
             return { create };
         }
-        if (id === '@stylable/runtime/cjs/index-legacy.js') {
+        if (id === '@stylable/runtime/cjs/index-legacy') {
             return { create: legacyCreate };
         }
         throw new Error(`Could not find module: ${id}`);

--- a/packages/module-utils/test/test-kit.ts
+++ b/packages/module-utils/test/test-kit.ts
@@ -1,5 +1,6 @@
 import { createMemoryFileSystemWithFiles } from '@stylable/e2e-test-kit';
 import { create } from '@stylable/runtime';
+import { create as legacyCreate } from '@stylable/runtime/src/index-legacy';
 import { stylableModuleFactory } from '../src';
 import { Options } from '../src/module-factory';
 
@@ -19,6 +20,9 @@ export function evalStylableModule<T = unknown>(source: string, fullPath: string
     return evalModule(fullPath, source, id => {
         if (id === '@stylable/runtime') {
             return { create };
+        }
+        if (id === '@stylable/runtime/cjs/index-legacy.js') {
+            return { create: legacyCreate };
         }
         throw new Error(`Could not find module: ${id}`);
     }) as T;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,7 +17,8 @@
     "cjs",
     "src",
     "!src/tsconfig.json",
-    "runtime.lib.js"
+    "runtime.lib.js",
+    "runtime-legacy.lib.js"
   ],
   "engines": {
     "node": ">=8"

--- a/packages/runtime/scripts/build-runtime.ts
+++ b/packages/runtime/scripts/build-runtime.ts
@@ -11,3 +11,16 @@ const outModule = bundle({
 useModule(outModule, ['$', 'create', 'createRenderable', 'RuntimeRenderer']);
 
 ensureWrite(join(__dirname, '../runtime.lib.js'), outModule);
+
+/* LEGACY BUILD: 5/6/2019 */
+
+const outModuleLegacy = bundle({
+    name: 'StylableRuntime',
+    entry: join(__dirname, '../src/index-legacy.ts'),
+    includeEntry: false,
+    header: `/* runtime version: ${require('../package.json').version} */`    
+});
+
+useModule(outModuleLegacy, ['$', 'create', 'createRenderable', 'RuntimeRenderer'], ['create']);
+
+ensureWrite(join(__dirname, '../runtime-legacy.lib.js'), outModuleLegacy);

--- a/packages/runtime/scripts/ts-lib-bundler.ts
+++ b/packages/runtime/scripts/ts-lib-bundler.ts
@@ -7,6 +7,7 @@ interface Options {
     entry: string;
     includeEntry?: boolean;
     header?: string;
+    allowOverride?: string[];
 }
 
 export function bundle({ name, entry, includeEntry, header }: Options) {
@@ -17,8 +18,8 @@ export function bundle({ name, entry, includeEntry, header }: Options) {
     return header ? `${header}\n${res}` : res;
 }
 
-export function useModule(outModule: string, libExports: string[]) {
-    const exportErrors: Array<string | number | symbol> = [];
+export function useModule(outModule: string, libExports: string[], allowOverride: string[] = []) {
+    let exportErrors: Array<string | number | symbol> = [];
     const _exports: any = new Proxy(
         {},
         {
@@ -32,6 +33,9 @@ export function useModule(outModule: string, libExports: string[]) {
     if (missing.length) {
         throw new Error(`missing lib exports ["${missing.join('", "')}"]`);
     }
+    
+    exportErrors = exportErrors.filter(k => !allowOverride.some(o => o === k));
+    
     if (exportErrors.length) {
         throw new Error(`duplicate export ["${exportErrors.join('", "')}"]`);
     }

--- a/packages/runtime/src/css-runtime-stylesheet-legacy.ts
+++ b/packages/runtime/src/css-runtime-stylesheet-legacy.ts
@@ -17,32 +17,24 @@ export function create(
     renderer: RuntimeRenderer | null
 ) {
     const stylesheet = newCreate(namespace, exports, css, depth, id, renderer);
-    const dataNamespace = 'data-' + namespace.toLowerCase() + '-';
+
     function $cssStates(stateMapping: StateMap) {
-        // TODO: legacy states does not compatible with class based states
-        return stateMapping
-            ? Object.keys(stateMapping).reduce(
-                  (states, key) => {
-                      const stateValue = stateMapping[key];
-                      if (stateValue === undefined || stateValue === null || stateValue === false) {
-                          return states;
-                      }
-                      states[dataNamespace + key.toLowerCase()] = stateValue;
-                      return states;
-                  },
-                  {} as StateMap
-              )
-            : {};
+        return {
+            className: stylesheet.cssStates(stateMapping)
+        };
     }
+
     function $get(localName: string) {
         return stylesheet.classes[localName];
     }
+
     function $mapClasses(className: string) {
         return className
             .split(/\s+/g)
             .map(className => stylesheet.classes[className] || className)
             .join(' ');
     }
+
     function stylable_runtime_stylesheet(
         className: string,
         states?: StateMap,
@@ -75,6 +67,7 @@ export function create(
         }
         return base;
     }
+
     Object.setPrototypeOf(stylable_runtime_stylesheet, {
         $root: 'root',
         ...stylesheet.stVars,

--- a/packages/runtime/src/css-runtime-stylesheet-legacy.ts
+++ b/packages/runtime/src/css-runtime-stylesheet-legacy.ts
@@ -1,0 +1,93 @@
+import { RuntimeRenderer } from './css-runtime-renderer';
+import { create as createNew } from './css-runtime-stylesheet';
+import { AttributeMap, InheritedAttributes, StateMap, StylableExports } from './types';
+
+// If you see this code and don't know anything about it don't change it.
+// Because Barak made a custom bundler we can only support one api export name.
+// In order to create legacy api support we allow duplicate export that we know we can override in the bundle.
+
+const newCreate = createNew;
+
+export function create(
+    namespace: string,
+    exports: StylableExports,
+    css: string,
+    depth: number,
+    id: string | number,
+    renderer: RuntimeRenderer | null
+) {
+    const stylesheet = newCreate(namespace, exports, css, depth, id, renderer);
+    const dataNamespace = 'data-' + namespace.toLowerCase() + '-';
+    function $cssStates(stateMapping: StateMap) {
+        // TODO: legacy states does not compatible with class based states
+        return stateMapping
+            ? Object.keys(stateMapping).reduce(
+                  (states, key) => {
+                      const stateValue = stateMapping[key];
+                      if (stateValue === undefined || stateValue === null || stateValue === false) {
+                          return states;
+                      }
+                      states[dataNamespace + key.toLowerCase()] = stateValue;
+                      return states;
+                  },
+                  {} as StateMap
+              )
+            : {};
+    }
+    function $get(localName: string) {
+        return stylesheet.classes[localName];
+    }
+    function $mapClasses(className: string) {
+        return className
+            .split(/\s+/g)
+            .map(className => stylesheet.classes[className] || className)
+            .join(' ');
+    }
+    function stylable_runtime_stylesheet(
+        className: string,
+        states?: StateMap,
+        inheritedAttributes?: InheritedAttributes
+    ) {
+        className = className ? $mapClasses(className) : '';
+
+        if (states) {
+            const stateClasses = stylesheet.cssStates(states);
+            if (stateClasses) {
+                className += className ? ' ' + stateClasses : stateClasses;
+            }
+        }
+
+        const base: AttributeMap = {};
+        if (inheritedAttributes) {
+            for (const k in inheritedAttributes) {
+                if (k.match(/^data-/)) {
+                    base[k] = inheritedAttributes[k];
+                }
+            }
+            if (inheritedAttributes.className) {
+                className += className
+                    ? ' ' + inheritedAttributes.className
+                    : inheritedAttributes.className;
+            }
+        }
+        if (className) {
+            base.className = className;
+        }
+        return base;
+    }
+    Object.setPrototypeOf(stylable_runtime_stylesheet, {
+        $root: 'root',
+        ...stylesheet.stVars,
+        ...stylesheet.classes,
+        $namespace: stylesheet.namespace,
+        $depth: stylesheet.$depth,
+        $id: stylesheet.$id,
+        $css: stylesheet.$css,
+        $get,
+        $cssStates
+    });
+    // EDGE CACHE BUG FIX
+    (stylable_runtime_stylesheet as any).root = stylesheet.classes.root;
+
+    return stylable_runtime_stylesheet;
+}

--- a/packages/runtime/src/index-legacy.ts
+++ b/packages/runtime/src/index-legacy.ts
@@ -1,0 +1,3 @@
+export * from './css-runtime-renderer';
+export * from './css-runtime-stylesheet-legacy';
+export * from './types';

--- a/packages/runtime/test/e2e/projects/runtime-legacy/src/index.js
+++ b/packages/runtime/test/e2e/projects/runtime-legacy/src/index.js
@@ -1,0 +1,4 @@
+import style from "./index.st.css";
+
+document.documentElement.classList.add(style('root').className);
+window.backgroundColorAtLoadTime = getComputedStyle(document.documentElement).backgroundColor;

--- a/packages/runtime/test/e2e/projects/runtime-legacy/src/index.st.css
+++ b/packages/runtime/test/e2e/projects/runtime-legacy/src/index.st.css
@@ -1,0 +1,3 @@
+.root {
+    background-color: rgb(255, 0, 0);
+}

--- a/packages/runtime/test/e2e/projects/runtime-legacy/webpack.config.js
+++ b/packages/runtime/test/e2e/projects/runtime-legacy/webpack.config.js
@@ -1,0 +1,9 @@
+const { StylableWebpackPlugin } = require("@stylable/webpack-plugin/src");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+module.exports = {
+  mode: "development",
+  context: __dirname,
+  devtool: "source-map",
+  plugins: [new StylableWebpackPlugin({legacyRuntime: true}), new HtmlWebpackPlugin()]
+};

--- a/packages/runtime/test/e2e/runtime-legacy.spec.ts
+++ b/packages/runtime/test/e2e/runtime-legacy.spec.ts
@@ -18,7 +18,7 @@ describe(`(${project})`, () => {
         after
     );
 
-    it('css runtime variable overrides', async () => {
+    it('css renders with legacy runtime', async () => {
         const { page } = await projectRunner.openInBrowser();
         const { backgroundColor } = await page.evaluate(() => {
             const computedStyle = getComputedStyle(document.documentElement!);

--- a/packages/runtime/test/e2e/runtime-legacy.spec.ts
+++ b/packages/runtime/test/e2e/runtime-legacy.spec.ts
@@ -1,0 +1,34 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'runtime-legacy';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                headless: false,
+                devtools: true
+            }
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('css runtime variable overrides', async () => {
+        const { page } = await projectRunner.openInBrowser();
+        const { backgroundColor } = await page.evaluate(() => {
+            const computedStyle = getComputedStyle(document.documentElement!);
+
+            return {
+                backgroundColor: computedStyle.backgroundColor
+            };
+        });
+       
+        expect(backgroundColor).to.eql('rgb(255, 0, 0)');
+        
+    });
+});

--- a/packages/runtime/test/e2e/runtime-legacy.spec.ts
+++ b/packages/runtime/test/e2e/runtime-legacy.spec.ts
@@ -9,8 +9,8 @@ describe(`(${project})`, () => {
         {
             projectDir: join(__dirname, 'projects', project),
             puppeteerOptions: {
-                headless: false,
-                devtools: true
+                // headless: false,
+                // devtools: true
             }
         },
         before,

--- a/packages/runtime/test/unit/css-runtime-stylesheet-legacy.spec.ts
+++ b/packages/runtime/test/unit/css-runtime-stylesheet-legacy.spec.ts
@@ -1,0 +1,64 @@
+const { expect } = require('chai');
+import { create } from '../../src/css-runtime-stylesheet-legacy';
+
+describe.only('Stylable runtime stylesheet (LEGACY)', () => {
+    it('creates stylesheet with mapping ', () => {
+        const stylesheet = create(
+            'entry',
+            {
+                classes: { root: 'entry__root' },
+                keyframes: {},
+                vars: {},
+                stVars: {}
+            },
+            '',
+            0,
+            'test-stylesheet.st.css',
+            null
+        );
+
+        expect(stylesheet('root')).to.eql({ className: 'entry__root' });
+    });
+
+    it('style multi classNames + global', () => {
+        const stylesheet = create(
+            'entry',
+            {
+                classes: { root: 'entry__root' },
+                keyframes: {},
+                vars: {},
+                stVars: {}
+            },
+            '',
+            0,
+            'test-stylesheet.st.css',
+            null
+        );
+
+        expect(stylesheet('root global')).to.eql({ className: 'entry__root global' });
+        expect(stylesheet('root global', {}, { className: 'parent', ['data-test']: true })).to.eql({
+            className: 'entry__root global parent',
+            ['data-test']: true
+        });
+    });
+
+    it('style should output new state format (classes)', () => {
+        const stylesheet = create(
+            'entry',
+            {
+                classes: { root: 'entry__root' },
+                keyframes: {},
+                vars: {},
+                stVars: {}
+            },
+            '',
+            0,
+            'test-stylesheet.st.css',
+            null
+        );
+
+        expect(stylesheet('root', { loading: true, col: 3 })).to.eql({
+            className: 'entry__root entry--loading entry---col-1-3'
+        });
+    });
+});

--- a/packages/webpack-plugin/src/plugin-options.ts
+++ b/packages/webpack-plugin/src/plugin-options.ts
@@ -11,6 +11,7 @@ export function normalizeOptions(
             delete require.cache[id];
             return require(id);
         },
+        legacyRuntime: false,
         transformHooks: undefined,
         resolveNamespace: undefined,
         createRuntimeChunk: false,

--- a/packages/webpack-plugin/src/runtime-dependencies.ts
+++ b/packages/webpack-plugin/src/runtime-dependencies.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
 
 export const RUNTIME_SOURCE = readFileSync(require.resolve('@stylable/runtime/runtime.lib.js'), 'utf8');
+export const RUNTIME_SOURCE_LEGACY = readFileSync(require.resolve('@stylable/runtime/runtime-legacy.lib.js'), 'utf8');
 export const WEBPACK_STYLABLE = '__webpack_require__.stylable';

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -6,7 +6,7 @@ import webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { getModuleInGraph, hasStylableModuleInGraph } from './get-module-in-graph';
 import { normalizeOptions } from './plugin-options';
-import { RUNTIME_SOURCE, WEBPACK_STYLABLE } from './runtime-dependencies';
+import { RUNTIME_SOURCE, RUNTIME_SOURCE_LEGACY, WEBPACK_STYLABLE } from './runtime-dependencies';
 import { StylableBootstrapModule } from './stylable-bootstrap-module';
 import { StylableAssetDependency, StylableImportDependency } from './stylable-dependencies';
 import { StylableGenerator } from './stylable-generator';
@@ -378,16 +378,18 @@ export class StylableWebpackPlugin {
                 if (!hasStylableModuleInGraph(chunk)) {
                     return source;
                 }
+                
+                const runtimeSource = this.options.legacyRuntime ? 'debugger;'+RUNTIME_SOURCE_LEGACY : RUNTIME_SOURCE;
 
                 if (this.options.runtimeMode === 'isolated') {
-                    return `${RUNTIME_SOURCE};\n${WEBPACK_STYLABLE} = StylableRuntime();\n${source}`;
+                    return `${runtimeSource};\n${WEBPACK_STYLABLE} = StylableRuntime();\n${source}`;
                 } else {
                     const id = this.options.globalRuntimeId;
                     const globalObj = compilation.outputOptions.globalObject;
                     // tslint:disable-next-line:max-line-length
                     const injected = `${globalObj}["${id}"] = ${WEBPACK_STYLABLE} = ${globalObj}["${id}"] || StylableRuntime();\n${source}`;
                     if (this.options.runtimeMode === 'shared') {
-                        return `${RUNTIME_SOURCE};\n${injected}`;
+                        return `${runtimeSource};\n${injected}`;
                     } else {
                         // external
                         return injected;

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -381,7 +381,7 @@ export class StylableWebpackPlugin {
                     return source;
                 }
                 
-                const runtimeSource = this.options.legacyRuntime ? 'debugger;'+RUNTIME_SOURCE_LEGACY : RUNTIME_SOURCE;
+                const runtimeSource = this.options.legacyRuntime ? RUNTIME_SOURCE_LEGACY : RUNTIME_SOURCE;
 
                 if (this.options.runtimeMode === 'isolated') {
                     return `${runtimeSource};\n${WEBPACK_STYLABLE} = StylableRuntime();\n${source}`;

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -3,6 +3,7 @@ import { StylableOptimizer } from '@stylable/optimizer';
 import webpack from 'webpack';
 
 export interface StylableWebpackPluginOptions {
+    legacyRuntime: boolean;
     filename: string;
     useWeakDeps: boolean;
     includeDynamicModulesInCSS: boolean;


### PR DESCRIPTION
Set to `false` by default, can be switched on with the `legacyRuntime` flag set to `true`.

When active, the default import on `*.st.css` files is available and maintains the old API, with the new output (states as classes), while still passing through any `data-*` attributes.

Supported packages:
* jest
* node
* module-utils
* webpack-plugin
* runtime
