### PR TITLE
infra: use single mocha with --parallel

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    timeout: 5000,
     require: ['@ts-tools/node/r', 'tsconfig-paths/register'],
     extension: ['js', 'json', 'ts', 'tsx'],
     colors: true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . -f codeframe",
     "pretest": "yarn typecheck && yarn lint",
-    "test": "lerna run test --stream",
+    "test": "yarn test:parallel",
+    "test:mocha": "mocha \"packages/**/*.{unit,spec}.{ts,tsx}\"",
+    "test:parallel": "yarn test:mocha --parallel",
     "prettify": "npx prettier \"packages/**/*.{js,ts,tsx}\" --write"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf ./cjs",
     "build": "ts-build ./src --cjs",
-    "test": "mocha \"test/**/*.spec.ts?(x)\" --timeout 25000",
+    "test": "mocha \"test/**/*.spec.ts?(x)\"",
     "prepack": "yarn build"
   },
   "dependencies": {

--- a/packages/cli/test/build.spec.ts
+++ b/packages/cli/test/build.spec.ts
@@ -5,11 +5,14 @@ import { expect } from 'chai';
 import { resolve } from 'path';
 import { build } from '../src';
 
-const log = () => {
-    /**/
-};
 
-describe('build stand alone', () => {
+describe('build stand alone', function () {
+    this.timeout(10_000);
+    
+    const log = () => {
+        /**/
+    };
+    
     it('should create modules and copy source css files', () => {
         const fs = createFS({
             '/main.st.css': `

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -39,7 +39,9 @@ function populateDirectorySync(rootDir: string, files: Files) {
     }
 }
 
-describe('Stylable Cli', () => {
+describe('Stylable Cli', function () {
+    this.timeout(10_000);
+
     let tempDir: ITempDirectory;
 
     beforeEach(async () => {

--- a/packages/cli/test/generate-index.spec.ts
+++ b/packages/cli/test/generate-index.spec.ts
@@ -3,11 +3,13 @@ import { createMemoryFileSystemWithFiles as createFS } from '@stylable/e2e-test-
 import { expect } from 'chai';
 import { resolve } from 'path';
 import { build } from '../src';
-const log = () => {
-    /**/
-};
 
-describe('build index', () => {
+describe('build index', function () {
+    this.timeout(10_000);
+    const log = () => {
+        /**/
+    };
+
     it('should create index file importing all matched stylesheets in srcDir', () => {
         const fs = createFS({
             '/compA.st.css': `

--- a/packages/custom-value/package.json
+++ b/packages/custom-value/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf ./cjs",
     "build": "ts-build ./src --cjs",
-    "test": "mocha \"test/**/*.spec.ts?(x)\" --timeout 20000",
+    "test": "mocha \"test/**/*.spec.ts?(x)\"",
     "prepack": "yarn build"
   },
   "dependencies": {

--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -49,7 +49,7 @@ export class ProjectRunner {
         const projectRunner = new this(runnerOptions);
 
         before('bundle and serve project', async function () {
-            this.timeout(40000);
+            this.timeout(40_000);
             watch ? await projectRunner.watch() : await projectRunner.bundle();
             await projectRunner.serve();
         });

--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -58,7 +58,8 @@ export class ProjectRunner {
             await projectRunner.closeAllPages();
         });
 
-        after('destroy runner', async () => {
+        after('destroy runner', async function () {
+            this.timeout(20_000);
             await projectRunner.destroy();
         });
 

--- a/packages/language-service/test/lib/completions/formatters.spec.ts
+++ b/packages/language-service/test/lib/completions/formatters.spec.ts
@@ -2,7 +2,9 @@ import { createRange, ProviderRange } from '../../../src/lib/completion-provider
 import { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
-describe('Formatters', () => {
+describe('Formatters', function () {
+    this.timeout(20_000);
+
     const ts_formatter_1 = 'paramlessFormatter';
     const ts_formatter_2 = 'formatterWithParams';
     const js_formatter_1 = 'aFormatter';
@@ -43,7 +45,7 @@ describe('Formatters', () => {
                         asserter.suggested(exp);
                         asserter.notSuggested(notExp);
                     }
-                ).timeout(10000);
+                );
 
                 it(
                     'should complete imported TS formatters after value, with prefix ' + prefix,
@@ -70,7 +72,7 @@ describe('Formatters', () => {
                         asserter.suggested(exp);
                         asserter.notSuggested(notExp);
                     }
-                ).timeout(10000);
+                );
             });
         });
     });
@@ -98,7 +100,7 @@ describe('Formatters', () => {
                         asserter.suggested(exp);
                         asserter.notSuggested(notExp);
                     }
-                ).timeout(10000);
+                );
 
                 it(
                     'should complete imported JS formatters after value, with prefix ' + prefix,
@@ -119,7 +121,7 @@ describe('Formatters', () => {
                         asserter.suggested(exp);
                         asserter.notSuggested(notExp);
                     }
-                ).timeout(10000);
+                );
             });
         });
 

--- a/packages/language-service/test/lib/completions/mixins.spec.ts
+++ b/packages/language-service/test/lib/completions/mixins.spec.ts
@@ -2,7 +2,9 @@ import { createRange, ProviderRange } from '../../../src/lib/completion-provider
 import { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
-describe('Mixins', () => {
+describe('Mixins', function () {
+    this.timeout(20_000);
+
     describe('CSS Class Mixins', () => {
         const createComp = (str: string, rng: ProviderRange, path: string) =>
             asserters.cssMixinCompletion(str, rng, path);
@@ -187,7 +189,7 @@ describe('Mixins', () => {
                             asserter.suggested(exp);
                             asserter.notSuggested(notExp);
                         }
-                    ).timeout(10000);
+                    );
 
                     it(
                         'should complete imported TS mixins after value, with prefix ' + prefix,
@@ -216,7 +218,7 @@ describe('Mixins', () => {
                             asserter.suggested(exp);
                             asserter.notSuggested(notExp);
                         }
-                    ).timeout(10000);
+                    );
                 });
             });
         });
@@ -248,7 +250,7 @@ describe('Mixins', () => {
                             asserter.suggested(exp);
                             asserter.notSuggested(notExp);
                         }
-                    ).timeout(10000);
+                    );
 
                     it(
                         'should complete imported JS mixins after value, with prefix ' + prefix,
@@ -271,7 +273,7 @@ describe('Mixins', () => {
                             asserter.suggested(exp);
                             asserter.notSuggested(notExp);
                         }
-                    ).timeout(10000);
+                    );
                 });
             });
 

