### PR TITLE
core: adjust minimal-fs for enhanced-resolve

### DIFF
--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -147,7 +147,7 @@ export function createStylableInstance(config: Config) {
 
     const stylable = new Stylable(
         '/',
-        fs as any,
+        fs,
         requireModule,
         '__',
         (meta, path) => {

--- a/packages/core/src/cached-process-file.ts
+++ b/packages/core/src/cached-process-file.ts
@@ -8,6 +8,7 @@ export interface CacheItem<T> {
 export interface MinimalFS {
     statSync: (fullpath: string) => { mtime: Date };
     readFileSync: (fullpath: string, encoding: string) => string;
+    readlinkSync(path: string, ...args: any[]): string;
 }
 
 export interface FileProcessor<T> {

--- a/packages/core/src/create-infra-structure.ts
+++ b/packages/core/src/create-infra-structure.ts
@@ -56,6 +56,9 @@ export function createInfrastructure(
                     };
                 }
                 return stat;
+            },
+            readlinkSync() {
+                throw new Error(`not implemented`);
             }
         },
         (path, context) => resolvePath(context || projectRoot, path)

--- a/packages/core/src/memory-minimal-fs.ts
+++ b/packages/core/src/memory-minimal-fs.ts
@@ -51,6 +51,9 @@ export function createMinimalFS(config: MinimalFSSetup) {
                 },
                 mtime: isDirectory ? new Date() : files[path].mtime!
             };
+        },
+        readlinkSync() {
+            throw new Error(`not implemented`);
         }
     };
 

--- a/packages/core/test/cached-process-file.spec.ts
+++ b/packages/core/test/cached-process-file.spec.ts
@@ -15,6 +15,9 @@ describe('cachedProcessFile', () => {
                 return {
                     mtime: new Date(0)
                 } as any;
+            },
+            readlinkSync() {
+                throw new Error(`not implemented`);
             }
         };
 
@@ -43,6 +46,9 @@ describe('cachedProcessFile', () => {
                 return {
                     mtime: new Date(0)
                 };
+            },
+            readlinkSync() {
+                throw new Error(`not implemented`);
             }
         };
 
@@ -73,6 +79,9 @@ describe('cachedProcessFile', () => {
                 return {
                     mtime: new Date(0)
                 };
+            },
+            readlinkSync() {
+                throw new Error(`not implemented`);
             }
         };
 
@@ -102,6 +111,9 @@ describe('cachedProcessFile', () => {
                 return {
                     mtime: readCount === 0 ? new Date(0) : new Date(1)
                 };
+            },
+            readlinkSync() {
+                throw new Error(`not implemented`);
             }
         };
 
@@ -136,6 +148,9 @@ describe('cachedProcessFile', () => {
                 return {
                     mtime: readCount === 0 ? new Date(0) : new Date(1)
                 };
+            },
+            readlinkSync() {
+                throw new Error(`not implemented`);
             }
         };
 

--- a/packages/core/test/stylable-ast-mixin.spec.ts
+++ b/packages/core/test/stylable-ast-mixin.spec.ts
@@ -3,7 +3,7 @@ import { safeParse } from '../src/parser';
 import { createSubsetAst, scopeSelector } from '../src/stylable-utils';
 
 describe('scopeSelector', () => {
-    const tests = [
+    const tests: Array<{ root: string; child: string; selector: string; only?: boolean }> = [
         {
             root: '.a',
             child: '.x',
@@ -71,13 +71,13 @@ describe('scopeSelector', () => {
         }
     ];
 
-    tests.forEach(test => {
-        const _it = (test as any).only ? it.only : it;
-        _it(`apply "${test.root}" on "${test.child}" should output "${test.selector}"`, () => {
-            const res = scopeSelector(test.root, test.child);
-            expect(res.selector).to.equal(test.selector);
+    for (const { only, root, selector, child } of tests) {
+        const test = only ? it.only : it;
+        test(`apply "${root}" on "${child}" should output "${selector}"`, () => {
+            const res = scopeSelector(root, child);
+            expect(res.selector).to.equal(selector);
         });
-    });
+    }
 });
 
 describe('createSubsetAst', () => {

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -484,7 +484,7 @@ describe('stylable-resolver', () => {
 
         const rule = meta.outputAst!.nodes![0] as postcss.Rule;
         expect(rule.selector).to.equal('.A__root');
-        expect(meta.diagnostics.reports).to.have.lengthOf(0);
-        expect(meta.transformDiagnostics!.reports).to.have.lengthOf(0);
+        expect(meta.diagnostics.reports).to.eql([]);
+        expect(meta.transformDiagnostics!.reports).to.eql([]);
     });
 });

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -448,9 +448,6 @@ describe('stylable-resolver', () => {
 
     it('should resolve 4th party according to context', () => {
         const stylable = createStylableInstance({
-            resolve: {
-                symlinks: false
-            },
             files: {
                 '/entry.st.css': {
                     namespace: 'entry',
@@ -484,7 +481,10 @@ describe('stylable-resolver', () => {
         });
 
         const { meta } = stylable.transform(stylable.process('/node_modules/a/index.st.css'));
+
         const rule = meta.outputAst!.nodes![0] as postcss.Rule;
         expect(rule.selector).to.equal('.A__root');
+        expect(meta.diagnostics.reports).to.have.lengthOf(0);
+        expect(meta.transformDiagnostics!.reports).to.have.lengthOf(0);
     });
 });


### PR DESCRIPTION
- exposes a `readlinkSync` function which always throws.
- allows using Stylable with minimal-fs without turning off symlinks especially in the tests.
- refactored file/directory lookup implementation. supports absolute paths properly. does not resolve relative-paths.