### PR TITLE
Schema Extract: fixes and additions

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -14,7 +14,7 @@ End-users will usually not add this package directly as a dependency themselves,
 
 When importing a Stylable stylesheet, there are multiple named exports that are exposed for usage.
 
-```ts
+```ts 
 import { 
     style, 
     classes, 

--- a/packages/runtime/test/unit/css-runtime-stylesheet-legacy.spec.ts
+++ b/packages/runtime/test/unit/css-runtime-stylesheet-legacy.spec.ts
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 import { create } from '../../src/css-runtime-stylesheet-legacy';
 
-describe.only('Stylable runtime stylesheet (LEGACY)', () => {
+describe('Stylable runtime stylesheet (LEGACY)', () => {
     it('creates stylesheet with mapping ', () => {
         const stylesheet = create(
             'entry',

--- a/packages/schema-extract/src/index.ts
+++ b/packages/schema-extract/src/index.ts
@@ -1,1 +1,2 @@
 export * from './main';
+export * from './types';

--- a/packages/schema-extract/src/main.ts
+++ b/packages/schema-extract/src/main.ts
@@ -7,30 +7,7 @@ import {
     StylableProcessor,
     valueMapping
 } from '@stylable/core';
-import { JSONSchema7 } from 'json-schema';
-
-export type StateDict = { [stateName: string]: SchemaStates } & object;
-
-export interface ExtractedSchema extends JSONSchema7 {
-    states?: StateDict;
-    extends?: { $ref: string };
-    properties?: {
-        [key: string]: boolean | ExtractedSchema;
-    };
-}
-
-export interface SchemaStates {
-    type: string;
-    default?: string;
-    enum?: string[];
-}
-
-export interface MinimalPath {
-    dirname: (p: string) => string;
-    join: (...paths: string[]) => string;
-    isAbsolute: (path: string) => boolean;
-    relative: (from: string, to: string) => string;
-}
+import { ExtractedSchema, MinimalPath, SchemaStates, StateDict } from './types';
 
 export function extractSchema(css: string, filePath: string, root: string, path: MinimalPath) {
     const processor = new StylableProcessor();
@@ -76,7 +53,9 @@ export function generateSchema(
                         ? { $ref: getImportedRef(filePath, extended, basePath, path) }
                         : { $ref: extended.name };
             }
-        } else if (symbol._kind === 'var' && typeof schemaEntry !== 'boolean') {
+        } else if (symbol._kind === 'var') {
+            schemaEntry.$ref = `stylable/${symbol._kind}`;
+        } else if (symbol._kind === 'cssVar') {
             schemaEntry.$ref = `stylable/${symbol._kind}`;
         }
     }

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -4,6 +4,7 @@ export const stylableModule = 'stylable/module';
 export const stylableClass = 'stylable/class';
 export const stylableElement = 'stylable/element';
 export const stylableVar = 'stylable/var';
+export const stylableCssVar = 'stylable/cssVar';
 
 export type StateDict = { [stateName: string]: SchemaStates } & object;
 

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -6,15 +6,23 @@ export const stylableElement = 'stylable/element';
 export const stylableVar = 'stylable/var';
 export const stylableCssVar = 'stylable/cssVar';
 
-export type StateDict = { [stateName: string]: SchemaStates } & object;
+export function isStylableModuleSchema(schema: any): schema is StylableModuleSchema {
+    return schema.$ref === stylableModule;
+}
 
-export interface ExtractedSchema extends JSONSchema7 {
-    states?: StateDict;
-    extends?: { $ref: string };
+export interface StylableModuleSchema extends JSONSchema7 {
+    namespace: string;
     properties?: {
-        [key: string]: boolean | ExtractedSchema;
+        [key: string]: boolean | StylableSymbolSchema;
     };
 }
+
+export interface StylableSymbolSchema extends JSONSchema7 {
+    states?: StateDict;
+    extends?: { $ref: string };
+}
+
+export type StateDict = { [stateName: string]: SchemaStates } & object;
 
 export interface SchemaStates {
     type: string;

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -1,0 +1,29 @@
+import { JSONSchema7 } from 'json-schema';
+
+export const stylableModule = 'stylable/module';
+export const stylableClass = 'stylable/class';
+export const stylableElement = 'stylable/element';
+export const stylableVar = 'stylable/var';
+
+export type StateDict = { [stateName: string]: SchemaStates } & object;
+
+export interface ExtractedSchema extends JSONSchema7 {
+    states?: StateDict;
+    extends?: { $ref: string };
+    properties?: {
+        [key: string]: boolean | ExtractedSchema;
+    };
+}
+
+export interface SchemaStates {
+    type: string;
+    default?: string;
+    enum?: string[];
+}
+
+export interface MinimalPath {
+    dirname: (p: string) => string;
+    join: (...paths: string[]) => string;
+    isAbsolute: (path: string) => boolean;
+    relative: (from: string, to: string) => string;
+}

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -7,11 +7,12 @@ export const stylableVar = 'stylable/var';
 export const stylableCssVar = 'stylable/cssVar';
 
 export function isStylableModuleSchema(schema: any): schema is StylableModuleSchema {
-    return schema.$ref === stylableModule;
+    return !!schema && !!schema.$ref && schema.$ref === stylableModule;
 }
 
 export interface StylableModuleSchema extends JSONSchema7 {
     namespace: string;
+    moduleDependencies?: string[];
     properties?: {
         [key: string]: boolean | StylableSymbolSchema;
     };

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -12,14 +12,19 @@ import {
 
 use(flatMatch);
 
+function mockNamespace(namespace: string, _source: string) {
+    return namespace;
+}
+
 describe('Stylable JSON Schema Extractor', () => {
     describe('local symbols', () => {
         it('schema with a class', () => {
-            const res = extractSchema('.root{}', '/entry.st.css', '/', path);
+            const res = extractSchema('.root{}', '/entry.st.css', '/', path, mockNamespace);
 
             expect(res).to.eql({
                 $id: '/entry.st.css',
                 $ref: stylableModule,
+                namespace: 'entry',
                 properties: {
                     root: {
                         $ref: stylableClass
@@ -102,7 +107,7 @@ describe('Stylable JSON Schema Extractor', () => {
                     $ref: stylableClass,
                     states: {
                         size: {
-                            type: 'enum',
+                            type: 'string',
                             enum: ['small', 'medium', 'large']
                         }
                     }
@@ -375,11 +380,12 @@ describe('Stylable JSON Schema Extractor', () => {
             }
         `;
 
-        const res = extractSchema(css, '/entry.st.css', '/', path);
+        const res = extractSchema(css, '/entry.st.css', '/', path, mockNamespace);
 
         expect(res).to.eql({
             $id: '/entry.st.css',
             $ref: stylableModule,
+            namespace: 'entry',
             properties: {
                 root: {
                     $ref: stylableClass,
@@ -401,7 +407,7 @@ describe('Stylable JSON Schema Extractor', () => {
                     $ref: stylableClass,
                     states: {
                         size: {
-                            type: 'enum',
+                            type: 'string',
                             enum: ['s', 'm', 'l']
                         }
                     },

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -1,7 +1,7 @@
 import { flatMatch } from '@stylable/core-test-kit';
 import { expect, use } from 'chai';
 import path from 'path';
-import { extractSchema } from '../src';
+import { extractSchema, stylableClass, stylableElement, stylableModule, stylableVar, stylableCssVar } from '../src';
 
 use(flatMatch);
 
@@ -12,10 +12,10 @@ describe('Stylable JSON Schema Extractor', () => {
 
             expect(res).to.eql({
                 $id: '/entry.st.css',
-                $ref: 'stylable/module',
+                $ref: stylableModule,
                 properties: {
                     root: {
-                        $ref: 'stylable/class'
+                        $ref: stylableClass
                     }
                 }
             });
@@ -25,7 +25,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema('Comp{}', '/entry.st.css', '/', path);
 
             expect(res.properties!.Comp).to.eql({
-                $ref: 'stylable/element'
+                $ref: stylableElement
             });
         });
 
@@ -33,7 +33,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(':vars { myVar: red; }', '/entry.st.css', '/', path);
 
             expect(res.properties!.myVar).to.eql({
-                $ref: 'stylable/var'
+                $ref: stylableVar
             });
         });
 
@@ -41,7 +41,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema('.root { --myVar: red; }', '/entry.st.css', '/', path);
 
             expect(res.properties!['--myVar']).to.eql({
-                $ref: 'stylable/cssVar'
+                $ref: stylableCssVar
             });
         });
     });
@@ -55,7 +55,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(css, '/entry.st.css', '/', path);
             expect(res.properties).to.eql({
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         someState: {
                             type: 'boolean'
@@ -73,7 +73,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(css, '/entry.st.css', '/', path);
             expect(res.properties).to.eql({
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         someState: {
                             type: 'string',
@@ -92,7 +92,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(css, '/entry.st.css', '/', path);
             expect(res.properties).to.eql({
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         size: {
                             type: 'enum',
@@ -111,7 +111,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(css, '/entry.st.css', '/', path);
             expect(res.properties).to.eql({
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         size: {
                             type: 'number'
@@ -129,7 +129,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(css, '/entry.st.css', '/', path);
             expect(res.properties).to.eql({
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         size: {
                             type: 'tag'
@@ -147,7 +147,7 @@ describe('Stylable JSON Schema Extractor', () => {
             const res = extractSchema(css, '/entry.st.css', '/', path);
             expect(res.properties).to.eql({
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         state: {
                             type: 'mapped'
@@ -172,7 +172,7 @@ describe('Stylable JSON Schema Extractor', () => {
                 .to.be.an('object')
                 .that.deep.include({
                     root: {
-                        $ref: 'stylable/class',
+                        $ref: stylableClass,
                         extends: {
                             $ref: 'extended'
                         }
@@ -193,7 +193,7 @@ describe('Stylable JSON Schema Extractor', () => {
                 .to.be.an('object')
                 .that.deep.include({
                     root: {
-                        $ref: 'stylable/class',
+                        $ref: stylableClass,
                         extends: {
                             $ref: 'Element'
                         }
@@ -220,7 +220,7 @@ describe('Stylable JSON Schema Extractor', () => {
                 const res = extractSchema(css, '/entry.st.css', '/', path);
                 expect(res.properties).to.flatMatch({
                     root: {
-                        $ref: 'stylable/class',
+                        $ref: stylableClass,
                         extends: {
                             $ref: '/imported.st.css#root'
                         }
@@ -244,7 +244,7 @@ describe('Stylable JSON Schema Extractor', () => {
                     .to.be.an('object')
                     .that.deep.include({
                         root: {
-                            $ref: 'stylable/class',
+                            $ref: stylableClass,
                             extends: {
                                 $ref: '/imported.st.css#part'
                             }
@@ -268,7 +268,7 @@ describe('Stylable JSON Schema Extractor', () => {
                     .to.be.an('object')
                     .that.deep.include({
                         root: {
-                            $ref: 'stylable/class',
+                            $ref: stylableClass,
                             extends: {
                                 $ref: '/imported.st.css#part'
                             }
@@ -290,7 +290,7 @@ describe('Stylable JSON Schema Extractor', () => {
                 const res = extractSchema(css, '/entry.st.css', '/', path);
                 expect(res.properties).to.flatMatch({
                     root: {
-                        $ref: 'stylable/class',
+                        $ref: stylableClass,
                         extends: {
                             $ref: 'mock-package/imported.st.css#root'
                         }
@@ -314,7 +314,7 @@ describe('Stylable JSON Schema Extractor', () => {
                     .to.be.an('object')
                     .that.deep.include({
                         root: {
-                            $ref: 'stylable/class',
+                            $ref: stylableClass,
                             extends: {
                                 $ref: 'mock-package/imported.st.css#part'
                             }
@@ -338,7 +338,7 @@ describe('Stylable JSON Schema Extractor', () => {
                     .to.be.an('object')
                     .that.deep.include({
                         root: {
-                            $ref: 'stylable/class',
+                            $ref: stylableClass,
                             extends: {
                                 $ref: 'mock-package/imported.st.css#part'
                             }
@@ -372,10 +372,10 @@ describe('Stylable JSON Schema Extractor', () => {
 
         expect(res).to.eql({
             $id: '/entry.st.css',
-            $ref: 'stylable/module',
+            $ref: stylableModule,
             properties: {
                 root: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         userSelected: {
                             type: 'boolean'
@@ -388,10 +388,10 @@ describe('Stylable JSON Schema Extractor', () => {
                 Comp: {},
                 part: {},
                 myColor: {
-                    $ref: 'stylable/var'
+                    $ref: stylableVar
                 },
                 otherPart: {
-                    $ref: 'stylable/class',
+                    $ref: stylableClass,
                     states: {
                         size: {
                             type: 'enum',

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -24,7 +24,7 @@ describe('Stylable JSON Schema Extractor', () => {
         it('schema with a element', () => {
             const res = extractSchema('Comp{}', '/entry.st.css', '/', path);
 
-            expect(res.properties!.Comp).to.flatMatch({
+            expect(res.properties!.Comp).to.eql({
                 $ref: 'stylable/element'
             });
         });
@@ -32,8 +32,16 @@ describe('Stylable JSON Schema Extractor', () => {
         it('schema with a var', () => {
             const res = extractSchema(':vars { myVar: red; }', '/entry.st.css', '/', path);
 
-            expect(res.properties!.myVar).to.flatMatch({
+            expect(res.properties!.myVar).to.eql({
                 $ref: 'stylable/var'
+            });
+        });
+
+        it('schema with a css var', () => {
+            const res = extractSchema('.root { --myVar: red; }', '/entry.st.css', '/', path);
+
+            expect(res.properties!['--myVar']).to.eql({
+                $ref: 'stylable/cssVar'
             });
         });
     });

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -1,7 +1,14 @@
 import { flatMatch } from '@stylable/core-test-kit';
 import { expect, use } from 'chai';
 import path from 'path';
-import { extractSchema, stylableClass, stylableElement, stylableModule, stylableVar, stylableCssVar } from '../src';
+import {
+    extractSchema,
+    stylableClass,
+    stylableCssVar,
+    stylableElement,
+    stylableModule,
+    stylableVar
+} from '../src';
 
 use(flatMatch);
 


### PR DESCRIPTION
- separate module and symbol typings
- add `namespace` and `moduleDependencies` to extracted module output
- include imports used as an alias in the outputted schema
- no longer include unused imported symbols in the schema
- add initial css vars support