--- a/packages/language-service/test/lib/signatures.spec.ts
+++ b/packages/language-service/test/lib/signatures.spec.ts
@@ -33,7 +33,7 @@ describe('Signature Help', () => {
                     expect(sig).to.not.equal(null);
                     expect(sig).to.deep.equal(exp);
                 }
-            ).timeout(5000);
+            );
         });
     });
 
@@ -51,7 +51,7 @@ describe('Signature Help', () => {
 
             expect(sig).to.not.equal(null);
             expect(sig).to.deep.equal(exp);
-        }).timeout(5000);
+        });
     });
 
     xdescribe('TS Paramful Mixin - Default Import', () => {
@@ -81,7 +81,7 @@ describe('Signature Help', () => {
                     expect(sig).to.not.equal(null);
                     expect(sig).to.deep.equal(exp);
                 }
-            ).timeout(5000);
+            );
         });
     });
 
@@ -114,7 +114,7 @@ describe('Signature Help', () => {
                     expect(sig).to.not.equal(null);
                     expect(sig).to.deep.equal(exp);
                 }
-            ).timeout(5000);
+            );
         });
     });
 
@@ -134,7 +134,7 @@ describe('Signature Help', () => {
 
             expect(sig).to.not.equal(null);
             expect(sig).to.deep.equal(exp);
-        }).timeout(5000);
+        });
     });
 
     xdescribe('JS Paramful Mixin with .d.ts', () => {
@@ -167,7 +167,7 @@ describe('Signature Help', () => {
                     expect(sig).to.not.equal(null);
                     expect(sig).to.deep.equal(exp);
                 }
-            ).timeout(5000);
+            );
         });
     });
 
@@ -185,7 +185,7 @@ describe('Signature Help', () => {
 
             expect(sig).to.not.equal(null);
             expect(sig).to.deep.equal(exp);
-        }).timeout(5000);
+        });
     });
 
     describe('No signature', () => {
@@ -453,7 +453,7 @@ describe('Signature Help', () => {
                     expect(sig).to.not.equal(null);
                     expect(sig).to.deep.equal(exp);
                 }
-            ).timeout(5000);
+            );
         });
     });
 });

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf ./cjs",
     "build": "ts-build ./src --cjs",
-    "test": "mocha \"test/**/*.spec.ts?(x)\" --timeout 10000",
+    "test": "mocha \"test/**/*.spec.ts?(x)\"",
     "prepack": "yarn build"
   },
   "dependencies": {

--- a/packages/optimizer/test/stylable-optimizer.spec.ts
+++ b/packages/optimizer/test/stylable-optimizer.spec.ts
@@ -97,5 +97,5 @@ describe('StylableOptimizer', () => {
         const { meta } = stylable.transform(files[index].content, index);
         const output = new StylableOptimizer().minifyCSS(meta.outputAst!.toString());
         expect(output).to.equal(`.${meta.namespace}__x{color:red}`);
-    }).timeout(25000);
+    });
 });

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,7 +9,7 @@
     "build": "ts-build ./src --cjs && yarn bundle",
     "bundle": "node -r @ts-tools/node/r -r tsconfig-paths/register ./scripts/build-runtime.ts",
     "test:unit": "mocha \"test/unit/**/*.spec.ts?(x)\"",
-    "test:e2e": "mocha \"test/e2e/**/*.spec.[tj]s?(x)\" --timeout 20000",
+    "test:e2e": "mocha \"test/e2e/**/*.spec.[tj]s?(x)\"",
     "test": "run-p test:unit test:e2e",
     "prepack": "yarn build"
   },

--- a/packages/runtime/test/unit/css-runtime-renderer.spec.ts
+++ b/packages/runtime/test/unit/css-runtime-renderer.spec.ts
@@ -311,7 +311,7 @@ describe('css-runtime-renderer', () => {
             expect(typeof api.renderer!.render).to.equal('function');
             expect(api.window).to.equal(window);
             expect(api.id).to.equal(0);
-        }).timeout(25000);
+        })
 
         it('init should render once', () => {
             const { window } = new JSDOM(`

--- a/packages/webpack-extensions/package.json
+++ b/packages/webpack-extensions/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rimraf ./cjs ./esm",
     "build": "ts-build ./src --cjs --esm",
-    "test": "mocha \"test/**/*.spec.ts?(x)\" --timeout 20000",
+    "test": "mocha \"test/**/*.spec.ts?(x)\"",
     "prepack": "yarn build"
   },
   "peerDependencies": {

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf ./cjs",
     "build": "ts-build ./src --cjs",
-    "test": "mocha \"test/**/*.spec.ts?(x)\" --timeout 20000",
+    "test": "mocha \"test/**/*.spec.ts?(x)\"",
     "prepack": "yarn build"
   },
   "peerDependencies": {


### PR DESCRIPTION
- as allowed by recently released mocha@8.
- extended default timeout to 5s.
- removed most custom timeouts to see which are still needed.
- separated root test script to test:mocha and test:parallel