### PR TITLE
dom-test-kit: add handling for scoping a class selector that includes composition

### DIFF
--- a/packages/dom-test-kit/src/stylable-dom-util.ts
+++ b/packages/dom-test-kit/src/stylable-dom-util.ts
@@ -33,7 +33,8 @@ export class StylableDOMUtil {
         const ast = parseSelector(selector);
         traverseNode(ast, (node: any) => {
             if (node.type === 'class') {
-                node.name = this.stylesheet.classes[node.name] || node.name;
+                const className: string = this.stylesheet.classes[node.name] || node.name;
+                node.name = className.includes(' ') ? className.split(' ')[0] : className;
             } else if (node.type === 'pseudo-class') {
                 const param = node.content;
                 if (!param) {

--- a/packages/dom-test-kit/test/contract-test.ts
+++ b/packages/dom-test-kit/test/contract-test.ts
@@ -10,7 +10,7 @@ export const contractTest = (
     const s = create(
         'ns',
         {
-            classes: { root: 'ns-root', x: 'ns__x', y: 'ns__y' },
+            classes: { root: 'ns-root', x: 'ns__x', y: 'ns__y', z: 'ns__y ns__x' },
             keyframes: {},
             vars: {},
             stVars: {}
@@ -29,6 +29,9 @@ export const contractTest = (
         });
         it('scopeSelector local class', () => {
             expect(util.scopeSelector('.x')).to.equal(`.ns__x`);
+        });
+        it('scopeSelector local class with compose', () => {
+            expect(util.scopeSelector('.z')).to.equal(`.ns__y`);
         });
         it('scopeSelector handle multiple local classes', () => {
             expect(util.scopeSelector('.x .y')).to.equal(`.ns__x .ns__y`);


### PR DESCRIPTION
Resolves #1031.

This solution will remove the invalid syntax that is being output by returning the original composing class.

We still need to enhance the variety of selectors we support in our `dom-test-kit` to support complex selectors, custom elements, pseudo-states and more.