### PR TITLE
docs(migration-v3): add doc with some notes about migrating to v3

### DIFF
--- a/packages/stylable.io/docs/guides/migration-v3.md
+++ b/packages/stylable.io/docs/guides/migration-v3.md
@@ -1,0 +1,138 @@
+---
+id: guides/migration-v3
+title: Migrating to Stylable v3
+layout: docs
+---
+
+This guide is intended to help migrate stylable version 1 or 2 to stylable version 3.
+It is mainly geared towards stylable integration within React.
+
+# Suggested steps of migration
+
+Follow these steps for a smooth transition. Each step is explained in
+more detail below.
+
+1. Update dependencies
+1. Update `.st.css` file imports
+1. Update usage in React components
+1. Update tests
+
+## Update dependencies
+
+Ensure you have v3 stylable dependencies available. You may need to
+update your `package.json` or ensure that other dependencies bring you
+v3 stylable:
+
+- `@stylable/cli`
+- `@stylable/core`
+- `@stylable/runtime`
+- `@stylable/node`
+- `@stylable/webpack-plugin`
+
+
+> Note: all stylable packages in v3 are scoped under `@stylable` namespace. 
+> if you have dependency like `stylable` (without namespace),
+> it is a different one and should be changed to namespaced version.
+
+## Update `.st.css` file imports
+
+Prior to v3 all `.st.css` files would export `style` function. In v3
+this has changed: `.st.css` files now export an object.
+
+List of all exported keys:
+
+```
+import {
+  classes,
+  cssStates,
+  keyframes,
+  namespace,
+  st,
+  stVars,
+  style,
+  vars,
+} from './style.st.css';
+```
+
+This means that all imports of `.st.css` files have to be changed, for example:
+
+```diff
+-import style from './Component.st.css';
++import { style, classes, /* ... */ } from './Component.st.css';
+```
+
+However, most often `{ style, classes }` is enough:
+
+`import { style, classes } from './Component.st.css';`
+
+## Update usage in React components
+
+Once `.st.css` imports are updated, React components should be updated too:
+
+```diff
+-<div {...style('root', states, props)} /> />
++<div className={style(classes.root, states, props.className)} />
+```
+
+There is a subtle but very important nuance in this change.
+
+Stylable v1 and v2 used spread pattern. It would take the output of
+`style('root', states, this.props)` function and spread it on component.
+
+This way one or more props would be applied to the component. Thus, code that looks like this:
+
+```
+<div {...style('root', {}, { className: 'additional-class', dataHook: 'test', hello: 'world' })} />
+```
+
+once evaluated, would behave like this:
+
+```
+<div
+  className="root additional-class"
+  dataHook="test"
+  hello="world"
+/>
+```
+
+Stylable v3 usage is like so:
+
+```
+className={style(classes.root, states, this.props.className)}
+```
+
+There is no more props sprad anymore and stylable requires only
+`className` to be used.
+
+However, if you were relying on the props spread pattern, in v3 you
+might find some props missing.
+
+Therefore, with Stylable v3 it is up to you to apply any additional props:
+
+```
+<div className={style(classes.root, states, 'additional-class')} dataHook="test" hello="world" />
+```
+
+> Note: find more details and examples in React integration guide https://stylable.io/docs/getting-started/react-integration
+
+## Update tests
+
+If you were using `@stylable/dom-test-kit`, it's usage has slightly
+changd in v3:
+
+```diff
+import { StylableDOMUtil } from '@stylable/dom-test-kit';
+-import * as style from './Component.st.css';
++import * as style from './Component.st.css';
+const stylableDOMUtil = new StylableDOMUtil(style);
+```
+
+Just as before, `StyalbleDOMUtil` accepts an argument, which is all that
+`.st.css` file exports
+
+Prior to v3 it was only one thing - `style` function
+
+In v3 `.st.css` files export more than that, therefore an easy way to
+fix tests is to use `* as`:
+
+`import * as style from './Component.st.css';`

--- a/packages/stylable.io/docs/guides/migration-v3.md
+++ b/packages/stylable.io/docs/guides/migration-v3.md
@@ -100,7 +100,7 @@ There are subtle but very important nuances in this change.
    This way one or more props would be applied to the component. Thus, code that looks like this:
 
      ```jsx
-     <div {...style('root', {}, { className: 'additional-class', dataHook: 'test' })} />
+     <div {...style('root', {}, { className: 'additional-class', 'data-hook': 'test' })} />
      ```
 
      once evaluated, would behave like this:
@@ -108,7 +108,7 @@ There are subtle but very important nuances in this change.
      ```jsx
      <div
        className="root additional-class"
-       dataHook="test"
+       data-hook="test"
      />
      ```
 
