### PR TITLE
Webpack@5 breaks expectations

### DIFF
--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -12,7 +12,7 @@
   },
   "peerDependencies": {
     "@stylable/core": ">=3",
-    "webpack": ">=4"
+    "webpack": "~4"
   },
   "dependencies": {
     "@stylable/module-utils": "^3.3.0",


### PR DESCRIPTION
```
[18:43:26][npm run test] Error: Cannot find module 'webpack/lib/MultiModule'
[18:43:26][npm run test]     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
[18:43:26][npm run test]     at Function.Module._load (internal/modules/cjs/loader.js:507:25)
[18:43:26][npm run test]     at Function._load (/home/builduser/agent00/work/f0c170388923639/promote-seo/promote-seo/node_modules/@sentry/node/dist/integrations/console.js:41:47)
[18:43:26][npm run test]     at Module.require (internal/modules/cjs/loader.js:637:17)
[18:43:26][npm run test]     at require (internal/modules/cjs/helpers.js:22:18)
[18:43:26][npm run test]     at Object.<anonymous> (/home/builduser/agent00/work/f0c170388923639/promote-seo/promote-seo/node_modules/@stylable/webpack-plugin/src/StylableWebpackPlugin.js:23:21)
[18:43:26][npm run test]     at Module._compile (internal/modules/cjs/loader.js:689:30)
[18:43:26][npm run test]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
[18:43:26][npm run test]     at Module.load (internal/modules/cjs/loader.js:599:32)
[18:43:26][npm run test]     at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
[18:43:26][npm run test]     at Function.Module._load (internal/modules/cjs/loader.js:530:3)
[18:43:26][npm run test]     at Function._load (/home/builduser/agent00/work/f0c170388923639/promote-seo/promote-seo/node_modules/@sentry/node/dist/integrations/console.js:41:47)
[18:43:26][npm run test]     at Module.require (internal/modules/cjs/loader.js:637:17)
[18:43:26][npm run test]     at require (internal/modules/cjs/helpers.js:22:18)
[18:43:26][npm run test]     at Object.<anonymous> (/home/builduser/agent00/work/f0c170388923639/promote-seo/promote-seo/node_modules/@stylable/webpack-plugin/src/index.js:1:80)
```