### PR TITLE
[core, schema-extract] Add cssDocs support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "deindent": "^0.1.0",
     "enhanced-resolve": "^4.1.0",
     "is-vendor-prefixed": "^3.3.0",
+    "jest-docblock": "^24.3.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.clonedeepwith": "^4.5.0",
     "murmurhash": "^0.0.2",

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -1,16 +1,16 @@
 import { extract, parseWithComments } from 'jest-docblock';
-import { StylableSymbol } from './stylable-meta';
+import { StylableMeta, StylableSymbol } from './stylable-meta';
 
 export interface CssDoc {
     description: string;
     tags: Record<string, string>;
 }
 
-export function getCssDocsForSymbol(symbol: StylableSymbol): CssDoc | null {
+export function getCssDocsForSymbol(meta: StylableMeta, symbol: StylableSymbol): CssDoc | null {
     const commentNode =
         (symbol._kind === 'class' || symbol._kind === 'element') &&
-        symbol.getNode &&
-        symbol.getNode().prev();
+        meta.mappedSimpleSelectors[symbol.name] &&
+        meta.mappedSimpleSelectors[symbol.name].node.prev();
 
     if (commentNode && commentNode.type === 'comment') {
         const { comments, pragmas } = parseWithComments(extract(commentNode.toString()));

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -1,0 +1,28 @@
+import { extract, parseWithComments } from 'jest-docblock';
+import { StylableSymbol } from './stylable-meta';
+
+export interface CssDoc {
+    description: string;
+    tags: Record<string, string>;
+}
+
+export function getCssDocsForSymbol(symbol: StylableSymbol): CssDoc | null {
+    const commentNode =
+        (symbol._kind === 'class' || symbol._kind === 'element') && symbol.node.prev();
+
+    if (commentNode && commentNode.type === 'comment') {
+        const { comments, pragmas } = parseWithComments(extract(commentNode.toString()));
+        const res: CssDoc = {
+            description: comments,
+            tags: {}
+        };
+
+        for (const [pragmaName, pragmaValue] of Object.entries(pragmas)) {
+            res.tags[pragmaName] = Array.isArray(pragmaValue) ? pragmaValue.join(' ') : pragmaValue;
+        }
+
+        return res;
+    }
+
+    return null;
+}

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -10,7 +10,7 @@ export function getCssDocsForSymbol(meta: StylableMeta, symbol: StylableSymbol):
     let commentNode;
     
     if (symbol._kind === 'class' || symbol._kind === 'element') {
-        commentNode = meta.mappedSimpleSelectors[symbol.name] && meta.mappedSimpleSelectors[symbol.name].node.prev();
+        commentNode = meta.simpleSelectors[symbol.name] && meta.simpleSelectors[symbol.name].node.prev();
     } else if (symbol._kind === 'var') {
         commentNode = symbol.node.prev();
     }

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -8,7 +8,9 @@ export interface CssDoc {
 
 export function getCssDocsForSymbol(symbol: StylableSymbol): CssDoc | null {
     const commentNode =
-        (symbol._kind === 'class' || symbol._kind === 'element') && symbol.node.prev();
+        (symbol._kind === 'class' || symbol._kind === 'element') &&
+        symbol.getNode &&
+        symbol.getNode().prev();
 
     if (commentNode && commentNode.type === 'comment') {
         const { comments, pragmas } = parseWithComments(extract(commentNode.toString()));

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -11,7 +11,6 @@ export function getCssDocsForSymbol(meta: StylableMeta, symbol: StylableSymbol):
     
     if (symbol._kind === 'class' || symbol._kind === 'element') {
         commentNode = meta.mappedSimpleSelectors[symbol.name] && meta.mappedSimpleSelectors[symbol.name].node.prev();
-        
     } else if (symbol._kind === 'var') {
         commentNode = symbol.node.prev();
     }

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -7,10 +7,14 @@ export interface CssDoc {
 }
 
 export function getCssDocsForSymbol(meta: StylableMeta, symbol: StylableSymbol): CssDoc | null {
-    const commentNode =
-        (symbol._kind === 'class' || symbol._kind === 'element') &&
-        meta.mappedSimpleSelectors[symbol.name] &&
-        meta.mappedSimpleSelectors[symbol.name].node.prev();
+    let commentNode;
+    
+    if (symbol._kind === 'class' || symbol._kind === 'element') {
+        commentNode = meta.mappedSimpleSelectors[symbol.name] && meta.mappedSimpleSelectors[symbol.name].node.prev();
+        
+    } else if (symbol._kind === 'var') {
+        commentNode = symbol.node.prev();
+    }
 
     if (commentNode && commentNode.type === 'comment') {
         const { comments, pragmas } = parseWithComments(extract(commentNode.toString()));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from './custom-values';
 export * from './state-validators';
 export * from './selector-utils';
 export * from './native-reserved-lists';
+export * from './cssdocs';
 
 import * as pseudoStates from './pseudo-states';
 export { pseudoStates };

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -22,7 +22,7 @@ export class StylableMeta {
     public parent?: StylableMeta;
     public transformDiagnostics: Diagnostics | null;
     public scopes: postcss.AtRule[];
-    public mappedSimpleSelectors: Record<string, MappedComment>;
+    public simpleSelectors: Record<string, SimpleSelector>;
     // Generated during transform
     public outputAst?: postcss.Root;
     public globals: Record<string, boolean> = {};
@@ -51,7 +51,7 @@ export class StylableMeta {
         this.customSelectors = {};
         this.urls = [];
         this.scopes = [];
-        this.mappedSimpleSelectors = {};
+        this.simpleSelectors = {};
         this.transformDiagnostics = null;
     }
 }
@@ -115,7 +115,7 @@ export interface RefedMixin {
     ref: ImportSymbol | ClassSymbol;
 }
 
-export interface MappedComment {
+export interface SimpleSelector {
     symbol: ClassSymbol | ElementSymbol;
     node: postcss.Rule | postcss.Root;
 }

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -5,13 +5,6 @@ import { getSourcePath } from './stylable-utils';
 import { MappedStates, MixinValue, valueMapping } from './stylable-value-parsers';
 export const RESERVED_ROOT_NAME = 'root';
 
-function findNodeInAst(ast: postcss.Root, nodeName: string) {
-    let root = null;
-    ast.walkRules(`.${nodeName}`, rule => (root = rule));
-
-    return root;
-}
-
 export class StylableMeta {
     public rawAst: postcss.Root;
     public root: 'root';
@@ -36,8 +29,7 @@ export class StylableMeta {
         const rootSymbol: ClassSymbol = {
             _kind: 'class',
             name: RESERVED_ROOT_NAME,
-            [valueMapping.root]: true,
-            node: findNodeInAst(ast, RESERVED_ROOT_NAME) || postcss.rule()
+            [valueMapping.root]: true
         };
 
         this.rawAst = ast.clone();
@@ -81,7 +73,7 @@ export interface StylableDirectives {
 export interface ClassSymbol extends StylableDirectives {
     _kind: 'class';
     name: string;
-    node: postcss.Rule | postcss.Root;
+    getNode?: () => postcss.Rule | postcss.Root;
     alias?: ImportSymbol;
     scoped?: string;
 }
@@ -89,7 +81,7 @@ export interface ClassSymbol extends StylableDirectives {
 export interface ElementSymbol extends StylableDirectives {
     _kind: 'element';
     name: string;
-    node: postcss.Rule | postcss.Root;
+    getNode?: () => postcss.Rule | postcss.Root;
     alias?: ImportSymbol;
 }
 

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -5,6 +5,13 @@ import { getSourcePath } from './stylable-utils';
 import { MappedStates, MixinValue, valueMapping } from './stylable-value-parsers';
 export const RESERVED_ROOT_NAME = 'root';
 
+function findNodeInAst(ast: postcss.Root, nodeName: string) {
+    let root = null;
+    ast.walkRules(`.${nodeName}`, rule => (root = rule));
+
+    return root;
+}
+
 export class StylableMeta {
     public rawAst: postcss.Root;
     public root: 'root';
@@ -29,7 +36,8 @@ export class StylableMeta {
         const rootSymbol: ClassSymbol = {
             _kind: 'class',
             name: RESERVED_ROOT_NAME,
-            [valueMapping.root]: true
+            [valueMapping.root]: true,
+            node: findNodeInAst(ast, RESERVED_ROOT_NAME) || postcss.rule()
         };
 
         this.rawAst = ast.clone();
@@ -73,6 +81,7 @@ export interface StylableDirectives {
 export interface ClassSymbol extends StylableDirectives {
     _kind: 'class';
     name: string;
+    node: postcss.Rule | postcss.Root;
     alias?: ImportSymbol;
     scoped?: string;
 }
@@ -80,6 +89,7 @@ export interface ClassSymbol extends StylableDirectives {
 export interface ElementSymbol extends StylableDirectives {
     _kind: 'element';
     name: string;
+    node: postcss.Rule | postcss.Root;
     alias?: ImportSymbol;
 }
 

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -22,6 +22,7 @@ export class StylableMeta {
     public parent?: StylableMeta;
     public transformDiagnostics: Diagnostics | null;
     public scopes: postcss.AtRule[];
+    public mappedSimpleSelectors: Record<string, MappedComment>;
     // Generated during transform
     public outputAst?: postcss.Root;
     public globals: Record<string, boolean> = {};
@@ -50,6 +51,7 @@ export class StylableMeta {
         this.customSelectors = {};
         this.urls = [];
         this.scopes = [];
+        this.mappedSimpleSelectors = {};
         this.transformDiagnostics = null;
     }
 }
@@ -73,7 +75,6 @@ export interface StylableDirectives {
 export interface ClassSymbol extends StylableDirectives {
     _kind: 'class';
     name: string;
-    getNode?: () => postcss.Rule | postcss.Root;
     alias?: ImportSymbol;
     scoped?: string;
 }
@@ -81,7 +82,6 @@ export interface ClassSymbol extends StylableDirectives {
 export interface ElementSymbol extends StylableDirectives {
     _kind: 'element';
     name: string;
-    getNode?: () => postcss.Rule | postcss.Root;
     alias?: ImportSymbol;
 }
 
@@ -113,4 +113,9 @@ export type StylableSymbol = ImportSymbol | VarSymbol | ClassSymbol | ElementSym
 export interface RefedMixin {
     mixin: MixinValue;
     ref: ImportSymbol | ClassSymbol;
+}
+
+export interface MappedComment {
+    symbol: ClassSymbol | ElementSymbol;
+    node: postcss.Rule | postcss.Root;
 }

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -406,7 +406,7 @@ export class StylableProcessor {
                 alias
             };
 
-            this.meta.mappedSimpleSelectors[name] = {
+            this.meta.simpleSelectors[name] = {
                 node: rule,
                 symbol: this.meta.elements[name]
             };
@@ -427,13 +427,13 @@ export class StylableProcessor {
                 alias
             };
 
-            this.meta.mappedSimpleSelectors[name] = {
+            this.meta.simpleSelectors[name] = {
                 node: rule,
                 symbol: this.meta.mappedSymbols[name] as ClassSymbol
             };
-        } else if (name === this.meta.root && !this.meta.mappedSimpleSelectors[name]) {
+        } else if (name === this.meta.root && !this.meta.simpleSelectors[name]) {
             // special handling for registering "root" node comments
-            this.meta.mappedSimpleSelectors[name] = {
+            this.meta.simpleSelectors[name] = {
                 node: rule,
                 symbol: this.meta.classes[name]
             };

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -399,11 +399,16 @@ export class StylableProcessor {
                 this.checkRedeclareSymbol(name, rule);
                 alias = undefined;
             }
+
             this.meta.elements[name] = this.meta.mappedSymbols[name] = {
                 _kind: 'element',
                 name,
-                alias,
-                getNode: () => rule
+                alias
+            };
+
+            this.meta.mappedSimpleSelectors[name] = {
+                node: rule,
+                symbol: this.meta.elements[name]
             };
         }
     }
@@ -415,16 +420,23 @@ export class StylableProcessor {
                 this.checkRedeclareSymbol(name, rule);
                 alias = undefined;
             }
+
             this.meta.classes[name] = this.meta.mappedSymbols[name] = {
                 _kind: 'class',
                 name,
-                alias,
-                getNode: () => rule
+                alias
             };
-        } else if (name === this.meta.root && !this.meta.classes[name].getNode) {
-            // adding a getter to the node for later cssDocs extraction
-            (this.meta.mappedSymbols[name] as ClassSymbol).getNode = () => rule;
-            this.meta.classes[name].getNode = () => rule;
+
+            this.meta.mappedSimpleSelectors[name] = {
+                node: rule,
+                symbol: this.meta.mappedSymbols[name] as ClassSymbol
+            };
+        } else if (name === this.meta.root && !this.meta.mappedSimpleSelectors[name]) {
+            // special handling for registering "root" node comments
+            this.meta.mappedSimpleSelectors[name] = {
+                node: rule,
+                symbol: this.meta.classes[name]
+            };
         }
     }
 

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -402,7 +402,8 @@ export class StylableProcessor {
             this.meta.elements[name] = this.meta.mappedSymbols[name] = {
                 _kind: 'element',
                 name,
-                alias
+                alias,
+                node: rule
             };
         }
     }
@@ -417,7 +418,8 @@ export class StylableProcessor {
             this.meta.classes[name] = this.meta.mappedSymbols[name] = {
                 _kind: 'class',
                 name,
-                alias
+                alias,
+                node: rule
             };
         }
     }

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -403,7 +403,7 @@ export class StylableProcessor {
                 _kind: 'element',
                 name,
                 alias,
-                node: rule
+                getNode: () => rule
             };
         }
     }
@@ -419,8 +419,12 @@ export class StylableProcessor {
                 _kind: 'class',
                 name,
                 alias,
-                node: rule
+                getNode: () => rule
             };
+        } else if (name === this.meta.root && !this.meta.classes[name].getNode) {
+            // adding a getter to the node for later cssDocs extraction
+            (this.meta.mappedSymbols[name] as ClassSymbol).getNode = () => rule;
+            this.meta.classes[name].getNode = () => rule;
         }
     }
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -819,7 +819,11 @@ export class StylableTransformer {
             }
 
             // this is an error mode fallback
-            return { _kind: 'css', meta, symbol: { _kind: 'element', name: '*' } };
+            return {
+                _kind: 'css',
+                meta,
+                symbol: { _kind: 'element', name: '*', node: postcss.rule({ selector: '*' }) }
+            };
         }
 
         // find if the current symbol exists in the initial meta;

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -822,7 +822,7 @@ export class StylableTransformer {
             return {
                 _kind: 'css',
                 meta,
-                symbol: { _kind: 'element', name: '*', node: postcss.rule({ selector: '*' }) }
+                symbol: { _kind: 'element', name: '*' }
             };
         }
 

--- a/packages/core/test/comments-metadata.spec.ts
+++ b/packages/core/test/comments-metadata.spec.ts
@@ -1,0 +1,102 @@
+import { generateStylableResult } from '@stylable/core-test-kit';
+import { expect } from 'chai';
+import { getCssDocsForSymbol } from '../src';
+
+describe('css docs comments metadata', () => {
+    it('should return null when extracting cssdocs from a meta without no definitions', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        .root {}
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+
+        expect(cssDoc).to.eql(null);
+    });
+
+    it('should parse a simple description', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /**
+                         * this is my description
+                         */
+                        .root {}
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+
+        expect(cssDoc).to.eql({ description: 'this is my description', tags: {} });
+    });
+
+    it('should parse a multiple tags, including multi-line', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /**
+                         * @description this is a description tag
+                         * @field1 data field 1
+                         * @field2 data field 2 is a multi
+                         * line input
+                         * @field3 data field 3
+                         */
+                        .root {}
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+
+        expect(cssDoc).to.eql({
+            description: '',
+            tags: {
+                description: 'this is a description tag',
+                field1: 'data field 1',
+                field2: 'data field 2 is a multi line input',
+                field3: 'data field 3'
+            }
+        });
+    });
+
+    it('should parse a simple description and tag', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /**
+                         * this is a description text
+                         * @description this is a description tag
+                         */
+                        .root {}
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+
+        expect(cssDoc).to.eql({
+            description: 'this is a description text',
+            tags: { description: 'this is a description tag' }
+        });
+    });
+});

--- a/packages/core/test/cssdocs.spec.ts
+++ b/packages/core/test/cssdocs.spec.ts
@@ -16,7 +16,7 @@ describe('cssDocs comments metadata', () => {
             }
         });
 
-        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.root);
 
         expect(cssDoc).to.eql(null);
     });
@@ -37,7 +37,7 @@ describe('cssDocs comments metadata', () => {
             }
         });
 
-        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.root);
 
         expect(cssDoc).to.eql({ description: 'this is my description', tags: {} });
     });