@@ -127,7 +127,7 @@ There are subtle but very important nuances in this change.
      Therefore, with Stylable v3 it is up to you to apply any additional props:
 
      ```jsx
-     <div className={st(classes.root, states, 'additional-class')} dataHook="test" hello="world" />
+     <div className={st(classes.root, states, 'additional-class')} data-hook="test" hello="world" />
      ```
 
 2. Stylable v1 `style()` would accept unscoped css class name as a string  

--- a/packages/stylable.io/docs/guides/migration-v3.md
+++ b/packages/stylable.io/docs/guides/migration-v3.md
@@ -101,7 +101,7 @@ Stylable v3 usage is like so:
 className={style(classes.root, states, this.props.className)}
 ```
 
-There is no more props sprad anymore and stylable requires only
+There is no more props spread anymore and stylable requires only
 `className` to be used.
 
 However, if you were relying on the props spread pattern, in v3 you
@@ -122,12 +122,12 @@ changd in v3:
 
 ```diff
 import { StylableDOMUtil } from '@stylable/dom-test-kit';
--import * as style from './Component.st.css';
+-import style from './Component.st.css';
 +import * as style from './Component.st.css';
 const stylableDOMUtil = new StylableDOMUtil(style);
 ```
 
-Just as before, `StyalbleDOMUtil` accepts an argument, which is all that
+Just as before, `StylableDOMUtil` accepts an argument, which is all that
 `.st.css` file exports
 
 Prior to v3 it was only one thing - `style` function

--- a/packages/stylable.io/docs/guides/migration-v3.md
+++ b/packages/stylable.io/docs/guides/migration-v3.md
@@ -51,7 +51,7 @@ required changes and provide typings for other Stylable use cases.
 
 ## Update `.st.css` file imports
 
-Prior to v3 all `.st.css` files would export `style` function. In v3
+Prior to v2 all `.st.css` files would export `style` function. In v2
 this has changed: `.st.css` files now export an object.
 
 List of all exported keys:

--- a/packages/stylable.io/docs/guides/migration-v3.md
+++ b/packages/stylable.io/docs/guides/migration-v3.md
@@ -4,8 +4,8 @@ title: Migrating to Stylable v3
 layout: docs
 ---
 
-This guide is intended to help migrate stylable version 1 or 2 to stylable version 3.
-It is mainly geared towards stylable integration within React.
+This guide is intended to help migrate Stylable version 1 to Stylable version 2 or 3.
+It is mainly geared towards Stylable integration in React.
 
 # Suggested steps of migration
 
@@ -13,15 +13,16 @@ Follow these steps for a smooth transition. Each step is explained in
 more detail below.
 
 1. Update dependencies
+1. Update global typings
 1. Update `.st.css` file imports
 1. Update usage in React components
 1. Update tests
 
 ## Update dependencies
 
-Ensure you have v3 stylable dependencies available. You may need to
+Ensure you have v3 Stylable dependencies available. You may need to
 update your `package.json` or ensure that other dependencies bring you
-v3 stylable:
+v3 Stylable:
 
 - `@stylable/cli`
 - `@stylable/core`
@@ -29,10 +30,24 @@ v3 stylable:
 - `@stylable/node`
 - `@stylable/webpack-plugin`
 
-
-> Note: all stylable packages in v3 are scoped under `@stylable` namespace. 
+> Note: all Stylable packages in v3 are scoped under `@stylable` namespace. 
 > if you have dependency like `stylable` (without namespace),
 > it is a different one and should be changed to namespaced version.
+
+# Update global typings
+
+If TypeScript is in the toolbelt, we recommend to update global typings
+(usually a file named `global.d.ts`) with `.st.css` module declaration:
+
+```ts
+declare module '*.st.css' {
+  const stylesheet: import('@stylable/runtime').RuntimeStylesheet;
+  export = stylesheet;
+}
+```
+
+This way TypeScript compiler will help moving through most of the
+required changes and provide typings for other Stylable use cases.
 
 ## Update `.st.css` file imports
 
@@ -41,13 +56,13 @@ this has changed: `.st.css` files now export an object.
 
 List of all exported keys:
 
-```
+```js
 import {
+  st, // alias to `style`
   classes,
   cssStates,
   keyframes,
   namespace,
-  st,
   stVars,
   style,
   vars,
@@ -58,12 +73,16 @@ This means that all imports of `.st.css` files have to be changed, for example:
 
 ```diff
 -import style from './Component.st.css';
