### PR TITLE
Local extended class export bug and resolver improvements

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -1289,7 +1289,7 @@ export class StylableTransformer {
                 Array<CSSResolve<ClassSymbol | ElementSymbol>>
             > = {};
             for (const k of Object.keys(meta.elements)) {
-                resolvedElements[k] = this.resolver.resolveExtends(meta, k, true, this);
+                resolvedElements[k] = this.resolver.resolveExtends(meta, k, true);
             }
             metaParts = { class: resolvedClasses, element: resolvedElements };
             this.metaParts.set(meta, metaParts);

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -344,9 +344,13 @@ export function getSourcePath(root: postcss.Root, diagnostics: Diagnostics) {
 }
 
 export function getAlias(symbol: StylableSymbol): ImportSymbol | undefined {
-    return (symbol && symbol._kind === 'class') || symbol._kind === 'element'
-        ? symbol.alias
-        : undefined;
+    if (symbol._kind === 'class' || symbol._kind === 'element') {
+        if (!symbol[valueMapping.extends]) {
+            return symbol.alias;
+        }
+    }
+
+    return undefined;
 }
 
 export function generateScopedCSSVar(namespace: string, varName: string) {

--- a/packages/core/test/stylable-transformer/exports.spec.ts
+++ b/packages/core/test/stylable-transformer/exports.spec.ts
@@ -235,7 +235,7 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes.root).to.equal('entry__root');
         });
-        
+
         it('should handle root extends local class', () => {
             const cssExports = generateStylableExports({
                 entry: '/entry.st.css',
@@ -253,7 +253,7 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes.root).to.equal('entry__root entry__y');
         });
-        
+
         it('should handle root extends imported class', () => {
             const cssExports = generateStylableExports({
                 entry: '/entry.st.css',
@@ -280,7 +280,7 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes.root).to.equal('entry__root index__y');
         });
-        
+
         it('should handle root extends imported class alias', () => {
             const cssExports = generateStylableExports({
                 entry: '/entry.st.css',
@@ -318,7 +318,7 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes.root).to.equal('entry__root index__y');
         });
-        
+
         it('should handle multiple extends levels', () => {
             const cssExports = generateStylableExports({
                 entry: '/entry.st.css',
@@ -359,7 +359,7 @@ describe('Exports to js', () => {
             expect(cssExports.classes.root).to.equal('entry__root middle__x index__y');
         });
 
-        it('should handle multiple levels of extending with a local class', () => {
+        it('should handle multiple levels of extending with local classes and an import', () => {
             const cssExports = generateStylableExports({
                 entry: '/entry.st.css',
                 files: {
@@ -373,8 +373,11 @@ describe('Exports to js', () => {
                             .local {
                                 -st-extends: Comp; 
                             }
+                            .local2 {
+                                -st-extends: local; 
+                            }
                             .extending {
-                                -st-extends: local;
+                                -st-extends: local2;
                             }
                         `
                     },
@@ -386,9 +389,11 @@ describe('Exports to js', () => {
                     }
                 }
             });
-            expect(cssExports.classes.extending).to.equal('entry__extending entry__local');
+            expect(cssExports.classes.extending).to.equal(
+                'entry__extending entry__local2 entry__local'
+            );
         });
-        
+
         it('should handle classes from mixins', () => {
             const cssExports = generateStylableExports({
                 entry: '/entry.st.css',
@@ -424,7 +429,6 @@ describe('Exports to js', () => {
                 z: 'entry__z'
             });
         });
-        
     });
 
     describe('stylable vars', () => {

--- a/packages/core/test/stylable-transformer/exports.spec.ts
+++ b/packages/core/test/stylable-transformer/exports.spec.ts
@@ -358,6 +358,36 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes.root).to.equal('entry__root middle__x index__y');
         });
+
+        it('should handle multiple levels of extending with a local class', () => {
+            const cssExports = generateStylableExports({
+                entry: '/entry.st.css',
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            :import {
+                                -st-from: "./base.st.css";
+                                -st-default: Comp;
+                            }
+                            .local {
+                                -st-extends: Comp; 
+                            }
+                            .extending {
+                                -st-extends: local;
+                            }
+                        `
+                    },
+                    '/base.st.css': {
+                        namespace: 'base',
+                        content: `
+                            .root {}
+                        `
+                    }
+                }
+            });
+            expect(cssExports.classes.extending).to.equal('entry__extending entry__local');
+        });
         
         it('should handle classes from mixins', () => {
             const cssExports = generateStylableExports({


### PR DESCRIPTION
- fix edge case with local extended classes and exports
- fix resolving a class as local and not an alias when extended
- add protection against a case causing an infinite loop in the resolver