### PR TITLE
fix issue with mixins and formatters as arguments

### DIFF
--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -297,7 +297,9 @@ export const strategies = {
 
 function stringifyParam(nodes: any) {
     return postcssValueParser.stringify(nodes, (n: any) => {
-        if (n.type === 'div') {
+        if(n.type === 'function'){
+            return postcssValueParser.stringify(n);
+        } else if (n.type === 'div') {
             return null;
         } else if (n.type === 'string') {
             return n.value;

--- a/packages/core/test/mixins/css-mixins.spec.ts
+++ b/packages/core/test/mixins/css-mixins.spec.ts
@@ -29,6 +29,39 @@ describe('CSS Mixins', () => {
         matchRuleAndDeclaration(result, 1, '.entry__container', 'color: red');
     });
 
+    it.only('Mixin with function arguments with multiple params (comma separated)', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    content: `
+                        :import {
+                            -st-from: "./formatter";
+                            -st-default: formatter;
+                        }
+                        
+                        .container {
+                            -st-mixin: Text(ZZZ formatter(color-1, color-2));
+                        }
+                        
+                        .Text {
+                            color: value(ZZZ);
+                        }
+                    `,
+                },
+                '/formatter.js': {
+                    content: `
+                        module.exports = function() {
+                            return \`\${[...arguments].join(', ')}\`;
+                        }
+                    `,
+                },
+            },
+        });
+        const rule = result.nodes![0] as postcss.Rule;
+        expect(rule.nodes![0].toString()).to.equal('color: color-1, color-2');
+    });
+
     it('transform state form imported element', () => {
         const result = generateStylableRoot({
             entry: `/entry.st.css`,

--- a/packages/core/test/mixins/css-mixins.spec.ts
+++ b/packages/core/test/mixins/css-mixins.spec.ts
@@ -29,7 +29,7 @@ describe('CSS Mixins', () => {
         matchRuleAndDeclaration(result, 1, '.entry__container', 'color: red');
     });
 
-    it.only('Mixin with function arguments with multiple params (comma separated)', () => {
+    it('Mixin with function arguments with multiple params (comma separated)', () => {
         const result = generateStylableRoot({
             entry: `/style.st.css`,
             files: {


### PR DESCRIPTION
When using mixins and formatters as arguments the formatter arguments turned in to nulls
```css
.root {
 -st-mixin: Mixin(param formatter(a, b, c))
}
```
the results was
```css
.root {
  color: anullbnullc;
}
```