-+import { style, classes, /* ... */ } from './Component.st.css';
++import { st, classes, /* ... */ } from './Component.st.css';
 ```
 
-However, most often `{ style, classes }` is enough:
+However, most often `{ st, classes }` is enough:
 
-`import { style, classes } from './Component.st.css';`
+`import { st, classes } from './Component.st.css';`
+
+> Note: `.st.css` files export `style` function and an alias to it -
+> `st`. It is recommended to use `st` in order to avoid name clashing
+> with other variables (for example, some other inline styles)
 
 ## Update usage in React components
 
@@ -71,68 +90,76 @@ Once `.st.css` imports are updated, React components should be updated too:
 
 ```diff
 -<div {...style('root', states, props)} /> />
-+<div className={style(classes.root, states, props.className)} />
++<div className={st(classes.root, states, props.className)} />
 ```
 
-There is a subtle but very important nuance in this change.
+There are subtle but very important nuances in this change.
 
-Stylable v1 and v2 used spread pattern. It would take the output of
-`style('root', states, this.props)` function and spread it on component.
+1. Stylable v1 used spread pattern. It would take the output of `style('root', states, this.props)` function and spread it on component.
 
-This way one or more props would be applied to the component. Thus, code that looks like this:
+   This way one or more props would be applied to the component. Thus, code that looks like this:
 
-```
-<div {...style('root', {}, { className: 'additional-class', dataHook: 'test', hello: 'world' })} />
-```
+     ```jsx
+     <div {...style('root', {}, { className: 'additional-class', dataHook: 'test' })} />
+     ```
 
-once evaluated, would behave like this:
+     once evaluated, would behave like this:
 
-```
-<div
-  className="root additional-class"
-  dataHook="test"
-  hello="world"
-/>
-```
+     ```jsx
+     <div
+       className="root additional-class"
+       dataHook="test"
+     />
+     ```
 
-Stylable v3 usage is like so:
+     Stylable v2 and v3 usage is like so:
 
-```
-className={style(classes.root, states, this.props.className)}
-```
+     ```
+     className={st(classes.root, states, this.props.className)}
+     ```
 
-There is no more props spread anymore and stylable requires only
-`className` to be used.
+     There is no more props spread anymore and Stylable requires only
+     `className` to be used.
 
-However, if you were relying on the props spread pattern, in v3 you
-might find some props missing.
+     However, if you were relying on the props spread pattern, in v2 and v3 you
+     might find some props missing.
 
-Therefore, with Stylable v3 it is up to you to apply any additional props:
+     Therefore, with Stylable v3 it is up to you to apply any additional props:
 
-```
-<div className={style(classes.root, states, 'additional-class')} dataHook="test" hello="world" />
-```
+     ```jsx
+     <div className={st(classes.root, states, 'additional-class')} dataHook="test" hello="world" />
+     ```
 
-> Note: find more details and examples in React integration guide https://stylable.io/docs/getting-started/react-integration
+2. Stylable v1 `style()` would accept unscoped css class name as a string  
+    This is no longer acceptable in Stylable v2 or v3, for example:
+
+    ```diff
+    -<div {...style('root', state, { className: 'additional-class-name' })} />
+    +<div className={style(classes.root, 'additional-class-name')} />
+    ```
+
+    note that `classes.root` comes from `.st.css`, which is the correct
+    way to import class names.
+
+    Similar scoping is applied to css variables too, imported from `vars`
+
+Note: find more details and examples in React integration guide https://Stylable.io/docs/getting-started/react-integration
 
 ## Update tests
 
-If you were using `@stylable/dom-test-kit`, it's usage has slightly
-changd in v3:
+If you were using `@stylable/dom-test-kit` in Stylable v1, it's usage is
+slightly different in v2 and v3:
 
 ```diff
-import { StylableDOMUtil } from '@stylable/dom-test-kit';
+import { StylableDOMUtil } from '@Stylable/dom-test-kit';
 -import style from './Component.st.css';
-+import * as style from './Component.st.css';
-const stylableDOMUtil = new StylableDOMUtil(style);
++import * as styleSheet from './Component.st.css';
+
+-const StylableDOMUtil = new StylableDOMUtil(style);
++const StylableDOMUtil = new StylableDOMUtil(styleSheet);
 ```
 
-Just as before, `StylableDOMUtil` accepts an argument, which is all that
-`.st.css` file exports
+Stylable v2 and v3, `StylableDOMUtil` expects to receive argument which
+is the whole stylesheet exported from `.st.css`
 
-Prior to v3 it was only one thing - `style` function
-
-In v3 `.st.css` files export more than that, therefore an easy way to
-fix tests is to use `* as`:
-
-`import * as style from './Component.st.css';`
+Prior to v2 it was only one thing - `style` function.


### PR DESCRIPTION
This PR adds a short migration guide to hopefully help those upgrading from stylable 1 to to stylable 2/3

it is quite specific to React but imo is much better than having nothing.