### PR TITLE
@st-scope and CSS service quality of life improvements

### DIFF
--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -72,6 +72,10 @@ export class CssService {
         );
     }
 
+    // cleaning strategy: replace the "value(*)" syntax with spaces,
+    // without touching the inner content (*)
+    // by removing the function from the params,
+    // the css-service will consider it a valid media query
     private cleanValuesInMediaQuery(ast: postcss.Root): postcss.Root {
         const mq = 'media';
         const valueMatch = 'value(';
@@ -93,6 +97,10 @@ export class CssService {
         return ast;
     }
 
+    // cleaning strategy: replace the "@st-scope" syntax with a media query,
+    // if the @st-scope param was a class, replace the "." with a space as well.
+    // this works because the css-service now considers this a valid media query where
+    // completions and nesting behaviors are similar between the two
     private cleanStScopes(ast: postcss.Root): postcss.Root {
         const stScope = 'st-scope';
         const mq = 'media';

--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -61,7 +61,6 @@ export class CssService {
     }
 
     public createSanitizedDocument(ast: postcss.Root, filePath: string, version: number) {
-        // const cleanContentAst = this.cleanValuesInMediaQuery(ast);
         let cleanContentAst = this.cleanValuesInMediaQuery(ast);
         cleanContentAst = this.cleanStScopes(cleanContentAst);
 
@@ -163,7 +162,6 @@ export class CssService {
                     // on windows, uri.fsPath replaces separators with '\'
                     // this breaks posix paths in-memory when running on windows
                     // take raw posix path instead
-                    // ()
                     const filePath =
                         uri.scheme === 'file' &&
                         !uri.authority && // not UNC

--- a/packages/language-service/src/lib/feature/color-provider.ts
+++ b/packages/language-service/src/lib/feature/color-provider.ts
@@ -149,7 +149,13 @@ export function resolveDocumentColors(
             });
         });
 
-        return colorComps.concat(cssService.findColors(document));
+        const cleanDocument = cssService.createSanitizedDocument(
+            meta.rawAst,
+            filePath,
+            document.version
+        );
+
+        return colorComps.concat(cssService.findColors(cleanDocument));
     }
 
     return [];

--- a/packages/language-service/test-kit/completions-asserters.ts
+++ b/packages/language-service/test-kit/completions-asserters.ts
@@ -1,6 +1,8 @@
 import fs from '@file-services/node';
 import { expect } from 'chai';
 import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
 import { ProviderPosition, ProviderRange } from '../src/lib/completion-providers';
 import { Completion, Snippet } from '../src/lib/completion-types';
 import { CASES_PATH, stylableLSP } from './stylable-fixtures-lsp';
@@ -84,6 +86,22 @@ export function getCompletions(fileName: string, prefix = '') {
             assertNotPresent(completions, expectedNoCompletions);
         }
     };
