### PR TITLE
Fix dynamic emit of assets when includeDynamicModulesInCSS is true

### DIFF
--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -188,7 +188,11 @@ export class ProjectRunner {
     }
 
     public getBuildAsset(assetPath: string) {
-        return this.stats!.compilation.assets[normalize(assetPath)].source();
+        return this.getBuildAssets()[normalize(assetPath)].source();
+    }
+
+    public getBuildAssets() {
+        return this.stats!.compilation.assets;
     }
 
     public evalAssetModule(source: string, publicPath = ''): any {

--- a/packages/webpack-plugin/src/plugin-options.ts
+++ b/packages/webpack-plugin/src/plugin-options.ts
@@ -49,6 +49,7 @@ export function normalizeOptions(
         },
         unsafeBuildNamespace: false,
         includeDynamicModulesInCSS: true,
+        skipDynamicCSSEmit: true,
         useEntryModuleInjection: false,
         experimentalHMR: false,
         plugins: [],

--- a/packages/webpack-plugin/src/plugin-options.ts
+++ b/packages/webpack-plugin/src/plugin-options.ts
@@ -49,7 +49,7 @@ export function normalizeOptions(
         },
         unsafeBuildNamespace: false,
         includeDynamicModulesInCSS: true,
-        skipDynamicCSSEmit: true,
+        skipDynamicCSSEmit: false,
         useEntryModuleInjection: false,
         experimentalHMR: false,
         plugins: [],

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -159,7 +159,7 @@ export class StylableWebpackPlugin {
         const rootContext = (compilation as any).options.context;
         const replacements: WebpackAssetModule[] = [];
         const moduleDir = dirname(module.resource);
-        const onUrl: OnUrlCallback  = (node) => {
+        const onUrl: OnUrlCallback = (node) => {
             if (node.url !== undefined && isAsset(node.url)) {
                 const resourcePath = makeAbsolute(node.url, rootContext, moduleDir);
                 const assetModule = compilation.modules.find((_) => _.resource === resourcePath);
@@ -322,6 +322,9 @@ export class StylableWebpackPlugin {
         compilation: webpack.compilation.Compilation
     ) {
         if (this.options.includeDynamicModulesInCSS) {
+            if (!chunk.isOnlyInitial() && this.options.skipDynamicCSSEmit) {
+                return;
+            }
             const stModules = getModuleInGraph(chunk, (module) => module.type === 'stylable');
             if (stModules.size !== 0) {
                 const cssSources = renderStaticCSS(
@@ -333,9 +336,7 @@ export class StylableWebpackPlugin {
                     chunk,
                     hash: compilation.hash,
                 });
-                compilation.assets[cssBundleFilename] = new RawSource(
-                    cssSources.join(EOL + EOL + EOL)
-                );
+                compilation.assets[cssBundleFilename] = new RawSource(cssSources.join(EOL));
                 chunk.files.push(cssBundleFilename);
             }
         } else {

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -13,6 +13,7 @@ export interface StylableWebpackPluginOptions {
     filename: string;
     useWeakDeps: boolean;
     includeDynamicModulesInCSS: boolean;
+    skipDynamicCSSEmit: boolean;
     createRuntimeChunk: boolean;
     outputCSS: boolean;
     includeCSSInJS: boolean;

--- a/packages/webpack-plugin/test/e2e/dynamic-split-chunks.spec.ts
+++ b/packages/webpack-plugin/test/e2e/dynamic-split-chunks.spec.ts
@@ -1,4 +1,4 @@
-import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { expect } from 'chai';
 import { join } from 'path';
 

--- a/packages/webpack-plugin/test/e2e/dynamic-split-chunks.spec.ts
+++ b/packages/webpack-plugin/test/e2e/dynamic-split-chunks.spec.ts
@@ -18,7 +18,7 @@ describe(`(${project})`, () => {
         after
     );
 
-    it('should not emit dynamic chunks css', async () => {
+    it('should not emit dynamic chunks css', () => {
         const source = projectRunner.getBuildAsset('main.bundle.css');
         const cssAssets = Object.keys(projectRunner.getBuildAssets()).filter((assetsName) =>
             assetsName.endsWith('css')

--- a/packages/webpack-plugin/test/e2e/dynamic-split-chunks.ts
+++ b/packages/webpack-plugin/test/e2e/dynamic-split-chunks.ts
@@ -1,0 +1,29 @@
+import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'dynamic-split-chunks';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                headless: false,
+                devtools: true,
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('should not emit dynamic chunks css', async () => {
+        const source = projectRunner.getBuildAsset('main.bundle.css');
+        const cssAssets = Object.keys(projectRunner.getBuildAssets()).filter((assetsName) =>
+            assetsName.endsWith('css')
+        );
+        expect(typeof source, 'source exist').to.equal('string');
+        expect(cssAssets.length, 'only one css emitted').to.equal(1);
+    });
+});

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compA/compA.js
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compA/compA.js
@@ -1,0 +1,5 @@
+import { classes } from './compA.st.css';
+
+export function compA() {
+    return `<div class="${classes.root}">CompA</div>`;
+}

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compA/compA.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compA/compA.st.css
@@ -1,0 +1,3 @@
+.root {
+    color: red;
+}

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compB/compB.js
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compB/compB.js
@@ -1,0 +1,5 @@
+import { classes } from "./compB.st.css";
+
+export function compB(){
+    return `<div class="${classes.root}">CompB</div>`
+} 

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compB/compB.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/compB/compB.st.css
@@ -1,0 +1,3 @@
+.root {
+    color: green;
+}

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/src/index.js
@@ -1,0 +1,3 @@
+Promise.all([import('./compA/compA'), import('./compB/compB')]).then(([{ compA }, { compB }]) => {
+    document.body.innerHTML = compA() + compB();
+});

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/webpack.config.js
@@ -8,8 +8,10 @@ module.exports = {
     plugins: [
         new StylableWebpackPlugin({
             useEntryModuleInjection: true,
+            includeDynamicModulesInCSS: true,
+            skipDynamicCSSEmit: true,
             outputCSS: true,
-            includeCSSInJS: false
+            includeCSSInJS: false,
         }),
         new HtmlWebpackPlugin(),
     ],

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-split-chunks/webpack.config.js
@@ -1,0 +1,16 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [
+        new StylableWebpackPlugin({
+            useEntryModuleInjection: true,
+            outputCSS: true,
+            includeCSSInJS: false
+        }),
+        new HtmlWebpackPlugin(),
+    ],
+};


### PR DESCRIPTION
This fixes a bug that cause our plugin to emit dynamic chunks css when we extract css into one bundle.

* Change the 3 EOL between css asset in the bundle to 1
* Fix emit of redundant css assets

This should be a patch but added the ability to disable this behavior if needed via 
`skipDynamicCSSEmit: false`  