@@ -62,7 +62,7 @@ describe('cssDocs comments metadata', () => {
             }
         });
 
-        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.root);
 
         expect(cssDoc).to.eql({
             description: '',
@@ -92,7 +92,7 @@ describe('cssDocs comments metadata', () => {
             }
         });
 
-        const cssDoc = getCssDocsForSymbol(meta.mappedSymbols.root);
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.root);
 
         expect(cssDoc).to.eql({
             description: 'this is a description text',

--- a/packages/core/test/cssdocs.spec.ts
+++ b/packages/core/test/cssdocs.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { getCssDocsForSymbol } from '../src';
 
 describe('cssDocs comments metadata', () => {
-    it('should return null when extracting cssDocs from a meta without no definitions', () => {
+    it('should return null when extracting cssDocs from a simple selector without a definition', () => {
         const { meta } = generateStylableResult({
             entry: `/entry.st.css`,
             files: {
@@ -21,7 +21,7 @@ describe('cssDocs comments metadata', () => {
         expect(cssDoc).to.eql(null);
     });
 
-    it('should parse a simple description', () => {
+    it('should parse a simple class description', () => {
         const { meta } = generateStylableResult({
             entry: `/entry.st.css`,
             files: {
@@ -42,7 +42,7 @@ describe('cssDocs comments metadata', () => {
         expect(cssDoc).to.eql({ description: 'this is my description', tags: {} });
     });
 
-    it('should parse a multiple tags, including multi-line', () => {
+    it('should parse a multiple tags, including multi-line for a simple class', () => {
         const { meta } = generateStylableResult({
             entry: `/entry.st.css`,
             files: {
@@ -75,7 +75,7 @@ describe('cssDocs comments metadata', () => {
         });
     });
 
-    it('should parse a simple description and tag', () => {
+    it('should parse a simple description and tag for a simple class', () => {
         const { meta } = generateStylableResult({
             entry: `/entry.st.css`,
             files: {
@@ -97,6 +97,89 @@ describe('cssDocs comments metadata', () => {
         expect(cssDoc).to.eql({
             description: 'this is a description text',
             tags: { description: 'this is a description tag' }
+        });
+    });
+
+    it('should parse a simple description and tag for a simple element', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /**
+                         * this is a description text
+                         * @description this is a description tag
+                         */
+                        Part {}
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.Part);
+
+        expect(cssDoc).to.eql({
+            description: 'this is a description text',
+            tags: { description: 'this is a description tag' }
+        });
+    });
+
+    it('should parse a simple var description', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        :vars {
+                            /**
+                             * this is a var description text
+                             */
+                            myVar: some value;
+                        }
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.myVar);
+
+        expect(cssDoc).to.eql({
+            description: 'this is a var description text',
+            tags: {}
+        });
+    });
+
+    it('should parse a simple var description and tags', () => {
+        const { meta } = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        :vars {
+                            /**
+                             * this is a var description text
+                             * @field1 data field 1
+                             * @field2 data field 2 is a multi
+                             * line input
+                             */
+                            myVar: some value;
+                        }
+                        `
+                }
+            }
+        });
+
+        const cssDoc = getCssDocsForSymbol(meta, meta.mappedSymbols.myVar);
+
+        expect(cssDoc).to.eql({
+            description: 'this is a var description text',
+            tags: {
+                field1: 'data field 1',
+                field2: 'data field 2 is a multi line input'
+            }
         });
     });
 });

--- a/packages/core/test/cssdocs.spec.ts
+++ b/packages/core/test/cssdocs.spec.ts
@@ -2,8 +2,8 @@ import { generateStylableResult } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 import { getCssDocsForSymbol } from '../src';
 
-describe('css docs comments metadata', () => {
-    it('should return null when extracting cssdocs from a meta without no definitions', () => {
+describe('cssDocs comments metadata', () => {
+    it('should return null when extracting cssDocs from a meta without no definitions', () => {
         const { meta } = generateStylableResult({
             entry: `/entry.st.css`,
             files: {

--- a/packages/schema-extract/src/main.ts
+++ b/packages/schema-extract/src/main.ts
@@ -1,4 +1,6 @@
 import {
+    ClassSymbol,
+    ElementSymbol,
     getCssDocsForSymbol,
     ImportSymbol,
     MappedStates,
@@ -6,15 +8,17 @@ import {
     StateParsedValue,
     StylableMeta,
     StylableProcessor,
-    valueMapping
+    valueMapping,
+    VarSymbol
 } from '@stylable/core';
-import { JSONSchema7 } from 'json-schema';
 import {
     MinimalPath,
     SchemaStates,
     StateDict,
+    stylableCssVar,
     StylableModuleSchema,
-    StylableSymbolSchema
+    StylableSymbolSchema,
+    stylableVar
 } from './types';
 
 export function extractSchema(
@@ -75,27 +79,34 @@ export function generateSchema(
                             : { $ref: extended.name };
                 }
 
-                const cssDoc = getCssDocsForSymbol(meta, symbol);
-
-                if (cssDoc) {
-                    if (cssDoc.description) {
-                        schemaEntry.description = cssDoc.description;
-                    }
-
-                    if (Object.keys(cssDoc.tags).length) {
-                        schemaEntry.tags = cssDoc.tags;
-                    }
-                }
-            } else if (symbol._kind === 'var' || symbol._kind === 'cssVar') {
-                schema.properties[entry] = {};
-                const schemaEntry = schema.properties[entry] as JSONSchema7;
-
-                schemaEntry.$ref = `stylable/${symbol._kind}`;
+                generateCssDocs(meta, symbol, schemaEntry);
+            } else if (symbol._kind === 'var') {
+                schema.properties[entry] = {
+                    $ref: stylableVar
+                };
+                
+                generateCssDocs(meta, symbol, schema.properties[entry] as StylableSymbolSchema);
+            } else if (symbol._kind === 'cssVar') {
+                schema.properties[entry] = {
+                    $ref: stylableCssVar
+                };
             }
         }
     }
 
     return schema;
+}
+
+function generateCssDocs(meta: StylableMeta, symbol: ClassSymbol | ElementSymbol | VarSymbol, schemaEntry: StylableSymbolSchema) {
+    const cssDoc = getCssDocsForSymbol(meta, symbol);
+    if (cssDoc) {
+        if (cssDoc.description) {
+            schemaEntry.description = cssDoc.description;
+        }
+        if (Object.keys(cssDoc.tags).length) {
+            schemaEntry.tags = cssDoc.tags;
+        }
+    }
 }
 
 function addModuleDependency(

--- a/packages/schema-extract/src/main.ts
+++ b/packages/schema-extract/src/main.ts
@@ -104,7 +104,7 @@ function generateCssDocs(meta: StylableMeta, symbol: ClassSymbol | ElementSymbol
             schemaEntry.description = cssDoc.description;
         }
         if (Object.keys(cssDoc.tags).length) {
-            schemaEntry.tags = cssDoc.tags;
+            schemaEntry.docTags = cssDoc.tags;
         }
     }
 }

--- a/packages/schema-extract/src/main.ts
+++ b/packages/schema-extract/src/main.ts
@@ -1,4 +1,5 @@
 import {
+    getCssDocsForSymbol,
     ImportSymbol,
     MappedStates,
     safeParse,
@@ -53,8 +54,7 @@ export function generateSchema(
             if (symbol._kind === 'class' || symbol._kind === 'element') {
                 schema.properties[entry] = {};
                 const schemaEntry = schema.properties[entry] as StylableSymbolSchema;
-                const states = symbol[valueMapping.states];
-                const extended = symbol[valueMapping.extends];
+                const { [valueMapping.states]: states, [valueMapping.extends]: extended } = symbol;
 
                 if (symbol.alias && symbol.alias.import) {
                     addModuleDependency(schema, filePath, symbol.alias.import.from, basePath, path);
@@ -73,6 +73,18 @@ export function generateSchema(
                         extended._kind === 'import' && extended.import
                             ? { $ref: getImportedRef(filePath, extended, basePath, path) }
                             : { $ref: extended.name };
+                }
+
+                const cssDoc = getCssDocsForSymbol(symbol);
+
+                if (cssDoc) {
+                    if (cssDoc.description) {
+                        schemaEntry.description = cssDoc.description;
+                    }
+
+                    if (Object.keys(cssDoc.tags).length) {
+                        schemaEntry.tags = cssDoc.tags;
+                    }
                 }
             } else if (symbol._kind === 'var' || symbol._kind === 'cssVar') {
                 schema.properties[entry] = {};

--- a/packages/schema-extract/src/main.ts
+++ b/packages/schema-extract/src/main.ts
@@ -75,7 +75,7 @@ export function generateSchema(
                             : { $ref: extended.name };
                 }
 
-                const cssDoc = getCssDocsForSymbol(symbol);
+                const cssDoc = getCssDocsForSymbol(meta, symbol);
 
                 if (cssDoc) {
                     if (cssDoc.description) {

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -21,7 +21,7 @@ export interface StylableModuleSchema extends JSONSchema7 {
 export interface StylableSymbolSchema extends JSONSchema7 {
     states?: StateDict;
     extends?: { $ref: string };
-    tags?: Record<string, string>;
+    docTags?: Record<string, string>;
 }
 
 export type StateDict = { [stateName: string]: SchemaStates } & object;

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -21,6 +21,7 @@ export interface StylableModuleSchema extends JSONSchema7 {
 export interface StylableSymbolSchema extends JSONSchema7 {
     states?: StateDict;
     extends?: { $ref: string };
+    tags?: Record<string, string>;
 }
 
 export type StateDict = { [stateName: string]: SchemaStates } & object;

--- a/packages/schema-extract/test/cssdocs.spec.ts
+++ b/packages/schema-extract/test/cssdocs.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import path from 'path';
+import { extractSchema, stylableClass, stylableModule, StylableModuleSchema } from '../src';
+import { mockNamespace } from './mock-namespace';
+
+describe('cssDocs extraction', () => {
+    it('should extract cssDocs description and tags', () => {
+        const res = extractSchema(`
+            /**
+             * this is a description text
+             * @description this is a description tag
+             */
+            .root{}
+            `, '/entry.st.css', '/', path, mockNamespace);
+
+        const expected: StylableModuleSchema = {
+            $id: '/entry.st.css',
+            $ref: stylableModule,
+            namespace: 'entry',
+            properties: {
+                root: {
+                    $ref: stylableClass,
+                    description: 'this is a description text',
+                    tags: {
+                        description: 'this is a description tag'
+                    }
+                }
+            }
+        };
+        expect(res).to.eql(expected);
+    });
+});

--- a/packages/schema-extract/test/cssdocs.spec.ts
+++ b/packages/schema-extract/test/cssdocs.spec.ts
@@ -1,17 +1,30 @@
 import { expect } from 'chai';
 import path from 'path';
-import { extractSchema, stylableClass, stylableModule, StylableModuleSchema } from '../src';
+import {
+    extractSchema,
+    stylableClass,
+    stylableElement,
+    stylableModule,
+    StylableModuleSchema,
+    stylableVar
+} from '../src';
 import { mockNamespace } from './mock-namespace';
 
 describe('cssDocs extraction', () => {
-    it('should extract cssDocs description and tags', () => {
-        const res = extractSchema(`
+    it('should extract cssDocs description and tags for a simple class', () => {
+        const res = extractSchema(
+            `
             /**
              * this is a description text
              * @description this is a description tag
              */
-            .root{}
-            `, '/entry.st.css', '/', path, mockNamespace);
+            .root {}
+            `,
+            '/entry.st.css',
+            '/',
+            path,
+            mockNamespace
+        );
 
         const expected: StylableModuleSchema = {
             $id: '/entry.st.css',
@@ -23,6 +36,78 @@ describe('cssDocs extraction', () => {
                     description: 'this is a description text',
                     tags: {
                         description: 'this is a description tag'
+                    }
+                }
+            }
+        };
+        expect(res).to.eql(expected);
+    });
+
+    it('should extract cssDocs description and tags for a simple element', () => {
+        const res = extractSchema(
+            `
+            /**
+             * this is a description text
+             * @description this is a description tag
+             */
+            Comp {}
+            `,
+            '/entry.st.css',
+            '/',
+            path,
+            mockNamespace
+        );
+
+        const expected: StylableModuleSchema = {
+            $id: '/entry.st.css',
+            $ref: stylableModule,
+            namespace: 'entry',
+            properties: {
+                root: {
+                    $ref: stylableClass
+                },
+                Comp: {
+                    $ref: stylableElement,
+                    description: 'this is a description text',
+                    tags: {
+                        description: 'this is a description tag'
+                    }
+                }
+            }
+        };
+        expect(res).to.eql(expected);
+    });
+
+    it('should extract cssDocs description and tags for a variable', () => {
+        const res = extractSchema(
+            `
+            :vars {
+                /**
+                 * this is a var description text
+                 * @description this is a var description tag
+                 */
+                myVar: some value;
+            }
+            `,
+            '/entry.st.css',
+            '/',
+            path,
+            mockNamespace
+        );
+
+        const expected: StylableModuleSchema = {
+            $id: '/entry.st.css',
+            $ref: stylableModule,
+            namespace: 'entry',
+            properties: {
+                root: {
+                    $ref: stylableClass
+                },
+                myVar: {
+                    $ref: stylableVar,
+                    description: 'this is a var description text',
+                    tags: {
+                        description: 'this is a var description tag'
                     }
                 }
             }

--- a/packages/schema-extract/test/cssdocs.spec.ts
+++ b/packages/schema-extract/test/cssdocs.spec.ts
@@ -34,7 +34,7 @@ describe('cssDocs extraction', () => {
                 root: {
                     $ref: stylableClass,
                     description: 'this is a description text',
-                    tags: {
+                    docTags: {
                         description: 'this is a description tag'
                     }
                 }
@@ -69,7 +69,7 @@ describe('cssDocs extraction', () => {
                 Comp: {
                     $ref: stylableElement,
                     description: 'this is a description text',
-                    tags: {
+                    docTags: {
                         description: 'this is a description tag'
                     }
                 }
@@ -106,7 +106,7 @@ describe('cssDocs extraction', () => {
                 myVar: {
                     $ref: stylableVar,
                     description: 'this is a var description text',
-                    tags: {
+                    docTags: {
                         description: 'this is a var description tag'
                     }
                 }

--- a/packages/schema-extract/test/mock-namespace.ts
+++ b/packages/schema-extract/test/mock-namespace.ts
@@ -1,0 +1,3 @@
+export function mockNamespace(namespace: string, _source: string) {
+    return namespace;
+}

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -491,8 +491,16 @@ describe('Stylable JSON Schema Extractor', () => {
                 -st-named: part1, part2;
             }
             :vars {
+                /**
+                 * a var description
+                 * @tag a var tag
+                 */
                 myColor: red;
             }
+            /**
+             * a description for root
+             * @tag a tag for root
+             */
             .root {
                 -st-states: userSelected;
                 -st-extends: Comp;
@@ -501,6 +509,10 @@ describe('Stylable JSON Schema Extractor', () => {
                 -st-states: size( enum(s, m, l) );
                 -st-extends: part1;
             }
+            /**
+             * a description for part2
+             * @tag a tag for part2
+             */
             .part2 {}
         `;
 
@@ -521,13 +533,19 @@ describe('Stylable JSON Schema Extractor', () => {
                     },
                     extends: {
                         $ref: '/imported.st.css#root'
-                    }
+                    },
+                    description: 'a description for root',
+                    tags: { tag: 'a tag for root' }
                 },
                 part2: {
-                    $ref: '/imported.st.css#part2'
+                    $ref: '/imported.st.css#part2',
+                    description: 'a description for part2',
+                    tags: { tag: 'a tag for part2' }
                 },
                 myColor: {
-                    $ref: stylableVar
+                    $ref: stylableVar,
+                    description: 'a var description',
+                    tags: { tag: 'a var tag' }
                 },
                 otherPart: {
                     $ref: stylableClass,

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -7,7 +7,8 @@ import {
     stylableCssVar,
     stylableElement,
     stylableModule,
-    stylableVar
+    stylableVar,
+    StylableModuleSchema
 } from '../src';
 import { mockNamespace } from './mock-namespace';
 
@@ -517,8 +518,7 @@ describe('Stylable JSON Schema Extractor', () => {
         `;
 
         const res = extractSchema(css, '/entry.st.css', '/', path, mockNamespace);
-
-        expect(res).to.eql({
+        const expected: StylableModuleSchema = {
             $id: '/entry.st.css',
             $ref: stylableModule,
             namespace: 'entry',
@@ -535,17 +535,17 @@ describe('Stylable JSON Schema Extractor', () => {
                         $ref: '/imported.st.css#root'
                     },
                     description: 'a description for root',
-                    tags: { tag: 'a tag for root' }
+                    docTags: { tag: 'a tag for root' }
                 },
                 part2: {
                     $ref: '/imported.st.css#part2',
                     description: 'a description for part2',
-                    tags: { tag: 'a tag for part2' }
+                    docTags: { tag: 'a tag for part2' }
                 },
                 myColor: {
                     $ref: stylableVar,
                     description: 'a var description',
-                    tags: { tag: 'a var tag' }
+                    docTags: { tag: 'a var tag' }
                 },
                 otherPart: {
                     $ref: stylableClass,
@@ -560,6 +560,8 @@ describe('Stylable JSON Schema Extractor', () => {
                     }
                 }
             }
-        });
+        };
+
+        expect(res).to.eql(expected);
     });
 });

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -9,12 +9,9 @@ import {
     stylableModule,
     stylableVar
 } from '../src';
+import { mockNamespace } from './mock-namespace';
 
 use(flatMatch);
-
-function mockNamespace(namespace: string, _source: string) {
-    return namespace;
-}
 
 describe('Stylable JSON Schema Extractor', () => {
     describe('local symbols', () => {

--- a/packages/schema-extract/test/test.spec.ts
+++ b/packages/schema-extract/test/test.spec.ts
@@ -7,8 +7,8 @@ import {
     stylableCssVar,
     stylableElement,
     stylableModule,
-    stylableVar,
-    StylableModuleSchema
+    StylableModuleSchema,
+    stylableVar
 } from '../src';
 import { mockNamespace } from './mock-namespace';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2955,6 +2955,11 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -4835,6 +4840,13 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+jest-docblock@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.3.0.tgz#b9c32dac70f72e4464520d2ba4aec02ab14db5dd"
+  integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
+  dependencies:
+    detect-newline "^2.1.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Expose a utility method in `@stylable/core` called `getCssDocsForSymbol`, that accepts a `StylableSymbol` (`class` or `element` for the moment), and attempts to extract the docBlock written above the symbol node.

These cssDocs are automatically added to the output from `@stylable/schema-extract`.