### PR TITLE
Add flag to CLI accepting require hooks to run

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,14 +29,15 @@ After installing `@stylable/cli`, a new `stc` command will be available, running
 |ext||extension of stylable css files|`.st.css`|
 |cssInJs||output transpiled css into the js module|`false`|
 |cssFilename||pattern of the generated css file|`[filename].css`|
-|injectCSSRequest|icr|add a static import for the generated css in the js module output|`false`|
-|namespaceResolver|nsr|node request to a module that exports a stylable resolveNamespace function|`@stylable/node`|
-|optimize|o|removes: empty nodes, stylable directives, comments|`false`|
-|minify|m|minify generated css|`false`|
+|injectCSSRequest|`icr`|add a static import for the generated css in the js module output|`false`|
+|namespaceResolver|`nsr`|node request to a module that exports a stylable resolveNamespace function|`@stylable/node`|
+|require|`r`|require hook to execture before running|`-`|
+|optimize|`o`|removes: empty nodes, stylable directives, comments|`false`|
+|minify|`m`|minify generated css|`false`|
 |log||verbose log|`false`|
 |diagnostics||verbose diagnostics|`false`|
 |compat||use legacy v1 runtime api|`false`|
-|help|h|Show help|`boolean`|
+|help|`h`|Show help|`boolean`|
 
 ### Generate an index file
 This generates an `index.st.css` file that acts as an export entry from every stylesheet in the provided `srcDir`.

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { normalize } = require('path');
+
+if (__filename.endsWith(normalize('/packages/cli/cli.js'))) {
+    require('@ts-tools/node/r');
+    require('./src/cli');
+} else {
+    require('./cjs/cli');
+}

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -2,6 +2,7 @@
 
 const { normalize } = require('path');
 
+// Use ts-tools to run typescript from source when running in the context of this mono-repo
 if (__filename.endsWith(normalize('/packages/cli/cli.js'))) {
     require('@ts-tools/node/r');
     require('./src/cli');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "cjs/index.js",
   "types": "cjs/index.d.ts",
   "bin": {
-    "stc": "cjs/cli.js"
+    "stc": "./cli.js"
   },
   "scripts": {
     "clean": "rimraf ./cjs",
@@ -24,6 +24,7 @@
   "files": [
     "cjs",
     "src",
+    "cli.js",
     "!src/tsconfig.json"
   ],
   "engines": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -147,9 +147,9 @@ const {
 
 log('[Arguments]', argv);
 
-for (const r of requires) {
-    if (r) {
-        import(path.resolve(r));
+for (const request of requires) {
+    if (request) {
+        require(request);
     }
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -147,6 +147,7 @@ const {
 
 log('[Arguments]', argv);
 
+// execute all require hooks before running the CLI build
 for (const request of requires) {
     if (request) {
         require(request);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -101,6 +101,12 @@ const argv = require('yargs')
     .describe('ext', 'extension of stylable css files')
     .default('ext', '.st.css')
 
+    .option('require')
+    .alias('require', 'r')
+    .array('require')
+    .describe('require', 'require hook ')
+    .default('require', [])
+
     .option('log')
     .describe('log', 'verbose log')
     .default('log', false)
@@ -115,6 +121,7 @@ const argv = require('yargs')
 const log = createLogger('[Stylable]', argv.log);
 
 const diagnostics = createLogger('[Stylable Diagnostics]\n', argv.diagnostics);
+
 const {
     outDir,
     srcDir,
@@ -134,10 +141,17 @@ const {
     compat,
     minify,
     manifestFilepath,
-    manifest
+    manifest,
+    require: requires
 } = argv;
 
 log('[Arguments]', argv);
+
+for (const r of requires) {
+    if (r) {
+        import(path.resolve(r));
+    }
+}
 
 const stylable = Stylable.create({
     fileSystem: fs,

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -8,9 +8,7 @@ import { join, relative } from 'path';
 
 function runCli(cliArgs: string[] = []): { stderr: any; stdout: any } {
     return spawnSync('node', [
-        '-r',
-        '@ts-tools/node/r',
-        join(__dirname, '../src/cli.ts'),
+        join(__dirname, '../cli.js'),
         ...cliArgs
     ]);
 }
@@ -233,4 +231,20 @@ describe('Stylable Cli', () => {
         expect(m.namespaceMapping).eql({ 'style.st.css': 'test-ns-0' });
     });
 
+    it('test require hook', () => {
+        populateDirectorySync(tempDir.path, {});
+        const nsr = join(__dirname, 'fixtures/test-ns-resolver.js');
+        const requireHook = join(__dirname, 'fixtures/test-require-hook.js');
+        const { stderr, stdout } = runCli([
+            '--rootDir',
+            tempDir.path,
+            '--nsr',
+            nsr,
+            '-r',
+            requireHook
+        ]);
+
+        expect(stderr.toString('utf8')).equal('');
+        expect(stdout.toString('utf8')).to.contain('I HAVE BEEN REQUIRED');
+    });
 });

--- a/packages/cli/test/fixtures/test-require-hook.js
+++ b/packages/cli/test/fixtures/test-require-hook.js
@@ -1,0 +1,1 @@
+console.log("I HAVE BEEN REQUIRED");


### PR DESCRIPTION
This will allow to pass the CLI `@ts-tools` require hook handler to run typescript (mixins, custom values, etc) from source.