### PR TITLE
Remove handling for incorrect path resolution in cross-os situations

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -677,7 +677,11 @@ export class StylableProcessor {
                         importObj.from = importPath;
                     } else {
                         importObj.fromRelative = importPath;
-                        importObj.from = path.resolve(path.dirname(this.meta.source), importPath);
+                        const dirPath = path.dirname(this.meta.source);
+                        importObj.from =
+                            path.posix && path.posix.isAbsolute(dirPath) // browser has no posix methods
+                                ? path.posix.join(dirPath, importPath)
+                                : path.join(dirPath, importPath);
                     }
                     fromExists = true;
                     break;

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -1,5 +1,5 @@
 import cloneDeep from 'lodash.clonedeep';
-import { isAbsolute, resolve } from 'path';
+import { isAbsolute } from 'path';
 import postcss from 'postcss';
 import { Diagnostics } from './diagnostics';
 import {
@@ -340,7 +340,7 @@ export function getSourcePath(root: postcss.Root, diagnostics: Diagnostics) {
     } else if (!isAbsolute(source)) {
         throw new Error('source filename is not absolute path: "' + source + '"');
     }
-    return source ? resolve(source) : source;
+    return source;
 }
 
 export function getAlias(symbol: StylableSymbol): ImportSymbol | undefined {

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -4,7 +4,6 @@ import {
     findTestLocations
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import { resolve } from 'path';
 import { functionWarnings, mixinWarnings, valueMapping } from '../src';
 import { nativePseudoElements, reservedKeyFrames } from '../src/native-reserved-lists';
 import { processorWarnings } from '../src/stylable-processor';
@@ -381,7 +380,7 @@ describe('diagnostics: warnings and errors', () => {
                         }
                     }
                 };
-                const mainPath = resolve('/main.css');
+                const mainPath = '/main.css';
                 const xPath = [`y from ${mainPath}`, `x from ${mainPath}`];
                 const yPath = [`x from ${mainPath}`, `y from ${mainPath}`];
                 expectWarningsFromTransform(config, [

--- a/packages/core/test/functions.spec.ts
+++ b/packages/core/test/functions.spec.ts
@@ -1,7 +1,6 @@
 import { expectWarningsFromTransform } from '@stylable/core-test-kit';
 import { generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import { resolve } from 'path';
 import postcss from 'postcss';
 import { functionWarnings } from '../src';
 import { nativeFunctionsDic } from '../src/native-reserved-lists';
@@ -901,7 +900,7 @@ describe('Stylable functions (native, formatter and variable)', () => {
                         }
                     }
                 };
-                const mainPath = resolve('/main.st.css');
+                const mainPath = '/main.st.css';
                 expectWarningsFromTransform(config, [
                     {
                         message: functionWarnings.CYCLIC_VALUE([
@@ -910,7 +909,7 @@ describe('Stylable functions (native, formatter and variable)', () => {
                             `${mainPath}: c`,
                             `${mainPath}: a`
                         ]),
-                        file: '/main.st.css'
+                        file: mainPath
                     }
                 ]);
             });

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -1,6 +1,5 @@
 import { createStylableInstance, generateInfra } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import { resolve } from 'path';
 import postcss from 'postcss';
 import { createMinimalFS, process, safeParse, StylableResolver } from '../src';
 import { cachedProcessFile, MinimalFS } from '../src/cached-process-file';
@@ -58,7 +57,7 @@ describe('stylable-resolver', () => {
         const results = createResolveExtendsResults(fs, '/extended-button.st.css', 'myClass');
         expect(results[0].symbol.name).to.equal('myClass');
         expect(results[1].symbol.name).to.equal('root');
-        expect(results[1].meta.source).to.equal(resolve('/button.st.css'));
+        expect(results[1].meta.source).to.equal('/button.st.css');
     });
 
     it('should resolve extend elements', () => {
@@ -89,7 +88,7 @@ describe('stylable-resolver', () => {
         const results = createResolveExtendsResults(fs, '/extended-button.st.css', 'Button', true);
         expect(results[0].symbol!.name).to.equal('Button');
         expect(results[1].symbol!.name).to.equal('root');
-        expect(results[1].meta.source).to.equal(resolve('/button.st.css'));
+        expect(results[1].meta.source).to.equal('/button.st.css');
     });
 
     it('should not enter infinite loops even with broken code', () => {
@@ -127,7 +126,7 @@ describe('stylable-resolver', () => {
         const results = createResolveExtendsResults(fs, '/extended-button.st.css', 'Button', true);
         expect(results[0].symbol!.name).to.equal('Button');
         expect(results[1].symbol!.name).to.equal('root');
-        expect(results[1].meta.source).to.equal(resolve('/button.st.css'));
+        expect(results[1].meta.source).to.equal('/button.st.css');
     });
 
     it('should resolve extend classes on broken css', () => {
@@ -140,7 +139,7 @@ describe('stylable-resolver', () => {
                 }
             }
         });
-        const results = createResolveExtendsResults(fs, resolve('/button.st.css'), 'gaga');
+        const results = createResolveExtendsResults(fs, '/button.st.css', 'gaga');
         expect(results).to.eql([]);
     });
 
@@ -174,15 +173,15 @@ describe('stylable-resolver', () => {
                 }
             }
         });
-        const results = createResolveExtendsResults(fs, resolve('/entry.st.css'), 'root');
+        const results = createResolveExtendsResults(fs, '/entry.st.css', 'root');
 
         expect(results[0].symbol!.name).to.equal('root');
         expect(results[1].symbol!.name).to.equal('Comp');
         expect(results[2].symbol!.name).to.equal('root');
 
-        expect(results[0].meta.source).to.equal(resolve('/entry.st.css'));
-        expect(results[1].meta.source).to.equal(resolve('/index.st.css'));
-        expect(results[2].meta.source).to.equal(resolve('/button.st.css'));
+        expect(results[0].meta.source).to.equal('/entry.st.css');
+        expect(results[1].meta.source).to.equal('/index.st.css');
+        expect(results[2].meta.source).to.equal('/button.st.css');
     });
 
     it('should resolve class as local and not an alias when an -st-extend is present', () => {
@@ -213,15 +212,15 @@ describe('stylable-resolver', () => {
             }
         });
 
-        const results = createResolveExtendsResults(fs, resolve('/entry.st.css'), 'target');
+        const results = createResolveExtendsResults(fs, '/entry.st.css', 'target');
 
         expect(results[0].symbol!.name).to.equal('target');
         expect(results[1].symbol!.name).to.equal('alias');
         expect(results[2].symbol!.name).to.equal('root');
 
-        expect(results[0].meta.source).to.equal(resolve('/entry.st.css'));
-        expect(results[1].meta.source).to.equal(resolve('/entry.st.css'));
-        expect(results[2].meta.source).to.equal(resolve('/entry.st.css'));
+        expect(results[0].meta.source).to.equal('/entry.st.css');
+        expect(results[1].meta.source).to.equal('/entry.st.css');
+        expect(results[2].meta.source).to.equal('/entry.st.css');
     });
 
     it('should resolve classes', () => {

--- a/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
+++ b/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
@@ -1,6 +1,5 @@
 import { createTransformer } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import { resolve } from 'path';
 import postcss from 'postcss';
 
 describe('post-process-and-hooks', () => {
@@ -179,8 +178,8 @@ describe('post-process-and-hooks', () => {
         const expected = [
             ['red', 'myColor', true, []],
             ['green', 'myBG', true, []],
-            ['Ariel', 'param2', true, [`default from ${resolve('/entry.st.css')}`]],
-            ['Ariel', 'param2', true, [`default from ${resolve('/entry.st.css')}`]]
+            ['Ariel', 'param2', true, [`default from '/entry.st.css'`]],
+            ['Ariel', 'param2', true, [`default from '/entry.st.css'`]]
         ];
 
         t.transform(t.fileProcessor.process('/entry.st.css'));

--- a/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
+++ b/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
@@ -178,8 +178,8 @@ describe('post-process-and-hooks', () => {
         const expected = [
             ['red', 'myColor', true, []],
             ['green', 'myBG', true, []],
-            ['Ariel', 'param2', true, [`default from '/entry.st.css'`]],
-            ['Ariel', 'param2', true, [`default from '/entry.st.css'`]]
+            ['Ariel', 'param2', true, [`default from /entry.st.css`]],
+            ['Ariel', 'param2', true, [`default from /entry.st.css`]]
         ];
 
         t.transform(t.fileProcessor.process('/entry.st.css'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,9 +7090,9 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
 
 postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.18, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.23, postcss@^7.0.24, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.24"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.24.tgz#972c3c5be431b32e40caefe6c81b5a19117704c2"
-  integrity sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==
+  version "7.0.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.25.tgz#dd2a2a753d50b13bed7a2009b4a18ac14d9db21e"
+  integrity sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
This follows a fix in the latest version of [postcss](https://github.com/postcss/postcss/releases/tag/7.0.25)