### PR TITLE
Fix stylable variable resolution in an unknown formatter

### DIFF
--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -262,6 +262,7 @@ export function processDeclarationValue(
                         } else if (isCssNativeFunction(value)) {
                             parsedNode.resolvedValue = stringifyFunction(value, parsedNode);
                         } else if (diagnostics) {
+                            parsedNode.resolvedValue = stringifyFunction(value, parsedNode);
                             diagnostics.warn(node, functionWarnings.UNKNOWN_FORMATTER(value), {
                                 word: value
                             });

--- a/packages/core/test/stylable-transformer/value.spec.ts
+++ b/packages/core/test/stylable-transformer/value.spec.ts
@@ -1,4 +1,4 @@
-import { box, CustomValueExtension, stTypes, functionWarnings } from '@stylable/core';
+import { box, CustomValueExtension, functionWarnings, stTypes } from '@stylable/core';
 import { generateStylableResult, generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 import postcss from 'postcss';


### PR DESCRIPTION
Should resolve a known variable even in unknown formatter functions.
You will still get a warning about an unknown formatter function being used.

Example:
```css
:vars {
    param: green;
}

.container {
    color: unknownFunc(value(param)); /* resolves to unknownFunc(green) */
}
```