### PR TITLE
Diagnostics: Remove extra warning on value called with several arguments

### DIFF
--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -32,8 +32,6 @@ export const functionWarnings = {
     CANNOT_USE_JS_AS_VALUE: (varName: string) =>
         `JavaScript import "${varName}" cannot be used as a variable`,
     CANNOT_FIND_IMPORTED_VAR: (varName: string) => `cannot use unknown imported "${varName}"`,
-    MULTI_ARGS_IN_VALUE: (args: string) =>
-        `value function accepts only a single argument: "value(${args})"`,
     UNKNOWN_FORMATTER: (name: string) =>
         `cannot find native function or custom formatter called ${name}`,
     UNKNOWN_VAR: (name: string) => `unknown var "${name}"`
@@ -287,14 +285,6 @@ export function processDeclarationValue(
                 outputValue += matchingType.getValue(args, topLevelType, n, customValues);
             } else {
                 outputValue += getStringValue([n]);
-
-                const parsedArgs = getFormatterArgs(n);
-                if (diagnostics && parsedArgs.length > 1 && n.value === 'value') {
-                    const argsAsString = parsedArgs.join(', ');
-                    diagnostics.warn(node, functionWarnings.MULTI_ARGS_IN_VALUE(argsAsString), {
-                        word: argsAsString
-                    });
-                }
             }
         } else {
             outputValue += getStringValue([n]);

--- a/packages/core/test/functions.spec.ts
+++ b/packages/core/test/functions.spec.ts
@@ -605,33 +605,6 @@ describe('Stylable functions (native, formatter and variable)', () => {
 
     describe('diagnostics', () => {
         describe('value()', () => {
-            it('should return warning when passing more than one argument to a value() function', () => {
-                expectWarningsFromTransform(
-                    {
-                        entry: '/style.st.css',
-                        files: {
-                            '/style.st.css': {
-                                content: `
-                            :vars {
-                                color1: red;
-                                color2: gold;
-                            }
-                            .my-class {
-                                |color:value($color1, color2$)|;
-                            }
-                            `
-                            }
-                        }
-                    },
-                    [
-                        {
-                            message: functionWarnings.MULTI_ARGS_IN_VALUE('color1, color2'),
-                            file: '/style.st.css'
-                        }
-                    ]
-                );
-            });
-
             it('should return warning for unknown var on transform', () => {
                 expectWarningsFromTransform(
                     {


### PR DESCRIPTION
Resolves https://github.com/wix/stylable/issues/779 because of https://stylable.io/docs/references/variables#advanced-variable-types