### PR TITLE
Set `@stylable/runtime` as dependancy of `@stylable/module-utils`

### DIFF
--- a/packages/module-utils/package.json
+++ b/packages/module-utils/package.json
@@ -11,7 +11,8 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@stylable/core": "^2.3.1-alpha.0"
+    "@stylable/core": "^2.3.1-alpha.0",
+    "@stylable/runtime": "^2.3.1-alpha.0"
   },
   "files": [
     "cjs",


### PR DESCRIPTION
Module utils now depends on structure available only on `runtime@alpha`
(within module-factory) 

Case - 
Tried updating @ui-autotools independently and it failed to find path `@stylable/runtime/cjs/index-legacy`