+}
+
+export function getStylableAndCssCompletions(fileName: string) {
+    const fullPath = path.join(CASES_PATH, fileName);
+    const src: string = fs.readFileSync(fullPath).toString();
+
+    const pos = getCaretPosition(src);
+
+    const document = TextDocument.create(
+        URI.file(fullPath).toString(),
+        'stylable',
+        1,
+        src.replace('|', '')
+    );
+
+    return stylableLSP.getCompletions(document, fullPath, pos);
 }
 
 export function getCaretPosition(src: string) {

--- a/packages/language-service/test/fixtures/server-cases/st-scope/directive.st.css
+++ b/packages/language-service/test/fixtures/server-cases/st-scope/directive.st.css
@@ -1,0 +1,7 @@
+.root {}
+
+@st-scope .root {
+    .part {
+        |
+    }
+}

--- a/packages/language-service/test/fixtures/server-cases/st-scope/inside-value-local-vars.st.css
+++ b/packages/language-service/test/fixtures/server-cases/st-scope/inside-value-local-vars.st.css
@@ -1,0 +1,12 @@
+:vars {
+    color1: red;
+    color2: blue;
+}
+
+.root {}
+
+@st-scope .root {
+    .local {
+        color: value(), value( | )
+    }
+}

--- a/packages/language-service/test/fixtures/server-cases/st-scope/local-class-from-selector.st.css
+++ b/packages/language-service/test/fixtures/server-cases/st-scope/local-class-from-selector.st.css
@@ -1,0 +1,20 @@
+@st-scope .root {
+      .gaga {
+        -st-states: active;
+        color: red;
+    }
+
+    .gaga:active .gaga {
+        background-color: fuchsia;
+    }
+
+    .lokal {
+        -st-extends:      gaga;
+    }
+
+    .mixed {
+        -st-mixin: lokal,
+        gaga, lokal,
+        gaga;
+    }
+}

--- a/packages/language-service/test/fixtures/server-cases/st-scope/local-vars.st.css
+++ b/packages/language-service/test/fixtures/server-cases/st-scope/local-vars.st.css
@@ -1,0 +1,12 @@
+:vars {
+    color1: red;
+    color2: blue;
+}
+
+.root {}
+
+@st-scope .root {
+    .local {
+        color: |
+    }
+}

--- a/packages/language-service/test/fixtures/server-cases/st-scope/selector.st.css
+++ b/packages/language-service/test/fixtures/server-cases/st-scope/selector.st.css
@@ -1,0 +1,6 @@
+.root {}
+.part {}
+
+@st-scope .root {
+    |
+}

--- a/packages/language-service/test/fixtures/server-cases/st-scope/single-variable-color.st.css
+++ b/packages/language-service/test/fixtures/server-cases/st-scope/single-variable-color.st.css
@@ -1,0 +1,10 @@
+:vars {
+    myColor: red;
+}
+
+@st-scope .root {
+    .root {
+        color: value(myColor);
+        background-color: #ffffff;
+    }
+}

--- a/packages/language-service/test/lib/colors.spec.ts
+++ b/packages/language-service/test/lib/colors.spec.ts
@@ -51,6 +51,25 @@ describe('Colors', () => {
 
             expect(res.length).to.eql(1);
         });
+
+        it('should resolve information colors in a @st-scope', () => {
+            const res = getDocumentColors('st-scope/single-variable-color.st.css');
+
+            expect(res).to.eql([
+                {
+                    range: createRange(6, 15, 6, 28),
+                    color: createColor(1, 0, 0, 1)
+                },
+                {
+                    range: createRange(1, 13, 1, 16),
+                    color: createColor(1, 0, 0, 1)
+                },
+                {
+                    range: createRange(7, 26, 7, 33),
+                    color: createColor(1, 1, 1, 1)
+                }
+            ]);
+        });
     });
 
     describe('ColorPresentation', () => {

--- a/packages/language-service/test/lib/completions/st-scope.spec.ts
+++ b/packages/language-service/test/lib/completions/st-scope.spec.ts
@@ -1,0 +1,146 @@
+import { createRange } from '../../../src/lib/completion-providers';
+import * as asserters from '../../../test-kit/completions-asserters';
+import { Completion, rulesetDirectives } from 'packages/language-service/src/lib/completion-types';
+import { expect } from 'chai';
+
+describe('completion inside @st-scope', () => {
+    describe('stylable variables', () => {
+        describe('value()', () => {
+            'value('.split('').map((_c, i) => {
+                const prefix = 'value('.slice(0, i);
+
+                it('should be completed inside rule value, with prefix ' + prefix + ' ', () => {
+                    const asserter = asserters.getCompletions('st-scope/local-vars.st.css', prefix);
+                    asserter.suggested([asserters.valueDirective(createRange(9, 14, 9, 15 + i))]);
+                });
+            });
+        });
+
+        describe('Inside value()', () => {
+            const str1 = 'color1';
+            const str2 = 'color2';
+
+            str1.split('').forEach((_c, i) => {
+                const prefix = str1.slice(0, i);
+                it('Local variables should be completed, with prefix ' + prefix + ' ', () => {
+                    const asserter = asserters.getCompletions(
+                        'st-scope/inside-value-local-vars.st.css',
+                        prefix
+                    );
+                    asserter.suggested([
+                        asserters.valueCompletion(
+                            str1,
+                            createRange(9, 31, 9, 31 + i),
+                            'red',
+                            'Local variable'
+                        ),
+                        asserters.valueCompletion(
+                            str2,
+                            createRange(9, 31, 9, 31 + i),
+                            'blue',
+                            'Local variable'
+                        )
+                    ]);
+                });
+            });
+        });
+    });
+
+    describe('st-directives', () => {
+        describe('should complete -st-extends inside simple selector ruleset ', () => {
+            rulesetDirectives.extends.split('').map((_c: string, i: number) => {
+                const prefix = rulesetDirectives.extends.slice(0, i);
+                it(' with Prefix: ' + prefix + ' ', () => {
+                    const asserter = asserters.getCompletions('st-scope/directive.st.css', prefix);
+                    asserter.suggested([
+                        asserters.extendsDirectiveCompletion(createRange(4, 8, 4, 8 + i))
+                    ]);
+                });
+            });
+        });
+
+        describe('should complete -st-mixin inside simple selector ruleset ', () => {
+            rulesetDirectives.mixin.split('').map((_c: string, i: number) => {
+                const prefix = rulesetDirectives.mixin.slice(0, i);
+                it(' with Prefix: ' + prefix + ' ', () => {
+                    const asserter = asserters.getCompletions('st-scope/directive.st.css', prefix);
+                    asserter.suggested([
+                        asserters.mixinDirectiveCompletion(createRange(4, 8, 4, 8 + i))
+                    ]);
+                });
+            });
+        });
+
+        describe('should complete -st-states inside simple selector ruleset ', () => {
+            rulesetDirectives.states.split('').map((_c: string, i: number) => {
+                const prefix = rulesetDirectives.states.slice(0, i);
+                it(' with Prefix: ' + prefix + ' ', () => {
+                    const asserter = asserters.getCompletions('st-scope/directive.st.css', prefix);
+                    asserter.suggested([
+                        asserters.statesDirectiveCompletion(createRange(4, 8, 4, 8 + i))
+                    ]);
+                });
+            });
+        });
+    });
+
+    describe(':global', () => {
+        const str = ':global()';
+
+        str.split('').forEach((_c, i) => {
+            const prefix = str.slice(0, i);
+            it(
+                'should not suggest globals in declaration properties inside a ruleset' + prefix,
+                () => {
+                    const rng = createRange(4, 8, 4, 8 + i);
+                    const asserter = asserters.getCompletions('st-scope/directive.st.css', prefix);
+                    const exp: Array<Partial<Completion>> = [];
+                    exp.push(asserters.globalCompletion(rng));
+                    asserter.notSuggested(exp);
+                }
+            );
+        });
+    });
+
+    describe('css service', () => {
+        it('should not suggest selector parts in declaration properties inside a ruleset', () => {
+            const actual = asserters.getStylableAndCssCompletions('st-scope/directive.st.css');
+
+            expect(actual.find(comp => comp.label === '.root')).to.eql(undefined);
+        });
+
+        it('should suggest declaration properties inside a ruleset', () => {
+            const actual = asserters.getStylableAndCssCompletions('st-scope/directive.st.css');
+
+            expect(actual.find(comp => comp.label === 'color')).to.deep.include({
+                label: 'color',
+                documentation: "Color of an element's text\n\nSyntax: <color>",
+                textEdit: {
+                    range: createRange(4, 8, 4, 8),
+                    newText: 'color: '
+                },
+                kind: 10,
+                command: {
+                    title: 'Suggest',
+                    command: 'editor.action.triggerSuggest'
+                },
+                sortText: 'd'
+            });
+        });
+
+        it('should suggest local class in the beginning of a ruleset', () => {
+            const actual = asserters.getStylableAndCssCompletions('st-scope/selector.st.css');
+
+            expect(actual.find(comp => comp.label === '.part')).to.deep.include({
+                label: '.part',
+                detail: 'Stylable class or tag',
+                textEdit: {
+                    range: createRange(4, 4, 4, 4),
+                    newText: '.part'
+                },
+                sortText: 'a',
+                filterText: '.part'
+            });
+        });
+    });
+});

--- a/packages/language-service/test/lib/references.spec.ts
+++ b/packages/language-service/test/lib/references.spec.ts
@@ -311,9 +311,7 @@ describe('References', () => {
             expect(refs[4].range).to.deep.equal(createRange(16, 8, 16, 12));
             expect(refs[5].range).to.deep.equal(createRange(17, 8, 17, 12));
             refs.forEach(ref => {
-                expect(ref.uri).to.equal(
-                    getCasePath('st-scope/local-class-from-selector.st.css')
-                );
+                expect(ref.uri).to.equal(getCasePath('st-scope/local-class-from-selector.st.css'));
             });
         });
     });

