### PR TITLE
security: replace url-regex with is-url-superb

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "css-selector-tokenizer": "^0.7.2",
     "deindent": "^0.1.0",
     "enhanced-resolve": "^4.2.0",
+    "is-url-superb": "^4.0.0",
     "is-vendor-prefixed": "^3.3.1",
     "jest-docblock": "^26.0.0",
     "lodash.clonedeep": "^4.5.0",
@@ -25,8 +26,7 @@
     "postcss-nested": "^4.2.1",
     "postcss-safe-parser": "^4.0.2",
     "postcss-selector-matches": "^4.0.0",
-    "postcss-value-parser": "^4.1.0",
-    "url-regex": "^5.0.0"
+    "postcss-value-parser": "^4.1.0"
   },
   "files": [
     "cjs",

--- a/packages/core/src/stylable-assets.ts
+++ b/packages/core/src/stylable-assets.ts
@@ -1,10 +1,9 @@
 import path from 'path';
 import postcss from 'postcss';
-import urlRegex from 'url-regex';
+import isUrl from 'is-url-superb';
 import { ParsedValue } from './types';
 
 const { parseValues, stringifyValues } = require('css-selector-tokenizer');
-const isUrl = urlRegex({ exact: true, strict: true });
 
 export type OnUrlCallback = (node: ParsedValue) => void;
 
@@ -18,7 +17,7 @@ export function collectAssets(ast: postcss.Root) {
 }
 
 export function isExternal(url: string) {
-    return url === '' || url.startsWith('data:') || isUrl.test(url);
+    return url === '' || url.startsWith('data:') || isUrl(url);
 }
 
 export function isAsset(url: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5164,11 +5164,6 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.1.0.tgz#5ad62f685a14edb421abebc2fff8db94df67b455"
-  integrity sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==
-
 ip@1.1.5, ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -5451,6 +5446,11 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url-superb@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
+  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -9059,11 +9059,6 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tlds@^1.203.0:
-  version "1.207.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.207.0.tgz#459264e644cf63ddc0965fece3898913286b1afd"
-  integrity sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9416,14 +9411,6 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-5.0.0.tgz#8f5456ab83d898d18b2f91753a702649b873273a"
-  integrity sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==
-  dependencies:
-    ip-regex "^4.1.0"
-    tlds "^1.203.0"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
`url-regex` has a security vulnerability.

`is-url-superb` uses native `URL` api to verify text is a valid url. much cleaner.

ref:
https://github.com/advisories/GHSA-v4rh-8p82-6h5w
https://github.com/kevva/url-regex/issues/70