### PR TITLE
fix: timed cache without timer flakiness

### DIFF
--- a/packages/core/src/timed-cache.ts
+++ b/packages/core/src/timed-cache.ts
@@ -20,7 +20,7 @@ export function timedCache<T extends (...args: string[]) => string>(
         }
         shouldClean = true;
         const current = Date.now();
-        if (current - prevTime > timeout && !useTimer) {
+        if (current - prevTime >= timeout && !useTimer) {
             cache.clear();
         }
         prevTime = current;


### PR DESCRIPTION
the first test in `timed-cache.spec.ts` depends on Date.now() being 1ms exact.

allow it to clean if diff from last call === timeout (which is also correct), hoping this would fix the flakiness.