### PR TITLE
jest: specify cache key method

### DIFF
--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -2,6 +2,8 @@ import { StylableConfig } from '@stylable/core';
 import { Options, stylableModuleFactory } from '@stylable/module-utils';
 import fs from 'fs';
 
+const stylableRuntimePath = require.resolve('@stylable/runtime');
+
 export function processFactory(
     stylableConfig?: Partial<StylableConfig>,
     factoryOptions?: Partial<Options>
@@ -15,8 +17,19 @@ export function processFactory(
         },
         // ensure the generated module points to our own @stylable/runtime copy
         // this allows @stylable/jest to be used as part of a globally installed CLI
-        { runtimePath: require.resolve('@stylable/runtime'), ...factoryOptions }
+        { runtimePath: stylableRuntimePath, ...factoryOptions }
     );
 }
 
 export const process = processFactory();
+
+export function getCacheKey(
+    fileData: string,
+    filename: string,
+    configString: string,
+    { instrument }: { instrument: boolean }
+) {
+    return (
+        fileData + configString + (instrument ? 'instrument' : '') + filename + stylableRuntimePath
+    );
+}


### PR DESCRIPTION
so that if the runtime location is changed locally, the module will be re-created.

fixes #875