### PR TITLE
Disable minifier restructuring in optimizer

### DIFF
--- a/packages/optimizer/src/stylable-optimizer.ts
+++ b/packages/optimizer/src/stylable-optimizer.ts
@@ -25,7 +25,8 @@ export class StylableOptimizer implements IStylableOptimizer {
     ) {}
 
     public minifyCSS(css: string): string {
-        return csso.minify(css).css;
+        // disabling restructuring as it breaks production mode by disappearing classes
+        return csso.minify(css, { restructure: false }).css;
     }
     public optimize(
         config: OptimizeConfig,


### PR DESCRIPTION
It breaks production mode by making classes disappear.