### PR TITLE
core: allow consumers to specify module resolver

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './state-validators';
 export * from './selector-utils';
 export * from './native-reserved-lists';
 export * from './cssdocs';
+export * from './module-resolver';
 
 import * as pseudoStates from './pseudo-states';
 export { pseudoStates };

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1,0 +1,19 @@
+// importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
+// this allows @stylable/core to be bundled for browser usage without special custom configuration
+const ResolverFactory = require('enhanced-resolve/lib/ResolverFactory') as typeof import('enhanced-resolve').ResolverFactory;
+
+import { ModuleResolver } from './types';
+import { MinimalFS } from './cached-process-file';
+
+const resolverContext = {};
+
+export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
+    const eResolver = ResolverFactory.createResolver({
+        useSyncFileSystemCalls: true,
+        fileSystem,
+        ...resolveOptions
+    });
+
+    return (directoryPath, request) =>
+        eResolver.resolveSync(resolverContext, directoryPath, request);
+}

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -11,7 +11,7 @@ import {
     TransformHooks
 } from './stylable-transformer';
 import { TimedCacheOptions } from './timed-cache';
-import { IStylableOptimizer } from './types';
+import { IStylableOptimizer, ModuleResolver } from './types';
 
 export interface StylableConfig {
     projectRoot: string;
@@ -30,6 +30,7 @@ export interface StylableConfig {
     mode?: 'production' | 'development';
     resolveNamespace?: typeof processNamespace;
     timedCacheOptions?: Omit<TimedCacheOptions, 'createKey'>;
+    resolveModule?: ModuleResolver;
 }
 
 export class Stylable {
@@ -72,7 +73,8 @@ export class Stylable {
         protected timedCacheOptions: Omit<TimedCacheOptions, 'createKey'> = {
             timeout: 1,
             useTimer: true
-        }
+        },
+        protected resolveModule?: ModuleResolver
     ) {
         const { fileProcessor, resolvePath } = createInfrastructure(
             projectRoot,
@@ -80,7 +82,8 @@ export class Stylable {
             onProcess,
             resolveOptions,
             this.resolveNamespace,
-            timedCacheOptions
+            timedCacheOptions,
+            resolveModule
         );
         this.resolvePath = resolvePath;
         this.fileProcessor = fileProcessor;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,3 +65,5 @@ export interface IStylableNamespaceOptimizer {
     namespaceMapping: Record<string, string>;
     getNamespace(meta: StylableMeta, ..._env: any[]): string;
 }
+
+export type ModuleResolver = (directoryPath: string, request: string) => string;

--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -91,8 +91,8 @@ export class ProjectRunner {
         compiler.run = compiler.run.bind(compiler);
         const promisedRun = promisify(compiler.run);
         this.stats = await promisedRun();
-        if (this.throwOnBuildError && this.stats.compilation.errors.length) {
-            throw new Error(this.stats.compilation.errors.join('\n'));
+        if (this.throwOnBuildError && this.stats.hasErrors()) {
+            throw new Error(this.stats.toString({ colors: true }));
         }
     }
 

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -1,4 +1,4 @@
-import { Stylable } from '@stylable/core';
+import { Stylable, createDefaultResolver } from '@stylable/core';
 import { resolveNamespace } from '@stylable/node';
 import { StylableOptimizer } from '@stylable/optimizer';
 import { EOL } from 'os';
@@ -71,6 +71,10 @@ export class StylableWebpackPlugin {
         return localConfigOverride;
     }
     public createStylable(compiler: webpack.Compiler) {
+        const resolveModule = createDefaultResolver(
+            compiler.inputFileSystem as any,
+            compiler.options.resolve
+        );
         const stylable = new Stylable(
             compiler.context,
             (compiler.inputFileSystem as any).fileSystem || (compiler.inputFileSystem as any),
@@ -101,7 +105,9 @@ export class StylableWebpackPlugin {
             compiler.options.resolve,
             this.options.optimizer || new StylableOptimizer(),
             compiler.options.mode as any,
-            this.options.resolveNamespace || resolveNamespace
+            this.options.resolveNamespace || resolveNamespace,
+            undefined,
+            resolveModule
         );
         this.stylable = stylable;
     }

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/button.js
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/button.js
@@ -1,0 +1,11 @@
+import { classes } from "./button.st.css";
+const render = (_text = 'Button') => {
+  const btn = document.createElement("button");
+  const text = document.createElement("span");
+  text.textContent = _text;
+  btn.appendChild(text);
+  btn.classList.add(classes.root);
+  text.classList.add(classes.text);
+  return btn;
+};
+export { classes, render };

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/button.st.css
@@ -1,0 +1,6 @@
+.root {
+    background: #000;
+}
+.text {
+    color: #fff;
+}

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/index.js
@@ -1,0 +1,3 @@
+import * as button from "./button";
+
+export { button };

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/index.st.css
@@ -1,0 +1,6 @@
+:import {
+    -st-from: "./button.st.css";
+    -st-default: Button;
+}
+
+Button {}

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/package.json
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/node_modules/test-components/package.json
@@ -1,0 +1,5 @@
+{
+  "version": "test",
+  "name": "test-components",
+  "main": "./index.js"
+}

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/src/index.js
@@ -1,0 +1,10 @@
+import { classes } from './index.st.css';
+import { button } from 'test-components';
+
+document.documentElement.classList.add(classes.root);
+
+const btn = button.render('I am a button');
+btn.id = 'btn';
+document.body.appendChild(btn);
+
+console.log('entry', button);

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/src/index.st.css
@@ -1,0 +1,9 @@
+:import {
+    -st-from: "test-components/index.st.css";
+    -st-named: Button;
+}
+
+Button {
+    font-size: 2em;
+    background: green;
+}

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/webpack.config.js
@@ -1,0 +1,15 @@
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const rootTsconfig = require.resolve('../../../../../../tsconfig.json');
+
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    resolve: {
+        plugins: [new TsconfigPathsPlugin({ configFile: rootTsconfig })]
+    },
+    plugins: [new StylableWebpackPlugin(), new HtmlWebpackPlugin()]
+};

--- a/packages/webpack-plugin/test/e2e/tsconfig-resolver-plugin.spec.ts
+++ b/packages/webpack-plugin/test/e2e/tsconfig-resolver-plugin.spec.ts
@@ -1,0 +1,27 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'tsconfig-resolver-plugin';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                // headless: false
+            }
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('override 3rd party', async () => {
+        const { page } = await projectRunner.openInBrowser();
+        const backgroundColor = await page.evaluate(() => {
+            return getComputedStyle((window as any).btn).backgroundColor;
+        });
+        expect(backgroundColor).to.eql('rgb(0, 128, 0)');
+    });
+});


### PR DESCRIPTION
- not just options for `enhanced-resolve`.
- `webpack-plugin` uses it to create the default resolver with the wrapped `inputFileSystem`.
- fixes 3rd party resolution when `tsconfig-paths-webpack-plugin` is used, as it requires `readJson`.