### PR TITLE
core-test-kit: refactor to use createInfra

### DIFF
--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -1,5 +1,4 @@
 import {
-    cachedProcessFile,
     createMinimalFS,
     Diagnostics,
     FileProcessor,
@@ -12,6 +11,7 @@ import {
     StylableResolver,
     StylableResults,
     StylableTransformer,
+    createInfrastructure,
 } from '@stylable/core';
 import { isAbsolute } from 'path';
 import postcss from 'postcss';
@@ -48,17 +48,19 @@ export function generateInfra(
     fileProcessor: FileProcessor<StylableMeta>;
 } {
     const { fs, requireModule } = createMinimalFS(config);
-
-    const fileProcessor = cachedProcessFile<StylableMeta>(
-        (from, content) => {
-            const meta = process(postcss.parse(content, { from }), diagnostics);
-            meta.namespace = config.files[from].namespace || meta.namespace;
+    const { fileProcessor } = createInfrastructure(
+        '/',
+        fs,
+        (meta, filePath) => {
+            meta.namespace = config.files[filePath].namespace || meta.namespace;
             return meta;
         },
-        fs,
-        (x) => (x.startsWith('./') || isAbsolute(x) ? x : '/node_modules/' + x)
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        diagnostics
     );
-
     const resolver = new StylableResolver(fileProcessor, requireModule);
 
     return { resolver, requireModule, fileProcessor };

--- a/packages/core/src/create-infra-structure.ts
+++ b/packages/core/src/create-infra-structure.ts
@@ -4,6 +4,7 @@ import { safeParse } from './parser';
 import { process, processNamespace, StylableMeta } from './stylable-processor';
 import { timedCache, TimedCacheOptions } from './timed-cache';
 import { createDefaultResolver } from './module-resolver';
+import { Diagnostics } from './diagnostics';
 
 export interface StylableInfrastructure {
     fileProcessor: FileProcessor<StylableMeta>;
@@ -17,7 +18,8 @@ export function createInfrastructure(
     resolveOptions: any = {},
     resolveNamespace?: typeof processNamespace,
     timedCacheOptions?: Omit<TimedCacheOptions, 'createKey'>,
-    resolveModule = createDefaultResolver(fileSystem, resolveOptions)
+    resolveModule = createDefaultResolver(fileSystem, resolveOptions),
+    diagnostics = new Diagnostics()
 ): StylableInfrastructure {
     let resolvePath = (context: string | undefined = projectRoot, moduleId: string) => {
         if (!path.isAbsolute(moduleId) && !moduleId.startsWith('.')) {
@@ -38,7 +40,7 @@ export function createInfrastructure(
         (from, content) => {
             return process(
                 safeParse(content, { from: resolvePath(projectRoot, from) }),
-                undefined,
+                diagnostics,
                 resolveNamespace
             );
         },


### PR DESCRIPTION
now uses the actual resolver the implementation uses during units