### PR TITLE
Language Service: ColorPresentation edits "value(x)" colors inline

### DIFF
--- a/packages/core/src/cached-process-file.ts
+++ b/packages/core/src/cached-process-file.ts
@@ -7,8 +7,8 @@ export interface CacheItem<T> {
 
 export interface MinimalFS {
     statSync: (fullpath: string) => { mtime: Date };
-    readFileSync: (fullpath: string, encoding: string) => string;
-    readlinkSync(path: string, ...args: any[]): string;
+    readFileSync: (fullpath: string, encoding: 'utf8') => string;
+    readlinkSync(path: string): string;
 }
 
 export interface FileProcessor<T> {

--- a/packages/language-service/src/lib/feature/color-provider.ts
+++ b/packages/language-service/src/lib/feature/color-provider.ts
@@ -1,5 +1,5 @@
 import { IFileSystem } from '@file-services/types';
-import { evalDeclarationValue, Stylable, StylableMeta, valueMapping } from '@stylable/core';
+import { evalDeclarationValue, Stylable, valueMapping } from '@stylable/core';
 import { Color, ColorInformation, ColorPresentation } from 'vscode-css-languageservice';
 import { ColorPresentationParams } from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -12,8 +12,7 @@ export function resolveDocumentColors(
     stylable: Stylable,
     cssService: CssService,
     document: TextDocument,
-    fs: IFileSystem,
-    colorStylableVars: boolean
+    fs: IFileSystem
 ) {
     const processor = stylable.fileProcessor;
     const src = document.getText();
@@ -28,130 +27,66 @@ export function resolveDocumentColors(
     const colorComps: ColorInformation[] = [];
 
     if (meta) {
-        if (colorStylableVars) {
-            const lines = src.split('\n');
-            lines.forEach((line, ind) => {
-                const valueRegex = /value\(([\w-]+)\)/g;
-                let regexResult = valueRegex.exec(line);
-                while (regexResult !== null) {
-                    const result = regexResult[1];
-                    const sym = meta.mappedSymbols[result];
-                    let color: Color | null = null;
-                    if (sym && sym._kind === 'var') {
-                        const doc = TextDocument.create(
-                            '',
-                            'css',
-                            0,
-                            '.gaga {border: ' +
-                                evalDeclarationValue(stylable.resolver, sym.text, meta, sym.node) +
-                                '}'
-                        );
-                        color = cssService.findColor(doc);
-                    } else if (sym && sym._kind === 'import' && sym.type === 'named') {
-                        const impMeta = processor.process(sym.import.from);
-                        const relevantVar = impMeta.vars.find((v) => v.name === sym.name);
-                        if (relevantVar) {
-                            const doc = TextDocument.create(
-                                '',
-                                'css',
-                                0,
-                                '.gaga {border: ' +
-                                    evalDeclarationValue(
-                                        stylable.resolver,
-                                        'value(' + sym.name + ')',
-                                        impMeta,
-                                        relevantVar.node
-                                    ) +
-                                    '}'
-                            );
-                            color = cssService.findColor(doc);
-                        }
-                    }
-                    if (color) {
-                        const range = new ProviderRange(
-                            new ProviderPosition(
-                                ind,
-                                regexResult.index +
-                                    regexResult[0].indexOf(regexResult[1]) -
-                                    'value('.length
-                            ),
-                            new ProviderPosition(
-                                ind,
-                                regexResult.index +
-                                    regexResult[0].indexOf(regexResult[1]) +
-                                    result.length
-                            )
-                        );
-                        colorComps.push({ color, range } as ColorInformation);
-                    }
-
-                    regexResult = valueRegex.exec(line);
-                }
-            });
-
-            meta.imports.forEach((imp) => {
-                let impMeta: StylableMeta | undefined;
-                try {
-                    impMeta = processor.process(imp.from);
-                } catch {
-                    /**/
-                }
-
-                if (!impMeta) {
-                    return;
-                }
-
-                const vars = impMeta.vars;
-                vars.forEach((v) => {
+        const lines = src.split('\n');
+        lines.forEach((line, ind) => {
+            const valueRegex = /value\(([\w-]+)\)/g;
+            let regexResult = valueRegex.exec(line);
+            while (regexResult !== null) {
+                const result = regexResult[1];
+                const sym = meta.mappedSymbols[result];
+                let color: Color | null = null;
+                if (sym && sym._kind === 'var') {
                     const doc = TextDocument.create(
                         '',
                         'css',
                         0,
                         '.gaga {border: ' +
-                            evalDeclarationValue(stylable.resolver, v.text, impMeta!, v.node) +
+                            evalDeclarationValue(stylable.resolver, sym.text, meta, sym.node) +
                             '}'
                     );
-                    const color = cssService.findColor(doc);
-                    if (color) {
-                        meta.rawAst.walkDecls(valueMapping.named, (decl) => {
-                            const lines = decl.value.split('\n');
-                            const reg = new RegExp('\\b' + v.name + '\\b', 'g');
-
-                            const lineIndex = lines.findIndex((l) => reg.test(l));
-                            if (lineIndex > -1 && lines[lineIndex].includes(v.name)) {
-                                let extraLines = 0;
-                                let extraChars = 0;
-                                if (decl.raws.between) {
-                                    extraLines = decl.raws.between.split('\n').length - 1;
-                                    const betweens = decl.raws.between.split('\n');
-                                    extraChars = betweens[betweens.length - 1]!.length;
-                                }
-                                const varStart = lineIndex // replace with value parser
-                                    ? lines[lineIndex].indexOf(v.name) // replace with regex
-                                    : extraLines
-                                    ? lines[lineIndex].indexOf(v.name) + extraChars
-                                    : lines[lineIndex].indexOf(v.name) +
-                                      valueMapping.named.length +
-                                      decl.source!.start!.column +
-                                      extraChars -
-                                      1;
-                                const range = new ProviderRange(
-                                    new ProviderPosition(
-                                        decl.source!.start!.line - 1 + lineIndex + extraLines,
-                                        varStart
-                                    ),
-                                    new ProviderPosition(
-                                        decl.source!.start!.line - 1 + lineIndex + extraLines,
-                                        v.name.length + varStart
-                                    )
-                                );
-                                colorComps.push({ color, range } as ColorInformation);
-                            }
-                        });
+                    color = cssService.findColor(doc);
+                } else if (sym && sym._kind === 'import' && sym.type === 'named') {
+                    const impMeta = processor.process(sym.import.from);
+                    const relevantVar = impMeta.vars.find((v) => v.name === sym.name);
+                    if (relevantVar) {
+                        const doc = TextDocument.create(
+                            '',
+                            'css',
+                            0,
+                            '.gaga {border: ' +
+                                evalDeclarationValue(
+                                    stylable.resolver,
+                                    'value(' + sym.name + ')',
+                                    impMeta,
+                                    relevantVar.node
+                                ) +
+                                '}'
+                        );
+                        color = cssService.findColor(doc);
                     }
-                });
-            });
-        }
+                }
+                if (color) {
+                    const range = new ProviderRange(
+                        new ProviderPosition(
+                            ind,
+                            regexResult.index +
+                                regexResult[0].indexOf(regexResult[1]) -
+                                'value('.length
+                        ),
+                        new ProviderPosition(
+                            ind,
+                            regexResult.index +
+                                regexResult[0].indexOf(regexResult[1]) +
+                                result.length +
+                                ')'.length
+                        )
+                    );
+                    colorComps.push({ color, range } as ColorInformation);
+                }
+
+                regexResult = valueRegex.exec(line);
+            }
+        });
 
         const cleanDocument = cssService.createSanitizedDocument(
             meta.rawAst,
@@ -173,13 +108,6 @@ export function getColorPresentation(
     const src = document.getText();
     const res = fixAndProcess(src, new ProviderPosition(0, 0), params.textDocument.uri);
     const meta = res.processed.meta!;
-
-    const word = src
-        .split('\n')
-        [params.range.start.line].slice(params.range.start.character, params.range.end.character);
-    if (word.startsWith('value(')) {
-        return [];
-    }
 
     const wordStart = new ProviderPosition(
         params.range.start.line + 1,

--- a/packages/language-service/src/lib/feature/color-provider.ts
+++ b/packages/language-service/src/lib/feature/color-provider.ts
@@ -29,11 +29,11 @@ export function resolveDocumentColors(
     if (meta) {
         const lines = src.split('\n');
         lines.forEach((line, ind) => {
-            const valueRegex = /value\(([\w-]+)\)/g;
+            const valueRegex = /value\((.*?)\)/g;
             let regexResult = valueRegex.exec(line);
             while (regexResult !== null) {
                 const result = regexResult[1];
-                const sym = meta.mappedSymbols[result];
+                const sym = meta.mappedSymbols[result.trim()];
                 let color: Color | null = null;
                 if (sym && sym._kind === 'var') {
                     const doc = TextDocument.create(

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -31,9 +31,10 @@ import { getRefs, getRenameRefs } from './provider';
 import { ExtendedTsLanguageService } from './types';
 import { typescriptSupport } from './typescript-support';
 
-interface Config {
+export interface StylableLanguageServiceOptions {
     fs: IFileSystem;
     stylable: Stylable;
+    colorStylableVars?: boolean;
 }
 
 export class StylableLanguageService {
@@ -42,14 +43,20 @@ export class StylableLanguageService {
     protected provider: Provider;
     protected stylable: Stylable;
     protected tsLanguageService: ExtendedTsLanguageService;
+    protected config: {
+        colorStylableVars: boolean;
+    };
 
-    constructor({ fs, stylable }: Config) {
+    constructor({ fs, stylable, colorStylableVars = true }: StylableLanguageServiceOptions) {
         this.fs = fs;
         this.stylable = stylable;
 
         this.tsLanguageService = typescriptSupport(this.fs);
         this.provider = new Provider(this.stylable, this.tsLanguageService);
         this.cssService = new CssService(this.fs);
+        this.config = {
+            colorStylableVars,
+        };
     }
 
     public getStylable() {
@@ -153,7 +160,13 @@ export class StylableLanguageService {
                 stylableFile.stat.mtime.getTime(),
                 stylableFile.content
             );
-            return resolveDocumentColors(this.stylable, this.cssService, doc, this.fs);
+            return resolveDocumentColors(
+                this.stylable,
+                this.cssService,
+                doc,
+                this.fs,
+                this.config.colorStylableVars
+            );
         }
 
         return [];
@@ -323,7 +336,13 @@ export class StylableLanguageService {
     }
 
     public resolveDocumentColors(document: TextDocument) {
-        return resolveDocumentColors(this.stylable, this.cssService, document, this.fs);
+        return resolveDocumentColors(
+            this.stylable,
+            this.cssService,
+            document,
+            this.fs,
+            this.config.colorStylableVars
+        );
     }
 
     public getColorPresentation(document: TextDocument, params: ColorPresentationParams) {

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -34,7 +34,6 @@ import { typescriptSupport } from './typescript-support';
 export interface StylableLanguageServiceOptions {
     fs: IFileSystem;
     stylable: Stylable;
-    colorStylableVars?: boolean;
 }
 
 export class StylableLanguageService {
@@ -43,20 +42,14 @@ export class StylableLanguageService {
     protected provider: Provider;
     protected stylable: Stylable;
     protected tsLanguageService: ExtendedTsLanguageService;
-    protected config: {
-        colorStylableVars: boolean;
-    };
 
-    constructor({ fs, stylable, colorStylableVars = true }: StylableLanguageServiceOptions) {
+    constructor({ fs, stylable }: StylableLanguageServiceOptions) {
         this.fs = fs;
         this.stylable = stylable;
 
         this.tsLanguageService = typescriptSupport(this.fs);
         this.provider = new Provider(this.stylable, this.tsLanguageService);
         this.cssService = new CssService(this.fs);
-        this.config = {
-            colorStylableVars,
-        };
     }
 
     public getStylable() {
@@ -160,13 +153,7 @@ export class StylableLanguageService {
                 stylableFile.stat.mtime.getTime(),
                 stylableFile.content
             );
-            return resolveDocumentColors(
-                this.stylable,
-                this.cssService,
-                doc,
-                this.fs,
-                this.config.colorStylableVars
-            );
+            return resolveDocumentColors(this.stylable, this.cssService, doc, this.fs);
         }
 
         return [];
@@ -336,13 +323,7 @@ export class StylableLanguageService {
     }
 
     public resolveDocumentColors(document: TextDocument) {
-        return resolveDocumentColors(
-            this.stylable,
-            this.cssService,
-            document,
-            this.fs,
-            this.config.colorStylableVars
-        );
+        return resolveDocumentColors(this.stylable, this.cssService, document, this.fs);
     }
 
     public getColorPresentation(document: TextDocument, params: ColorPresentationParams) {

--- a/packages/language-service/test-kit/asserters.ts
+++ b/packages/language-service/test-kit/asserters.ts
@@ -15,7 +15,6 @@ import { URI } from 'vscode-uri';
 import { ProviderPosition } from '../src/lib/completion-providers';
 import { createMeta, ProviderLocation } from '../src/lib/provider';
 import { pathFromPosition } from '../src/lib/utils/postcss-ast-utils';
-import { StylableLanguageService } from '../src';
 import { CASES_PATH, stylableLSP } from './stylable-fixtures-lsp';
 
 export function getCaretPosition(src: string) {
@@ -70,17 +69,6 @@ export function getDocumentColors(fileName: string): ColorInformation[] {
     const doc = TextDocument.create(URI.file(fullPath).toString(), 'stylable', 1, src);
 
     return stylableLSP.resolveDocumentColors(doc);
-}
-
-export function getNonStVarsDocumentColors(
-    fileName: string,
-    configuredStylableLSP: StylableLanguageService
-): ColorInformation[] {
-    const fullPath = path.join(CASES_PATH, fileName);
-    const src: string = fs.readFileSync(fullPath).toString();
-    const doc = TextDocument.create(URI.file(fullPath).toString(), 'stylable', 1, src);
-
-    return configuredStylableLSP.resolveDocumentColors(doc);
 }
 
 export function getDocColorPresentation(

--- a/packages/language-service/test-kit/asserters.ts
+++ b/packages/language-service/test-kit/asserters.ts
@@ -15,6 +15,7 @@ import { URI } from 'vscode-uri';
 import { ProviderPosition } from '../src/lib/completion-providers';
 import { createMeta, ProviderLocation } from '../src/lib/provider';
 import { pathFromPosition } from '../src/lib/utils/postcss-ast-utils';
+import { StylableLanguageService } from '../src';
 import { CASES_PATH, stylableLSP } from './stylable-fixtures-lsp';
 
 export function getCaretPosition(src: string) {
@@ -69,6 +70,17 @@ export function getDocumentColors(fileName: string): ColorInformation[] {
     const doc = TextDocument.create(URI.file(fullPath).toString(), 'stylable', 1, src);
 
     return stylableLSP.resolveDocumentColors(doc);
+}
+
+export function getNonStVarsDocumentColors(
+    fileName: string,
+    configuredStylableLSP: StylableLanguageService
+): ColorInformation[] {
+    const fullPath = path.join(CASES_PATH, fileName);
+    const src: string = fs.readFileSync(fullPath).toString();
+    const doc = TextDocument.create(URI.file(fullPath).toString(), 'stylable', 1, src);
+
+    return configuredStylableLSP.resolveDocumentColors(doc);
 }
 
 export function getDocColorPresentation(

--- a/packages/language-service/test-kit/stylable-fixtures-lsp.ts
+++ b/packages/language-service/test-kit/stylable-fixtures-lsp.ts
@@ -1,6 +1,6 @@
 import fs from '@file-services/node';
 import { Stylable } from '@stylable/core';
-import { StylableLanguageService } from '../src/lib/service';
+import { StylableLanguageService, StylableLanguageServiceOptions } from '../src/lib/service';
 
 export const CASES_PATH = fs.join(
     fs.dirname(fs.findClosestFileSync(__dirname, 'package.json')!),
@@ -17,3 +17,13 @@ export const stylableLSP = new StylableLanguageService({
     fs,
     stylable: new Stylable(CASES_PATH, fs as any, requireModule),
 });
+
+export function createStylableTestLSP(
+    config: Partial<StylableLanguageServiceOptions>
+): StylableLanguageService {
+    return new StylableLanguageService({
+        fs,
+        stylable: new Stylable(CASES_PATH, fs as any, requireModule),
+        ...config,
+    });
+}

--- a/packages/language-service/test-kit/stylable-fixtures-lsp.ts
+++ b/packages/language-service/test-kit/stylable-fixtures-lsp.ts
@@ -1,6 +1,6 @@
 import fs from '@file-services/node';
 import { Stylable } from '@stylable/core';
-import { StylableLanguageService, StylableLanguageServiceOptions } from '../src/lib/service';
+import { StylableLanguageService } from '../src/lib/service';
 
 export const CASES_PATH = fs.join(
     fs.dirname(fs.findClosestFileSync(__dirname, 'package.json')!),
@@ -15,15 +15,5 @@ function requireModule(request: string) {
 
 export const stylableLSP = new StylableLanguageService({
     fs,
-    stylable: new Stylable(CASES_PATH, fs as any, requireModule),
+    stylable: new Stylable(CASES_PATH, fs, requireModule),
 });
-
-export function createStylableTestLSP(
-    config: Partial<StylableLanguageServiceOptions>
-): StylableLanguageService {
-    return new StylableLanguageService({
-        fs,
-        stylable: new Stylable(CASES_PATH, fs as any, requireModule),
-        ...config,
-    });
-}

--- a/packages/language-service/test/fixtures/server-cases/colors/imported-color.st.css
+++ b/packages/language-service/test/fixtures/server-cases/colors/imported-color.st.css
@@ -2,3 +2,7 @@
     -st-from: "./single-var-color.st.css";
     -st-named: color1;
 }
+
+.root {
+    color: value(color1);
+}

--- a/packages/language-service/test/fixtures/server-cases/colors/substring-var-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/colors/substring-var-import.st.css
@@ -2,3 +2,7 @@
     -st-from: "./substring-var-top.st.css";
     -st-named: colcol;
 }
+
+.root {
+    color: value(colcol);
+}

--- a/packages/language-service/test/lib/colors.spec.ts
+++ b/packages/language-service/test/lib/colors.spec.ts
@@ -1,12 +1,7 @@
 import { expect } from 'chai';
 import { Color } from 'vscode-languageserver-protocol';
 import { createRange } from '../../src/lib/completion-providers';
-import {
-    getDocColorPresentation,
-    getDocumentColors,
-    getNonStVarsDocumentColors,
-} from '../../test-kit/asserters';
-import { createStylableTestLSP } from '../../test-kit/stylable-fixtures-lsp';
+import { getDocColorPresentation, getDocumentColors } from '../../test-kit/asserters';
 
 export function createColor(red: number, green: number, blue: number, alpha: number): Color {
     return { red, green, blue, alpha } as Color;
@@ -30,7 +25,7 @@ describe('Colors', () => {
 
             expect(res).to.eql([
                 {
-                    range: createRange(5, 11, 5, 23),
+                    range: createRange(5, 11, 5, 24),
                     color: createColor(0, 1, 0, 0.8),
                 },
                 {
@@ -45,7 +40,7 @@ describe('Colors', () => {
 
             expect(res).to.eql([
                 {
-                    range: createRange(2, 15, 2, 21),
+                    range: createRange(6, 11, 6, 24),
                     color: createColor(0, 1, 0, 0.8),
                 },
             ]);
@@ -62,7 +57,7 @@ describe('Colors', () => {
 
             expect(res).to.eql([
                 {
-                    range: createRange(6, 15, 6, 28),
+                    range: createRange(6, 15, 6, 29),
                     color: createColor(1, 0, 0, 1),
                 },
                 {
@@ -75,30 +70,6 @@ describe('Colors', () => {
                 },
             ]);
         });
-
-        describe('colorStylableVars', () => {
-            const stylableLSP = createStylableTestLSP({ colorStylableVars: false });
-
-            it('should not return colors for value() when configured to false', () => {
-                const res = getNonStVarsDocumentColors(
-                    'colors/single-var-color.st.css',
-                    stylableLSP
-                );
-
-                expect(res).to.eql([
-                    {
-                        range: createRange(1, 12, 1, 31),
-                        color: createColor(0, 1, 0, 0.8),
-                    },
-                ]);
-            });
-
-            it('should not resolve information for an imported color', () => {
-                const res = getNonStVarsDocumentColors('colors/imported-color.st.css', stylableLSP);
-
-                expect(res).to.eql([]);
-            });
-        });
     });
 
     describe('ColorPresentation', () => {
@@ -110,37 +81,45 @@ describe('Colors', () => {
                 blue: 0,
                 alpha: 0.8,
             };
+
             const res = getDocColorPresentation('colors/color-presentation.st.css', color, range);
+
             expect(res.length).to.equal(3);
             expect(res.filter((cp) => cp.label === 'rgba(0, 255, 0, 0.8)').length).to.equal(1);
         });
 
-        it('should not return presentation in variable usage', () => {
-            const range = createRange(5, 11, 5, 23);
+        it('should return presentation in variable usage', () => {
+            const range = createRange(5, 11, 5, 24);
             const color = {
                 red: 0,
                 green: 1,
                 blue: 0,
                 alpha: 0.8,
             };
+
             const res = getDocColorPresentation('colors/color-presentation.st.css', color, range);
-            expect(res.length).to.equal(0);
+
+            expect(res.length).to.equal(3);
+            expect(res.filter((cp) => cp.label === 'rgba(0, 255, 0, 0.8)').length).to.equal(1);
         });
 
-        it('should not return presentation in -st-named', () => {
-            const range = createRange(2, 15, 2, 21);
+        it('should return presentation for imports variables', () => {
+            const range = createRange(7, 11, 7, 24);
             const color = {
                 red: 0,
                 green: 1,
                 blue: 0,
                 alpha: 0.8,
             };
+
             const res = getDocColorPresentation(
                 'colors/color-presentation-import.st.css',
                 color,
                 range
             );
-            expect(res.length).to.equal(0);
+
+            expect(res.length).to.equal(3);
+            expect(res.filter((cp) => cp.label === 'rgba(0, 255, 0, 0.8)').length).to.equal(1);
         });
     });
 });

--- a/packages/language-service/test/lib/colors.spec.ts
+++ b/packages/language-service/test/lib/colors.spec.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import { Color } from 'vscode-languageserver-protocol';
 import { createRange } from '../../src/lib/completion-providers';
-import { getDocColorPresentation, getDocumentColors } from '../../test-kit/asserters';
+import {
+    getDocColorPresentation,
+    getDocumentColors,
+    getNonStVarsDocumentColors,
+} from '../../test-kit/asserters';
+import { createStylableTestLSP } from '../../test-kit/stylable-fixtures-lsp';
 
 export function createColor(red: number, green: number, blue: number, alpha: number): Color {
     return { red, green, blue, alpha } as Color;
@@ -69,6 +74,30 @@ describe('Colors', () => {
                     color: createColor(1, 1, 1, 1),
                 },
             ]);
+        });
+
+        describe('colorStylableVars', () => {
+            const stylableLSP = createStylableTestLSP({ colorStylableVars: false });
+
+            it('should not return colors for value() when configured to false', () => {
+                const res = getNonStVarsDocumentColors(
+                    'colors/single-var-color.st.css',
+                    stylableLSP
+                );
+
+                expect(res).to.eql([
+                    {
+                        range: createRange(1, 12, 1, 31),
+                        color: createColor(0, 1, 0, 0.8),
+                    },
+                ]);
+            });
+
+            it('should not resolve information for an imported color', () => {
+                const res = getNonStVarsDocumentColors('colors/imported-color.st.css', stylableLSP);
+
+                expect(res).to.eql([]);
+            });
         });
     });
 

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -9,7 +9,7 @@ function createDiagnostics(files: { [filePath: string]: string }, filePath: stri
 
     const stylableLSP = new StylableLanguageService({
         fs,
-        stylable: new Stylable('/', fs as any, require),
+        stylable: new Stylable('/', fs, require),
     });
 
     return stylableLSP.diagnose(filePath);


### PR DESCRIPTION
Currently, color presentation calls on `value(<some variable>)` do nothing. From now on, color presentation will edit the entire `value()` string inline - not the source variable.

Furthermore, the color square previews will no longer appear in the `:import` `named` field, and only where colors are used.

```css
/* before color presentation on "value(aColor) */
:vars {
    aColor: red;
}

.root {
    color: value(aColor);
}
```

```css
/* after color presentation on "value(aColor) */
:vars {
    aColor: red;
}

.root {
    color: rgba(12, 34, 56, 0.75); /* value chosen in colorpicker  */
}
```