--- a/packages/language-service/test/lib/references.spec.ts
+++ b/packages/language-service/test/lib/references.spec.ts
@@ -296,4 +296,25 @@ describe('References', () => {
             });
         });
     });
+
+    describe('inside an @st-scope', () => {
+        it('should return all instances of local class when called from selector ', () => {
+            const refs = getReferences('st-scope/local-class-from-selector.st.css', {
+                line: 6,
+                character: 20
+            });
+            expect(refs.length).to.equal(6);
+            expect(refs[0].range).to.deep.equal(createRange(1, 7, 1, 11));
+            expect(refs[1].range).to.deep.equal(createRange(6, 5, 6, 9));
+            expect(refs[2].range).to.deep.equal(createRange(6, 18, 6, 22));
+            expect(refs[3].range).to.deep.equal(createRange(11, 26, 11, 30));
+            expect(refs[4].range).to.deep.equal(createRange(16, 8, 16, 12));
+            expect(refs[5].range).to.deep.equal(createRange(17, 8, 17, 12));
+            refs.forEach(ref => {
+                expect(ref.uri).to.equal(
+                    getCasePath('st-scope/local-class-from-selector.st.css')
+                );
+            });
+        });
+    });
 });


### PR DESCRIPTION
#### Add support for the following within `@st-scope`
- Stylable and native CSS completions
- Native CSS diagnostics
- Native CSS color info (vscode color squares) and presentation (editing color picker) 

#### Media query diagnostics fix
- Using a Stylable value in a media query parameter no longer issues a warning or break css completions