### PR TITLE
feat(core): add support for multiple extends on a simple selector by using composition

### DIFF
--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -72,6 +72,7 @@ export interface StylableDirectives {
     '-st-states'?: MappedStates;
     '-st-extends'?: ImportSymbol | ClassSymbol | ElementSymbol;
     '-st-global'?: SelectorAstNode[];
+    '-st-compose'?: Array<ImportSymbol | ClassSymbol | ElementSymbol>;
 }
 
 export interface ClassSymbol extends StylableDirectives {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -248,11 +248,11 @@ export class StylableResolver {
                         res.symbol &&
                         (res.symbol._kind === 'element' || res.symbol._kind === 'class')
                     ) {
-                        const { _kind, meta, symbol } = res;
+                        const { _kind, symbol, meta } = res;
                         current = {
                             _kind,
-                            meta,
-                            symbol
+                            symbol,
+                            meta
                         };
                     } else {
                         if (reportError) {
@@ -261,7 +261,7 @@ export class StylableResolver {
                         break;
                     }
                 } else {
-                    current = { _kind: 'css', symbol: parent, meta };
+                    current = { _kind: 'css', symbol: parent, meta: current.meta };
                 }
             } else {
                 break;

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -57,7 +57,8 @@ export const valueMapping = {
     states: '-st-states' as '-st-states',
     extends: '-st-extends' as '-st-extends',
     mixin: '-st-mixin' as '-st-mixin',
-    global: '-st-global' as '-st-global'
+    global: '-st-global' as '-st-global',
+    compose: '-st-compose' as '-st-compose'
 };
 
 export type stKeys = keyof typeof valueMapping;

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -212,6 +212,54 @@ describe('Stylable postcss process', () => {
         });
     });
 
+    it('collect typed classes extends with multiple extends into compose', () => {
+        const result = processSource(
+            `
+            :import {
+                -st-from: './file.css';
+                -st-default: Style;
+                -st-named: z;
+            }
+            .y{}
+            .myclass {
+                -st-extends: Style x y z;
+            }
+            .x{}
+        `,
+            { from: 'path/to/style.css' }
+        );
+
+        expect(result.diagnostics.reports.length, 'no reports').to.eql(0);
+
+        expect(result.classes).to.flatMatch({
+            myclass: {
+                '-st-extends': {
+                    _kind: 'import',
+                    type: 'default',
+                    import: {
+                        // from: '/path/to/file.css',
+                        fromRelative: './file.css',
+                        defaultExport: 'Style'
+                    }
+                },
+                '-st-compose': [
+                    {
+                        _kind: 'class',
+                        name: 'x'
+                    },
+                    {
+                        _kind: 'class',
+                        name: 'y'
+                    },
+                    {
+                        _kind: 'import',
+                        name: 'z'
+                    }
+                ]
+            }
+        });
+    });
+
     it('collect typed elements', () => {
         const result = processSource(
             `

--- a/packages/core/test/stylable-transformer/exports.spec.ts
+++ b/packages/core/test/stylable-transformer/exports.spec.ts
@@ -358,6 +358,132 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes.root).to.equal('entry__root middle__x index__y');
         });
+        it('should handle multiple extends values', () => {
+            const cssExports = generateStylableExports({
+                entry: '/entry.st.css',
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            .a {
+                                -st-extends: x y y1;
+                            }
+                            .x {
+                                -st-extends: z end;
+                            }
+                            .y {
+
+                            }
+                            .y1 {
+                                -st-extends: a x;
+                            }
+                            .z {}
+                            .end {}
+                        `
+                    }
+                }
+            });
+            expect(cssExports.classes.a).to.equal(
+                'entry__a entry__x entry__z entry__y entry__y1 entry__end'
+            );
+        });
+
+        it('should handle multiple extends values from different stylesheets', () => {
+            const cssExports = generateStylableExports({
+                entry: '/entry.st.css',
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            :import {-st-from: './base.st.css';-st-named: base;}
+                            .x {
+                                -st-extends: base end;
+                            }
+                            .end {}
+                        `
+                    },
+                    '/base.st.css': {
+                        namespace: 'base',
+                        content: `
+                            .base {
+                                -st-extends: a b c;
+                            }
+                            .a {}
+                            .b {}
+                            .c {}
+                        `
+                    }
+                }
+            });
+            expect(cssExports.classes.x).to.equal(
+                'entry__x base__base base__a entry__end base__b base__c'
+            );
+        });
+
+        it('should handle class extends values from different stylesheets (bug fix)', () => {
+            const cssExports = generateStylableExports({
+                entry: '/entry.st.css',
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            :import {-st-from: './base.st.css';-st-named: base;}
+                            .x {
+                                -st-extends: base;
+                            }
+                        `
+                    },
+                    '/base.st.css': {
+                        namespace: 'base',
+                        content: `
+                            .base {
+                                -st-extends: a;
+                            }
+                            .a {
+                                -st-extends: b;
+                            }
+                            .b {
+
+                            }
+                        `
+                    }
+                }
+            });
+            expect(cssExports.classes.x).to.equal(
+                'entry__x base__base base__a base__b'
+            );
+        });
+        
+        it('should handle root extends with multiple extends values (should not add composed classes on root)', () => {
+            const cssExports = generateStylableExports({
+                entry: '/entry.st.css',
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            :import {-st-from: './base.st.css';-st-default: Base;}
+                            .x {
+                                -st-extends: Base;
+                            }
+                        `
+                    },
+                    '/base.st.css': {
+                        namespace: 'base',
+                        content: `
+                            .root {
+                                -st-extends: a b c;
+                            }
+                            .a {}
+                            .b {}
+                            .c {}
+                        `
+                    }
+                }
+            });
+            expect(cssExports.classes.x).to.equal(
+                'entry__x'
+            );
+        });
 
         it('should handle multiple levels of extending with local classes and an import', () => {
             const cssExports = generateStylableExports({

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -854,6 +854,30 @@ describe('Stylable postcss transform (Scoping)', () => {
             expect((result.nodes![0] as postcss.Rule).selector).to.equal('.entry__a');
         });
 
+        it('scope selector that extends multiple classes (no change on the output)', () => {
+            const result = generateStylableRoot({
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            .a {
+                                -st-extends: root x;
+                            }
+                            .x {
+                                -st-extends: y z;
+                            }
+                            .y {}
+                            .z {}
+                        `
+                    }
+                }
+            });
+
+            expect((result.nodes![0] as postcss.Rule).selector).to.equal('.entry__a');
+        });
+
+
         it.skip('TODO: fix it. scope selector that extends local root', () => {
             generateStylableRoot({
                 entry: `/entry.st.css`,


### PR DESCRIPTION
* Add `-st-compose` to StylableDirectives
* Process multiple extends into `-st-compose` after the first one
* Reorder resolver object
* Fix bug wrong meta for local classes from parent resolution
* Export multiple composed classes

This feature will allow to write multiple `-st-extends` on parts. the first extends defines the type like before and the rest will be added to the JavaScript module exports.
Example: 
```css
.root {
  -st-extends: a b c;
}
.a {}
.b {}
.c {}
```
exported classes
```ts
{
  root: "root a b c",
  a: "a",
  b: "b",
  c: "c"
}
```