### PR TITLE
Core: fix absolute path .st.css imports

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -702,7 +702,7 @@ export class StylableProcessor {
                         this.diagnostics.warn(rule, processorWarnings.MULTIPLE_FROM_IN_IMPORT());
                     }
 
-                    if (!path.isAbsolute(importPath) && !importPath.startsWith('.')) {
+                    if (!path.isAbsolute(importPath) && !importPath.startsWith('.')) { // 3rd party request
                         importObj.fromRelative = importPath;
                         importObj.from = importPath;
                     } else {
@@ -710,8 +710,8 @@ export class StylableProcessor {
                         const dirPath = path.dirname(this.meta.source);
                         importObj.from =
                             path.posix && path.posix.isAbsolute(dirPath) // browser has no posix methods
-                                ? path.posix.join(dirPath, importPath)
-                                : path.join(dirPath, importPath);
+                                ? path.posix.resolve(dirPath, importPath)
+                                : path.resolve(dirPath, importPath);
                     }
                     fromExists = true;
                     break;

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -146,6 +146,30 @@ describe('Stylable postcss process', () => {
         });
     });
 
+    it('collect :import with absolute paths', () => {
+        const result = processSource(
+            `
+            :import {
+                -st-from: "/abs/path";
+                -st-named: abs;
+            }
+        `,
+            { from: '/path/to/style.css' }
+        );
+
+        expect(result.imports.length).to.eql(1);
+
+        expect(result.mappedSymbols.abs).to.deep.include({
+            _kind: 'import',
+            type: 'named'
+        });
+        expect((result.mappedSymbols.abs as ImportSymbol).import).to.include({
+            context: '/path/to',
+            defaultExport: '',
+            from: '/abs/path',
+        });
+    });
+
     it('collect :vars', () => {
         const result = processSource(
             `


### PR DESCRIPTION
Fixed issue where using absolute paths in stylable imports causes resolution bug  