### PR TITLE
Jest: add runtime version to jest cache key

### DIFF
--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -3,6 +3,7 @@ import { Options, stylableModuleFactory } from '@stylable/module-utils';
 import fs from 'fs';
 
 const stylableRuntimePath = require.resolve('@stylable/runtime');
+const { version } = require('@stylable/runtime/package.json') as { version: string };
 
 export function processFactory(
     stylableConfig?: Partial<StylableConfig>,
@@ -30,6 +31,11 @@ export function getCacheKey(
     { instrument }: { instrument: boolean }
 ) {
     return (
-        fileData + configString + (instrument ? 'instrument' : '') + filename + stylableRuntimePath
+        fileData +
+        configString +
+        (instrument ? 'instrument' : '') +
+        filename +
+        stylableRuntimePath +
+        version
     );
 }


### PR DESCRIPTION
Include the `@stylable/runtime` version as part of the `@stylable/jest` caching key. A different runtime version should cause new transformations and not yield previously cached results.