### PR TITLE
infra: set importsNotUsedAsValues to "error"

### DIFF
--- a/packages/cli/src/build-tools.ts
+++ b/packages/cli/src/build-tools.ts
@@ -1,5 +1,5 @@
-import { StylableResults } from '@stylable/core';
-import { FileSystem } from '@stylable/node';
+import type { StylableResults } from '@stylable/core';
+import type { FileSystem } from '@stylable/node';
 import { dirname } from 'path';
 
 export function handleDiagnostics(

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -4,7 +4,7 @@ import { FileSystem, findFiles } from '@stylable/node';
 import { StylableOptimizer } from '@stylable/optimizer';
 import { basename, dirname, join, relative, resolve } from 'path';
 import { ensureDirectory, handleDiagnostics, tryRun } from './build-tools';
-import { Generator } from './default-generator';
+import type { Generator } from './default-generator';
 import { generateFileIndexEntry, generateIndexFile } from './generate-index';
 import { generateManifest } from './generate-manifest';
 import { handleAssets } from './handle-assets';

--- a/packages/cli/src/generate-index.ts
+++ b/packages/cli/src/generate-index.ts
@@ -1,7 +1,7 @@
 import { relative } from 'path';
 import { join } from 'path';
 import { addDotSlash, createImportForComponent, ensureDirectory, tryRun } from './build-tools';
-import { Generator } from './default-generator';
+import type { Generator } from './default-generator';
 
 export function generateFileIndexEntry(
     filePath: string,

--- a/packages/cli/src/generate-manifest.ts
+++ b/packages/cli/src/generate-manifest.ts
@@ -1,4 +1,4 @@
-import { Stylable } from '@stylable/core';
+import type { Stylable } from '@stylable/core';
 import { dirname, relative } from 'path';
 import { ensureDirectory, tryRun } from './build-tools';
 export function generateManifest(

--- a/packages/core-test-kit/src/match-rules.ts
+++ b/packages/core-test-kit/src/match-rules.ts
@@ -1,4 +1,4 @@
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 export function matchRuleAndDeclaration(
     parent: postcss.Container,

--- a/packages/core-test-kit/src/matchers/results.ts
+++ b/packages/core-test-kit/src/matchers/results.ts
@@ -1,6 +1,6 @@
-import { StylableResults } from '@stylable/core';
+import type { StylableResults } from '@stylable/core';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 export function mediaQuery(chai: any, util: any) {
     const { flag } = util;

--- a/packages/core/src/cssdocs.ts
+++ b/packages/core/src/cssdocs.ts
@@ -1,5 +1,5 @@
 import { extract, parseWithComments } from 'jest-docblock';
-import { StylableMeta, StylableSymbol } from './stylable-meta';
+import type { StylableMeta, StylableSymbol } from './stylable-meta';
 
 export interface CssDoc {
     description: string;

--- a/packages/core/src/custom-values.ts
+++ b/packages/core/src/custom-values.ts
@@ -1,9 +1,9 @@
 import cloneDeepWith from 'lodash.clonedeepwith';
 import postcssValueParser from 'postcss-value-parser';
-import { StylableMeta } from './stylable-meta';
-import { StylableResolver } from './stylable-resolver';
+import type { StylableMeta } from './stylable-meta';
+import type { StylableResolver } from './stylable-resolver';
 import { getFormatterArgs, getNamedArgs, getStringValue } from './stylable-value-parsers';
-import { ParsedValue } from './types';
+import type { ParsedValue } from './types';
 
 export interface Box<Type extends string, Value extends any> {
     type: Type;

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 export type DiagnosticType = 'error' | 'warning';
 

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -1,12 +1,12 @@
 import { dirname, relative } from 'path';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import { resolveCustomValues, stTypes } from './custom-values';
-import { Diagnostics } from './diagnostics';
+import type { Diagnostics } from './diagnostics';
 import { isCssNativeFunction } from './native-reserved-lists';
 import { assureRelativeUrlPrefix } from './stylable-assets';
-import { StylableMeta } from './stylable-processor';
-import { CSSResolve, JSResolve, StylableResolver } from './stylable-resolver';
-import { replaceValueHook, StylableTransformer } from './stylable-transformer';
+import type { StylableMeta } from './stylable-processor';
+import type { CSSResolve, JSResolve, StylableResolver } from './stylable-resolver';
+import type { replaceValueHook, StylableTransformer } from './stylable-transformer';
 import { isCSSVarProp } from './stylable-utils';
 import {
     getFormatterArgs,
@@ -14,7 +14,7 @@ import {
     strategies,
     valueMapping,
 } from './stylable-value-parsers';
-import { ParsedValue } from './types';
+import type { ParsedValue } from './types';
 import { stripQuotation } from './utils';
 
 const postcssValueParser = require('postcss-value-parser');

--- a/packages/core/src/memory-minimal-fs.ts
+++ b/packages/core/src/memory-minimal-fs.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'path';
 const deindent = require('deindent');
 
-import { MinimalFS } from './cached-process-file';
+import type { MinimalFS } from './cached-process-file';
 
 export interface File {
     content: string;

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -2,8 +2,8 @@
 // this allows @stylable/core to be bundled for browser usage without special custom configuration
 const ResolverFactory = require('enhanced-resolve/lib/ResolverFactory') as typeof import('enhanced-resolve').ResolverFactory;
 
-import { ModuleResolver } from './types';
-import { MinimalFS } from './cached-process-file';
+import type { ModuleResolver } from './types';
+import type { MinimalFS } from './cached-process-file';
 
 const resolverContext = {};
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
 import postcssNested from 'postcss-nested';
-import { CSSObject } from './types';
+import type { CSSObject } from './types';
 const postcssJS = require('postcss-js');
 const safeParser = require('postcss-safe-parser');
 

--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -1,21 +1,21 @@
-import postcss from 'postcss';
-import { Diagnostics } from './diagnostics';
+import type postcss from 'postcss';
+import type { Diagnostics } from './diagnostics';
 import { evalDeclarationValue } from './functions';
 import { nativePseudoClasses } from './native-reserved-lists';
-import { SelectorAstNode } from './selector-utils';
+import type { SelectorAstNode } from './selector-utils';
 import { StateResult, systemValidators } from './state-validators';
-import {
+import type {
     ClassSymbol,
     ElementSymbol,
     SRule,
     StylableMeta,
     StylableSymbol,
 } from './stylable-processor';
-import { StylableResolver } from './stylable-resolver';
+import type { StylableResolver } from './stylable-resolver';
 import { isValidClassName } from './stylable-utils';
 import { groupValues, listOptions, MappedStates } from './stylable-value-parsers';
 import { valueMapping } from './stylable-value-parsers';
-import { ParsedValue, StateParsedValue } from './types';
+import type { ParsedValue, StateParsedValue } from './types';
 import { stripQuotation } from './utils';
 
 const isVendorPrefixed = require('is-vendor-prefixed');

--- a/packages/core/src/resolve-namespace-factories.ts
+++ b/packages/core/src/resolve-namespace-factories.ts
@@ -1,5 +1,5 @@
 import hash from 'murmurhash';
-import { processNamespace } from './stylable-processor';
+import type { processNamespace } from './stylable-processor';
 
 export function packageNamespaceFactory(
     findConfig: (fileName: string, options: { cwd: string }) => string | null,

--- a/packages/core/src/selector-utils.ts
+++ b/packages/core/src/selector-utils.ts
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
-import { ClassSymbol, ElementSymbol } from './stylable-meta';
-import { CSSResolve } from './stylable-resolver';
+import type { ClassSymbol, ElementSymbol } from './stylable-meta';
+import type { CSSResolve } from './stylable-resolver';
 import { valueMapping } from './stylable-value-parsers';
 const tokenizer = require('css-selector-tokenizer');
 

--- a/packages/core/src/state-validators.ts
+++ b/packages/core/src/state-validators.ts
@@ -1,4 +1,4 @@
-import { StateArguments } from './types';
+import type { StateArguments } from './types';
 
 export interface StateResult {
     res: string;

--- a/packages/core/src/stylable-assets.ts
+++ b/packages/core/src/stylable-assets.ts
@@ -1,7 +1,7 @@
 import path from 'path';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import isUrl from 'is-url-superb';
-import { ParsedValue } from './types';
+import type { ParsedValue } from './types';
 
 const { parseValues, stringifyValues } = require('css-selector-tokenizer');
 

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -1,6 +1,6 @@
-import postcss from 'postcss';
-import { Diagnostics } from './diagnostics';
-import { SelectorAstNode } from './selector-utils';
+import type postcss from 'postcss';
+import type { Diagnostics } from './diagnostics';
+import type { SelectorAstNode } from './selector-utils';
 import { getSourcePath } from './stylable-utils';
 import { MappedStates, MixinValue, valueMapping } from './stylable-value-parsers';
 export const RESERVED_ROOT_NAME = 'root';

--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -4,10 +4,10 @@ import postcss from 'postcss';
 import { resolveArgumentsValue } from './functions';
 import { cssObjectToAst } from './parser';
 import { fixRelativeUrls } from './stylable-assets';
-import { ImportSymbol } from './stylable-meta';
-import { RefedMixin, SRule, StylableMeta } from './stylable-processor';
-import { CSSResolve } from './stylable-resolver';
-import { StylableTransformer } from './stylable-transformer';
+import type { ImportSymbol } from './stylable-meta';
+import type { RefedMixin, SRule, StylableMeta } from './stylable-processor';
+import type { CSSResolve } from './stylable-resolver';
+import type { StylableTransformer } from './stylable-transformer';
 import { createSubsetAst, isValidDeclaration, mergeRules } from './stylable-utils';
 import { valueMapping } from './stylable-value-parsers';
 

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -1,8 +1,8 @@
-import { FileProcessor } from './cached-process-file';
-import { Diagnostics } from './diagnostics';
-import { ClassSymbol, ElementSymbol, Imported } from './stylable-meta';
-import { ImportSymbol, StylableMeta, StylableSymbol } from './stylable-processor';
-import { StylableTransformer } from './stylable-transformer';
+import type { FileProcessor } from './cached-process-file';
+import type { Diagnostics } from './diagnostics';
+import type { ClassSymbol, ElementSymbol, Imported } from './stylable-meta';
+import type { ImportSymbol, StylableMeta, StylableSymbol } from './stylable-processor';
+import type { StylableTransformer } from './stylable-transformer';
 import { valueMapping } from './stylable-value-parsers';
 
 export const resolverWarnings = {

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -3,9 +3,9 @@ import postcss from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
 import cloneDeep from 'lodash.clonedeep';
 
-import { FileProcessor } from './cached-process-file';
+import type { FileProcessor } from './cached-process-file';
 import { unbox } from './custom-values';
-import { Diagnostics } from './diagnostics';
+import type { Diagnostics } from './diagnostics';
 import { evalDeclarationValue, processDeclarationValue } from './functions';
 import {
     nativePseudoClasses,
@@ -31,7 +31,7 @@ import {
     traverseNode,
 } from './selector-utils';
 import { appendMixins } from './stylable-mixins';
-import {
+import type {
     ClassSymbol,
     ElementSymbol,
     SDecl,

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -1,8 +1,8 @@
 import cloneDeep from 'lodash.clonedeep';
 import { isAbsolute } from 'path';
 import postcss from 'postcss';
-import { Diagnostics } from './diagnostics';
-import {
+import type { Diagnostics } from './diagnostics';
+import type {
     DeclStylableProps,
     Imported,
     SDecl,
@@ -19,7 +19,7 @@ import {
     stringifySelector,
     traverseNode,
 } from './selector-utils';
-import { ImportSymbol } from './stylable-meta';
+import type { ImportSymbol } from './stylable-meta';
 import { valueMapping } from './stylable-value-parsers';
 const replaceRuleSelector = require('postcss-selector-matches/dist/replaceRuleSelector');
 

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -1,8 +1,8 @@
-import postcss from 'postcss';
-import { Diagnostics } from './diagnostics';
+import type postcss from 'postcss';
+import type { Diagnostics } from './diagnostics';
 import { processPseudoStates } from './pseudo-states';
 import { parseSelector } from './selector-utils';
-import { ParsedValue, StateParsedValue } from './types';
+import type { ParsedValue, StateParsedValue } from './types';
 
 const postcssValueParser = require('postcss-value-parser');
 

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -1,4 +1,4 @@
-import { FileProcessor, MinimalFS } from './cached-process-file';
+import type { FileProcessor, MinimalFS } from './cached-process-file';
 import { createInfrastructure } from './create-infra-structure';
 import { Diagnostics } from './diagnostics';
 import { safeParse } from './parser';
@@ -10,8 +10,8 @@ import {
     TransformerOptions,
     TransformHooks,
 } from './stylable-transformer';
-import { TimedCacheOptions } from './timed-cache';
-import { IStylableOptimizer, ModuleResolver } from './types';
+import type { TimedCacheOptions } from './timed-cache';
+import type { IStylableOptimizer, ModuleResolver } from './types';
 
 export interface StylableConfig {
     projectRoot: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
-import postcss from 'postcss';
-import { Box } from './custom-values';
-import { StylableMeta } from './stylable-meta';
-import { StylableResults } from './stylable-transformer';
+import type postcss from 'postcss';
+import type { Box } from './custom-values';
+import type { StylableMeta } from './stylable-meta';
+import type { StylableResults } from './stylable-transformer';
 
 export type PartialObject<T> = Partial<T> & object;
 export type CSSObject = any & object;

--- a/packages/core/test/css-vars.spec.ts
+++ b/packages/core/test/css-vars.spec.ts
@@ -4,7 +4,7 @@ import {
     processSource,
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import { processorWarnings, resolverWarnings } from '../src';
 
 describe('css custom-properties (vars)', () => {

--- a/packages/core/test/custom-selectors.spec.ts
+++ b/packages/core/test/custom-selectors.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableRoot, processSource } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('@custom-selector', () => {
     it('collect custom-selectors', () => {

--- a/packages/core/test/functions.spec.ts
+++ b/packages/core/test/functions.spec.ts
@@ -1,7 +1,7 @@
 import { expectWarningsFromTransform } from '@stylable/core-test-kit';
 import { generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import { functionWarnings } from '../src';
 import { nativeFunctionsDic } from '../src/native-reserved-lists';
 

--- a/packages/core/test/mixins/css-mixins.spec.ts
+++ b/packages/core/test/mixins/css-mixins.spec.ts
@@ -5,7 +5,7 @@ import {
     matchRuleAndDeclaration,
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('CSS Mixins', () => {
     it('apply simple class mixins declarations', () => {

--- a/packages/core/test/mixins/js-mixins.spec.ts
+++ b/packages/core/test/mixins/js-mixins.spec.ts
@@ -4,7 +4,7 @@ import {
     matchRuleAndDeclaration,
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('Javascript Mixins', () => {
     it('simple mixin', () => {

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -7,7 +7,7 @@ import {
     shouldReportNoDiagnostics,
 } from '@stylable/core-test-kit';
 import { expect, use } from 'chai';
-import { AtRule, Declaration, Rule } from 'postcss';
+import type { AtRule, Declaration, Rule } from 'postcss';
 import { processorWarnings, SRule } from '../src';
 import { transformerWarnings } from '../src/stylable-transformer';
 // import { generateStylableResult, processSource } from './utils/generate-test-util';

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -1,9 +1,9 @@
 import { createStylableInstance, generateInfra } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import { createMinimalFS, process, safeParse, StylableResolver } from '../src';
 import { cachedProcessFile, MinimalFS } from '../src/cached-process-file';
-import { StylableMeta } from '../src/stylable-processor';
+import type { StylableMeta } from '../src/stylable-processor';
 
 function createResolveExtendsResults(
     fs: MinimalFS,

--- a/packages/core/test/stylable-transformer/elements.spec.ts
+++ b/packages/core/test/stylable-transformer/elements.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('Stylable transform elements', () => {
     describe('scoped elements', () => {

--- a/packages/core/test/stylable-transformer/general.spec.ts
+++ b/packages/core/test/stylable-transformer/general.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('Stylable postcss transform (General)', () => {
     it('should output empty on empty input', () => {

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableResult, generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('Stylable postcss transform (Global)', () => {
     it('should support :global()', () => {

--- a/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
+++ b/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
@@ -1,6 +1,6 @@
 import { createTransformer } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('post-process-and-hooks', () => {
     it("should call postProcess after transform and use it's return value", () => {

--- a/packages/core/test/stylable-transformer/scope-selector-v2.spec.ts
+++ b/packages/core/test/stylable-transformer/scope-selector-v2.spec.ts
@@ -1,5 +1,5 @@
 import { generateStylableRoot } from '@stylable/core-test-kit';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 function selfTest(
     result: postcss.Root,

--- a/packages/core/test/stylable-transformer/scoping-edge-cases.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping-edge-cases.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 describe('scoping-edge-cases', () => {
     it('root scoping always uses origin meta', () => {

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableRoot } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import { createWarningRule } from '../../src';
 
 describe('Stylable postcss transform (Scoping)', () => {

--- a/packages/core/test/stylable-transformer/value.spec.ts
+++ b/packages/core/test/stylable-transformer/value.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
 import { box, CustomValueExtension, functionWarnings, stTypes } from '@stylable/core';
 import { generateStylableResult, generateStylableRoot } from '@stylable/core-test-kit';

--- a/packages/create-stylable-app/src/create-project.ts
+++ b/packages/create-stylable-app/src/create-project.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { promises } from 'fs';
-import { SpawnOptions } from 'child_process';
+import type { SpawnOptions } from 'child_process';
 import validatePackageName from 'validate-npm-package-name';
 import { statSafe, spawnSafe, directoryDeepChildren, executeWithProgress } from './helpers';
 

--- a/packages/dom-test-kit/src/stylable-dom-util.ts
+++ b/packages/dom-test-kit/src/stylable-dom-util.ts
@@ -5,7 +5,7 @@ import {
     stringifySelector,
     traverseNode,
 } from '@stylable/core';
-import { RuntimeStylesheet, StateValue } from '@stylable/runtime';
+import type { RuntimeStylesheet, StateValue } from '@stylable/runtime';
 
 export interface PartialElement {
     querySelector: Element['querySelector'];

--- a/packages/e2e-test-kit/src/stylable-project-runner.ts
+++ b/packages/e2e-test-kit/src/stylable-project-runner.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { ProjectRunner } from './project-runner';
 
 export class StylableProjectRunner extends ProjectRunner {

--- a/packages/experimental-loader/src/add-meta-dependencies.ts
+++ b/packages/experimental-loader/src/add-meta-dependencies.ts
@@ -1,4 +1,4 @@
-import { StylableMeta, StylableTransformer } from '@stylable/core';
+import type { StylableMeta, StylableTransformer } from '@stylable/core';
 
 export function addMetaDependencies(
     meta: StylableMeta,

--- a/packages/experimental-loader/src/cached-stylable-factory.ts
+++ b/packages/experimental-loader/src/cached-stylable-factory.ts
@@ -1,5 +1,5 @@
 import { Stylable, StylableConfig } from '@stylable/core';
-import { Compiler } from 'webpack';
+import type { Compiler } from 'webpack';
 
 const stylableInstancesCache = new WeakMap<Compiler, Map<Stylable, StylableConfig>>();
 

--- a/packages/experimental-loader/src/create-runtime-target-code.ts
+++ b/packages/experimental-loader/src/create-runtime-target-code.ts
@@ -1,4 +1,4 @@
-import { StylableExports } from '@stylable/core';
+import type { StylableExports } from '@stylable/core';
 
 export function createRuntimeTargetCode(namespace: string, mapping: StylableExports) {
     return `

--- a/packages/experimental-loader/src/stylable-runtime-loader.ts
+++ b/packages/experimental-loader/src/stylable-runtime-loader.ts
@@ -1,5 +1,5 @@
-import { loader } from 'webpack';
-import { StylableExports } from '@stylable/core';
+import type { loader } from 'webpack';
+import type { StylableExports } from '@stylable/core';
 import { createRuntimeTargetCode } from './create-runtime-target-code';
 
 function evalStylableExtractModule(source: string): [string, StylableExports] {

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -1,6 +1,6 @@
 import { Stylable, processNamespace, StylableResults } from '@stylable/core';
 import { StylableOptimizer } from '@stylable/optimizer';
-import { loader } from 'webpack';
+import type { loader } from 'webpack';
 import { getOptions, isUrlRequest, stringifyRequest } from 'loader-utils';
 import { Warning } from './warning';
 import postcss from 'postcss';

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -1,4 +1,4 @@
-import { StylableConfig } from '@stylable/core';
+import type { StylableConfig } from '@stylable/core';
 import { Options, stylableModuleFactory } from '@stylable/module-utils';
 import fs from 'fs';
 

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -1,7 +1,7 @@
 import path from 'path';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
-import ts from 'typescript';
+import type ts from 'typescript';
 
 import {
     ClassSymbol,
@@ -21,7 +21,7 @@ import {
     VarSymbol,
 } from '@stylable/core';
 
-import { IFileSystem } from '@file-services/types';
+import type { IFileSystem } from '@file-services/types';
 import {
     classCompletion,
     codeMixinCompletion,
@@ -52,9 +52,9 @@ import {
     isDirective,
     isInValue,
 } from './provider';
-import { ExtendedTsLanguageService } from './types';
+import type { ExtendedTsLanguageService } from './types';
 import { isComment, isDeclaration } from './utils/postcss-ast-utils';
-import { CursorPosition, SelectorChunk } from './utils/selector-analyzer';
+import type { CursorPosition, SelectorChunk } from './utils/selector-analyzer';
 
 const { hasOwnProperty } = Object.prototype;
 

--- a/packages/language-service/src/lib/completion-types.ts
+++ b/packages/language-service/src/lib/completion-types.ts
@@ -1,5 +1,5 @@
 import { valueMapping } from '@stylable/core';
-import { ProviderRange } from './completion-providers';
+import type { ProviderRange } from './completion-providers';
 
 export class Completion {
     constructor(

--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -1,6 +1,6 @@
-import { IFileSystem } from '@file-services/types';
+import type { IFileSystem } from '@file-services/types';
 import path from 'path';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 import { getCSSLanguageService, Stylesheet } from 'vscode-css-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {

--- a/packages/language-service/src/lib/dedupe-refs.ts
+++ b/packages/language-service/src/lib/dedupe-refs.ts
@@ -1,4 +1,4 @@
-import { Location } from 'vscode-languageserver-types';
+import type { Location } from 'vscode-languageserver-types';
 
 export function dedupeRefs(refs: Location[]): Location[] {
     const res: Location[] = [];

--- a/packages/language-service/src/lib/diagnosis.ts
+++ b/packages/language-service/src/lib/diagnosis.ts
@@ -1,6 +1,6 @@
 import { Diagnostic as StylableDiagnostic, process, safeParse, Stylable } from '@stylable/core';
 import { Diagnostic, Range } from 'vscode-languageserver-types';
-import { CssService } from './css-service';
+import type { CssService } from './css-service';
 
 export function createDiagnosis(
     content: string,

--- a/packages/language-service/src/lib/feature/color-provider.ts
+++ b/packages/language-service/src/lib/feature/color-provider.ts
@@ -1,11 +1,11 @@
-import { IFileSystem } from '@file-services/types';
+import type { IFileSystem } from '@file-services/types';
 import { evalDeclarationValue, Stylable, valueMapping } from '@stylable/core';
-import { Color, ColorInformation, ColorPresentation } from 'vscode-css-languageservice';
-import { ColorPresentationParams } from 'vscode-languageserver-protocol';
+import type { Color, ColorInformation, ColorPresentation } from 'vscode-css-languageservice';
+import type { ColorPresentationParams } from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { ProviderPosition, ProviderRange } from '../completion-providers';
-import { CssService } from '../css-service';
+import type { CssService } from '../css-service';
 import { fixAndProcess } from '../provider';
 
 export function resolveDocumentColors(

--- a/packages/language-service/src/lib/feature/formatting.ts
+++ b/packages/language-service/src/lib/feature/formatting.ts
@@ -1,6 +1,6 @@
 import { css } from 'js-beautify';
-import { TextDocument, Range } from 'vscode-languageserver-textdocument';
-import { FormattingOptions } from 'vscode-languageserver';
+import type { TextDocument, Range } from 'vscode-languageserver-textdocument';
+import type { FormattingOptions } from 'vscode-languageserver';
 
 export interface JSBeautifyFormatCSSOptions {
     indent_size?: number;

--- a/packages/language-service/src/lib/feature/pseudo-class.ts
+++ b/packages/language-service/src/lib/feature/pseudo-class.ts
@@ -1,7 +1,11 @@
 import postcssValueParser from 'postcss-value-parser';
-import { ParameterInformation, SignatureHelp, SignatureInformation } from 'vscode-languageserver';
+import type {
+    ParameterInformation,
+    SignatureHelp,
+    SignatureInformation,
+} from 'vscode-languageserver';
 import { StateParsedValue, systemValidators } from '@stylable/core';
-import { ProviderPosition } from '../completion-providers';
+import type { ProviderPosition } from '../completion-providers';
 
 // Goes over an '-st-states' declaration value
 // parses the state and position to resolve if inside a state with a parameter

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import ts from 'typescript';
 import postcss from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
-import { IFileSystem, IFileSystemDescriptor } from '@file-services/types';
+import type { IFileSystem, IFileSystemDescriptor } from '@file-services/types';
 import {
     ClassSymbol,
     CSSResolve,
@@ -19,7 +19,7 @@ import {
     StylableTransformer,
     valueMapping,
 } from '@stylable/core';
-import {
+import type {
     Location,
     ParameterInformation,
     Position,
@@ -51,14 +51,14 @@ import {
     ValueCompletionProvider,
     ValueDirectiveProvider,
 } from './completion-providers';
-import { Completion } from './completion-types';
+import type { Completion } from './completion-types';
 import {
     createStateTypeSignature,
     createStateValidatorSignature,
     resolveStateParams,
     resolveStateTypeOrValidator,
 } from './feature/pseudo-class';
-import { ExtendedTsLanguageService } from './types';
+import type { ExtendedTsLanguageService } from './types';
 import { isInNode, isRoot, isSelector, pathFromPosition } from './utils/postcss-ast-utils';
 import {
     parseSelector,

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -1,6 +1,6 @@
-import { IFileSystem, IFileSystemStats } from '@file-services/types';
+import type { IFileSystem, IFileSystemStats } from '@file-services/types';
 import { Stylable, safeParse } from '@stylable/core';
-import { ColorPresentationParams } from 'vscode-languageserver-protocol';
+import type { ColorPresentationParams } from 'vscode-languageserver-protocol';
 import { Range, TextDocument } from 'vscode-languageserver-textdocument';
 import {
     Color,
@@ -20,7 +20,7 @@ import {
 import { URI } from 'vscode-uri';
 
 import { ProviderPosition, ProviderRange } from './completion-providers';
-import { Completion } from './completion-types';
+import type { Completion } from './completion-types';
 import { CssService } from './css-service';
 import { dedupeRefs } from './dedupe-refs';
 import { createDiagnosis } from './diagnosis';
@@ -32,7 +32,7 @@ import {
 } from './feature/formatting';
 import { Provider } from './provider';
 import { getRefs, getRenameRefs } from './provider';
-import { ExtendedTsLanguageService } from './types';
+import type { ExtendedTsLanguageService } from './types';
 import { typescriptSupport } from './typescript-support';
 
 export interface StylableLanguageServiceOptions {

--- a/packages/language-service/src/lib/types.ts
+++ b/packages/language-service/src/lib/types.ts
@@ -1,5 +1,5 @@
-import ts from 'typescript';
-import {
+import type ts from 'typescript';
+import type {
     Command,
     CompletionItem,
     Diagnostic,
@@ -10,7 +10,10 @@ import {
     Range,
     TextEdit,
 } from 'vscode-languageserver';
-import { ColorPresentationRequest, DocumentColorRequest } from 'vscode-languageserver-protocol';
+import type {
+    ColorPresentationRequest,
+    DocumentColorRequest,
+} from 'vscode-languageserver-protocol';
 
 export interface NotificationTypes {
     // TODO: remove me?

--- a/packages/language-service/src/lib/typescript-support.ts
+++ b/packages/language-service/src/lib/typescript-support.ts
@@ -1,7 +1,7 @@
-import { IFileSystem } from '@file-services/types';
+import type { IFileSystem } from '@file-services/types';
 import { createBaseHost, createLanguageServiceHost } from '@file-services/typescript';
 import ts from 'typescript';
-import { ExtendedTsLanguageService } from './types';
+import type { ExtendedTsLanguageService } from './types';
 
 export function typescriptSupport(fileSystem: IFileSystem) {
     let openedFiles: string[] = [];

--- a/packages/language-service/src/lib/utils/postcss-ast-utils.ts
+++ b/packages/language-service/src/lib/utils/postcss-ast-utils.ts
@@ -1,5 +1,5 @@
-import postcss from 'postcss';
-import { ProviderPosition } from '../completion-providers';
+import type postcss from 'postcss';
+import type { ProviderPosition } from '../completion-providers';
 
 export function isInNode(
     position: ProviderPosition,

--- a/packages/language-service/test-kit/asserters.ts
+++ b/packages/language-service/test-kit/asserters.ts
@@ -1,7 +1,7 @@
 import fs from '@file-services/node';
 import * as path from 'path';
-import { NodeBase } from 'postcss';
-import { ColorInformation } from 'vscode-css-languageservice';
+import type { NodeBase } from 'postcss';
+import type { ColorInformation } from 'vscode-css-languageservice';
 import {
     Color,
     ColorPresentation,

--- a/packages/language-service/test/lib/colors.spec.ts
+++ b/packages/language-service/test/lib/colors.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Color } from 'vscode-languageserver-protocol';
+import type { Color } from 'vscode-languageserver-protocol';
 import { createRange } from '../../src/lib/completion-providers';
 import { getDocColorPresentation, getDocumentColors } from '../../test-kit/asserters';
 

--- a/packages/language-service/test/lib/completions/custom-selectors.spec.ts
+++ b/packages/language-service/test/lib/completions/custom-selectors.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Custom Selectors', () => {

--- a/packages/language-service/test/lib/completions/formatters.spec.ts
+++ b/packages/language-service/test/lib/completions/formatters.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Formatters', () => {

--- a/packages/language-service/test/lib/completions/globals.spec.ts
+++ b/packages/language-service/test/lib/completions/globals.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Global scope reference', () => {

--- a/packages/language-service/test/lib/completions/imported-values.spec.ts
+++ b/packages/language-service/test/lib/completions/imported-values.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Imported Values', () => {

--- a/packages/language-service/test/lib/completions/mixins.spec.ts
+++ b/packages/language-service/test/lib/completions/mixins.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Mixins', () => {

--- a/packages/language-service/test/lib/completions/named-values.spec.ts
+++ b/packages/language-service/test/lib/completions/named-values.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Named Values', () => {

--- a/packages/language-service/test/lib/completions/pseudo-elements.spec.ts
+++ b/packages/language-service/test/lib/completions/pseudo-elements.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('Pseudo-elements', () => {

--- a/packages/language-service/test/lib/completions/states.spec.ts
+++ b/packages/language-service/test/lib/completions/states.spec.ts
@@ -1,5 +1,5 @@
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import { Completion } from '../../../src/lib/completion-types';
+import type { Completion } from '../../../src/lib/completion-types';
 import * as asserters from '../../../test-kit/completions-asserters';
 
 describe('States', () => {

--- a/packages/module-utils/src/module-source.ts
+++ b/packages/module-utils/src/module-source.ts
@@ -1,4 +1,4 @@
-import { StylableResults } from '@stylable/core';
+import type { StylableResults } from '@stylable/core';
 
 export function generateModuleSource(
     stylableResult: StylableResults,

--- a/packages/module-utils/test/test-kit.ts
+++ b/packages/module-utils/test/test-kit.ts
@@ -1,7 +1,7 @@
 import { createMemoryFileSystemWithFiles } from '@stylable/e2e-test-kit';
 import { create } from '@stylable/runtime';
 import { stylableModuleFactory } from '../src';
-import { Options } from '../src/module-factory';
+import type { Options } from '../src/module-factory';
 
 function evalModule(id: string, source: string, requireModule: (s: string) => any) {
     if (!source) {

--- a/packages/node/src/require-hook.ts
+++ b/packages/node/src/require-hook.ts
@@ -1,4 +1,4 @@
-import { StylableConfig } from '@stylable/core';
+import type { StylableConfig } from '@stylable/core';
 import { stylableModuleFactory } from '@stylable/module-utils';
 import fs from 'fs';
 import { resolveNamespace } from './resolve-namespace';

--- a/packages/optimizer/src/classname-optimizer.ts
+++ b/packages/optimizer/src/classname-optimizer.ts
@@ -5,7 +5,7 @@ import {
     stringifySelector,
     traverseNode,
 } from '@stylable/core';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 export class StylableClassNameOptimizer implements IStylableClassNameOptimizer {
     public context: { names: Record<string, string> };

--- a/packages/optimizer/src/namespace-optimizer.ts
+++ b/packages/optimizer/src/namespace-optimizer.ts
@@ -1,4 +1,4 @@
-import { IStylableNamespaceOptimizer, StylableMeta } from '@stylable/core';
+import type { IStylableNamespaceOptimizer, StylableMeta } from '@stylable/core';
 
 export class StylableNamespaceOptimizer implements IStylableNamespaceOptimizer {
     public index: number;

--- a/packages/runtime/src/cached-node-renderer.ts
+++ b/packages/runtime/src/cached-node-renderer.ts
@@ -1,4 +1,4 @@
-import { NodeRenderer, RenderableStylesheet } from './types';
+import type { NodeRenderer, RenderableStylesheet } from './types';
 
 export interface CachedNodeRendererOptions {
     createElement: typeof document.createElement;

--- a/packages/runtime/src/css-runtime-renderer.ts
+++ b/packages/runtime/src/css-runtime-renderer.ts
@@ -1,6 +1,6 @@
 import { CacheStyleNodeRenderer } from './cached-node-renderer';
 import { createDOMListRenderer, DOMListRenderer } from './keyed-list-renderer';
-import { RenderableStylesheet } from './types';
+import type { RenderableStylesheet } from './types';
 
 declare global {
     interface Window {

--- a/packages/runtime/src/css-runtime-stylesheet.ts
+++ b/packages/runtime/src/css-runtime-stylesheet.ts
@@ -1,5 +1,5 @@
-import { RuntimeRenderer } from './css-runtime-renderer';
-import { RuntimeStylesheet, StateMap, StateValue, StylableExports } from './types';
+import type { RuntimeRenderer } from './css-runtime-renderer';
+import type { RuntimeStylesheet, StateMap, StateValue, StylableExports } from './types';
 
 const stateMiddleDelimiter = '-';
 const booleanStateDelimiter = '--';

--- a/packages/runtime/src/keyed-list-renderer.ts
+++ b/packages/runtime/src/keyed-list-renderer.ts
@@ -1,4 +1,4 @@
-import { NodeRenderer } from './types';
+import type { NodeRenderer } from './types';
 
 export interface DOMListRenderer<I, O extends Element, C extends Element = Element> {
     nodes: { [key: string]: O };

--- a/packages/runtime/test/unit/keyed-list-renderer.spec.ts
+++ b/packages/runtime/test/unit/keyed-list-renderer.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { JSDOM } from 'jsdom';
 import { createDOMListRenderer, DOMListRenderer } from '../../src/keyed-list-renderer';
-import { NodeRenderer } from '../../src/types';
+import type { NodeRenderer } from '../../src/types';
 
 interface TestNode {
     key: string;

--- a/packages/schema-extract/src/types.ts
+++ b/packages/schema-extract/src/types.ts
@@ -1,4 +1,4 @@
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 
 export const stylableModule = 'stylable/module';
 export const stylableClass = 'stylable/class';

--- a/packages/uni-driver/src/uni-driver.ts
+++ b/packages/uni-driver/src/uni-driver.ts
@@ -1,4 +1,4 @@
-import { ElementRemoteApi, MinimalStylesheet, StateValue } from './types';
+import type { ElementRemoteApi, MinimalStylesheet, StateValue } from './types';
 
 const stateMiddleDelimiter = '-';
 

--- a/packages/webpack-extensions/src/compile-as-entry.ts
+++ b/packages/webpack-extensions/src/compile-as-entry.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import type webpack from 'webpack';
 
 const NativeModule = require('module');
 const NodeTemplatePlugin = require('webpack/lib/node/NodeTemplatePlugin');

--- a/packages/webpack-extensions/src/create-metadata-stylesheet.ts
+++ b/packages/webpack-extensions/src/create-metadata-stylesheet.ts
@@ -6,7 +6,7 @@ import {
     CSSResolve,
     JSResolve,
 } from '@stylable/core';
-import { Rule, ChildNode } from 'postcss';
+import type { Rule, ChildNode } from 'postcss';
 import { hashContent } from './hash-content-util';
 
 export function createMetadataForStylesheet(

--- a/packages/webpack-extensions/src/remove-unused-css-modules.ts
+++ b/packages/webpack-extensions/src/remove-unused-css-modules.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import type webpack from 'webpack';
 
 export class RemoveUnusedCSSModules {
     public apply(compiler: webpack.Compiler) {

--- a/packages/webpack-extensions/src/stylable-forcestates-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-forcestates-plugin.ts
@@ -7,7 +7,7 @@ import {
     traverseNode,
 } from '@stylable/core';
 import cloneDeep from 'lodash.clonedeep';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 // This transformation is applied on target AST code
 // Not Stylable source AST

--- a/packages/webpack-extensions/src/stylable-html-snapshot.ts
+++ b/packages/webpack-extensions/src/stylable-html-snapshot.ts
@@ -1,5 +1,5 @@
 import { basename, join } from 'path';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { compileAsEntry, exec } from './compile-as-entry';
 

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { createMetadataForStylesheet } from './create-metadata-stylesheet';
 import { Stylable } from '@stylable/core';

--- a/packages/webpack-extensions/src/stylable-metadata-loader.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-loader.ts
@@ -1,5 +1,5 @@
 import { Stylable, StylableMeta, processNamespace } from '@stylable/core';
-import { loader as webpackLoader } from 'webpack';
+import type { loader as webpackLoader } from 'webpack';
 import findConfig from 'find-config';
 import { getOptions } from 'loader-utils';
 import { createMetadataForStylesheet, ResolvedImport } from './create-metadata-stylesheet';

--- a/packages/webpack-extensions/src/stylable-metadata-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-plugin.ts
@@ -1,6 +1,6 @@
 import { findFiles } from '@stylable/node';
 import { dirname, join } from 'path';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { compileAsEntry, exec } from './compile-as-entry';
 import { ComponentConfig, ComponentMetadataBuilder } from './component-metadata-builder';

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.config.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.config.ts
@@ -1,6 +1,6 @@
 import { StylableManifestPlugin } from '../../../../src/stylable-manifest-plugin';
 import { stylableLoaders } from '@stylable/experimental-loader';
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 
 const config: Configuration = {
     mode: 'development',

--- a/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/webpack.config.ts
+++ b/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/webpack.config.ts
@@ -1,6 +1,6 @@
 import { StylableWebpackPlugin } from '@stylable/webpack-plugin';
 import { metadataLoaderLocation } from '@stylable/webpack-extensions';
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 const config: Configuration = {
     mode: 'development',
     context: __dirname,

--- a/packages/webpack-extensions/test/unit/forcestates-plugin.spec.ts
+++ b/packages/webpack-extensions/test/unit/forcestates-plugin.spec.ts
@@ -1,6 +1,6 @@
 import { generateStylableResult } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import postcss from 'postcss';
+import type postcss from 'postcss';
 
 import {
     applyStylableForceStateSelectors,

--- a/packages/webpack-plugin/src/get-module-in-graph.ts
+++ b/packages/webpack-plugin/src/get-module-in-graph.ts
@@ -1,5 +1,5 @@
-import webpack from 'webpack';
-import { StylableModule } from './types';
+import type webpack from 'webpack';
+import type { StylableModule } from './types';
 
 const earlyReturn = Symbol('earlyReturn');
 

--- a/packages/webpack-plugin/src/is-loaded-by-loaders.ts
+++ b/packages/webpack-plugin/src/is-loaded-by-loaders.ts
@@ -1,4 +1,4 @@
-import { StylableModule } from './types';
+import type { StylableModule } from './types';
 
 export function isLoadedByLoaders(module: StylableModule, warn: (m: StylableModule) => void) {
     let isSupportedLoader = false;

--- a/packages/webpack-plugin/src/plugin-options.ts
+++ b/packages/webpack-plugin/src/plugin-options.ts
@@ -1,5 +1,5 @@
-import webpack from 'webpack';
-import { ShallowPartial, StylableWebpackPluginOptions } from './types';
+import type webpack from 'webpack';
+import type { ShallowPartial, StylableWebpackPluginOptions } from './types';
 
 export function normalizeOptions(
     options: ShallowPartial<StylableWebpackPluginOptions>,

--- a/packages/webpack-plugin/src/stylable-bootstrap-module.ts
+++ b/packages/webpack-plugin/src/stylable-bootstrap-module.ts
@@ -1,10 +1,10 @@
 import { EOL } from 'os';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { WEBPACK_STYLABLE } from './runtime-dependencies';
 import { StylableImportDependency } from './stylable-dependencies';
 import { getStylableModulesFromDependencies, renderStaticCSS } from './stylable-module-helpers';
-import { StylableModule, StylableWebpackPluginOptions } from './types';
+import type { StylableModule, StylableWebpackPluginOptions } from './types';
 const Module = require('webpack/lib/Module');
 
 export class StylableBootstrapModule extends Module {

--- a/packages/webpack-plugin/src/stylable-dependencies.ts
+++ b/packages/webpack-plugin/src/stylable-dependencies.ts
@@ -1,4 +1,4 @@
-import { StylableModule } from './types';
+import type { StylableModule } from './types';
 
 const NullDependency = require('webpack/lib/dependencies/NullDependency');
 const ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');

--- a/packages/webpack-plugin/src/stylable-generator.ts
+++ b/packages/webpack-plugin/src/stylable-generator.ts
@@ -1,9 +1,9 @@
-import { Stylable, StylableMeta, StylableResults } from '@stylable/core';
+import type { Stylable, StylableMeta, StylableResults } from '@stylable/core';
 import { generateModuleSource } from '@stylable/module-utils';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { OriginalSource, ReplaceSource } from 'webpack-sources';
 import { WEBPACK_STYLABLE } from './runtime-dependencies';
-import { StylableGeneratorOptions, StylableModule, WebpackAssetModule } from './types';
+import type { StylableGeneratorOptions, StylableModule, WebpackAssetModule } from './types';
 export class StylableGenerator {
     constructor(
         private stylable: Stylable,

--- a/packages/webpack-plugin/src/stylable-module-helpers.ts
+++ b/packages/webpack-plugin/src/stylable-module-helpers.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import webpack from 'webpack';
-import { CalcResult, StylableModule } from './types';
+import type webpack from 'webpack';
+import type { CalcResult, StylableModule } from './types';
 
 type MultiMap<K extends object, V> = Map<K, V> | WeakMap<K, V>;
 

--- a/packages/webpack-plugin/src/stylable-parser.ts
+++ b/packages/webpack-plugin/src/stylable-parser.ts
@@ -7,14 +7,14 @@ import {
     StylableResults,
 } from '@stylable/core';
 import path from 'path';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { isLoadedByLoaders } from './is-loaded-by-loaders';
 import {
     StylableAssetDependency,
     StylableExportsDependency,
     StylableImportDependency,
 } from './stylable-dependencies';
-import { StylableModule } from './types';
+import type { StylableModule } from './types';
 
 const stylableExtension = /\.st\.css$/;
 export class StylableParser {

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -9,7 +9,7 @@ import {
 import { resolveNamespace } from '@stylable/node';
 import { StylableOptimizer } from '@stylable/optimizer';
 import { EOL } from 'os';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { getModuleInGraph, hasStylableModuleInGraph } from './get-module-in-graph';
 import { normalizeOptions } from './plugin-options';
@@ -26,7 +26,7 @@ import {
     StylableAutoInitDependency,
     StylableAutoInitDependencyTemplate,
 } from './stylable-auto-init-dependency';
-import {
+import type {
     CalcResult,
     ShallowPartial,
     StylableModule,

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -1,12 +1,12 @@
-import {
+import type {
     Stylable,
     StylableMeta,
     StylableResults,
     TransformHooks,
     StylableExports,
 } from '@stylable/core';
-import { StylableOptimizer } from '@stylable/optimizer';
-import webpack from 'webpack';
+import type { StylableOptimizer } from '@stylable/optimizer';
+import type webpack from 'webpack';
 
 export interface StylableWebpackPluginOptions {
     filename: string;

--- a/packages/webpack-plugin/src/utils.ts
+++ b/packages/webpack-plugin/src/utils.ts
@@ -1,5 +1,5 @@
-import webpack from 'webpack';
-import { StylableModule } from './types';
+import type webpack from 'webpack';
+import type { StylableModule } from './types';
 
 export function isImportedByNonStylable(module: { reasons: Array<{ module: { type: string } }> }) {
     return module.reasons.some(({ module }) => module && module.type !== 'stylable');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     "noUnusedParameters": true,               /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
+    "importsNotUsedAsValues": "error",
 
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */


### PR DESCRIPTION
- forces us to use `import type` when the imported symbol is not used as value.
- the `import type` statements bump min `typescript` to 3.8+. might want to consider running `downlevel-dts` on @stylable/runtime.