### PR TITLE
Experimental-loader: add exportsOnly mode for transform loader

### DIFF
--- a/packages/experimental-loader/README.md
+++ b/packages/experimental-loader/README.md
@@ -56,7 +56,7 @@ module.exports = {
 interface LoaderOptions {
   resolveNamespace?(namespace: string, filePath: string): string;
   filterUrls?(url: string, ctx: loader.LoaderContext): boolean;
-  exportsOnly: boolean;
+  exportsOnly?: boolean;
 }
 ```
 

--- a/packages/experimental-loader/README.md
+++ b/packages/experimental-loader/README.md
@@ -56,6 +56,7 @@ module.exports = {
 interface LoaderOptions {
   resolveNamespace?(namespace: string, filePath: string): string;
   filterUrls?(url: string, ctx: loader.LoaderContext): boolean;
+  exportsOnly: boolean;
 }
 ```
 
@@ -63,6 +64,20 @@ interface LoaderOptions {
 | ------------------ | --------------------------------------------- |
 | `resolveNamespace` | override default stylesheet namespace process |
 | `filterUrls`       | filter urls from webpack process              |
+| `exportsOnly`      | only export the runtime stylesheet            |
+
+## SSR (exportsOnly)
+
+Sometimes for server pre-rendering build, you don't want to extract css for stylable files and only export the runtime stylesheet. For that case you only need the `transform` loader and enable `exportsOnly` mode.
+
+```js
+{
+  test: /\.st\.css$/i,
+  use: [
+    stylableLoaders.transform({ exportsOnly: true }),
+  ],
+}
+```
 
 ## Known issues
 

--- a/packages/experimental-loader/README.md
+++ b/packages/experimental-loader/README.md
@@ -68,7 +68,7 @@ interface LoaderOptions {
 
 ## SSR (exportsOnly)
 
-Sometimes for server pre-rendering build, you don't want to extract css for stylable files and only export the runtime stylesheet. For that case you only need the `transform` loader and enable `exportsOnly` mode.
+When building Stylable for consumption in a server-side renderer build, you may want to extract only the exports of the runtime stylesheets and not the content of their CSS. In such a case you would only be required to use the `transform` loader and  the `exportsOnly` option.
 
 ```js
 {

--- a/packages/experimental-loader/src/create-runtime-target-code.ts
+++ b/packages/experimental-loader/src/create-runtime-target-code.ts
@@ -1,0 +1,15 @@
+import { StylableExports } from '@stylable/core';
+
+export function createRuntimeTargetCode(namespace: string, mapping: StylableExports) {
+    return `
+  const rt = require("@stylable/runtime/cjs/css-runtime-stylesheet.js");
+
+  module.exports = rt.create(
+      ${JSON.stringify(namespace)},
+      ${JSON.stringify(mapping)},
+      "",
+      -1,
+      module.id,
+  );
+  `;
+}

--- a/packages/experimental-loader/src/stylable-runtime-loader.ts
+++ b/packages/experimental-loader/src/stylable-runtime-loader.ts
@@ -1,6 +1,8 @@
 import { loader } from 'webpack';
+import { StylableExports } from '@stylable/core';
+import { createRuntimeTargetCode } from './create-runtime-target-code';
 
-function evalStylableExtractModule(source: string): [string, Record<string, unknown>] {
+function evalStylableExtractModule(source: string): [string, StylableExports] {
     if (!source) {
         throw new Error('No source is provided to evalModule');
     }
@@ -15,7 +17,7 @@ function evalStylableExtractModule(source: string): [string, Record<string, unkn
         source.replace('export default ', 'module.exports = ')
     );
     fn(_module, _module.exports);
-    return _module.exports as [string, Record<string, unknown>];
+    return _module.exports as [string, StylableExports];
 }
 
 const stylableRuntimeLoader: loader.Loader = function loader(content) {
@@ -25,17 +27,7 @@ const stylableRuntimeLoader: loader.Loader = function loader(content) {
 
     const [namespace, mapping] = evalStylableExtractModule(content);
 
-    return `
-  const rt = require("@stylable/runtime/cjs/css-runtime-stylesheet.js");
-
-  module.exports = rt.create(
-      ${JSON.stringify(namespace)},
-      ${JSON.stringify(mapping)},
-      "",
-      -1,
-      module.id,
-  );
-  `;
+    return createRuntimeTargetCode(namespace, mapping);
 };
 
 export const loaderPath = __filename;

--- a/packages/experimental-loader/test/exports-only-mode.spec.ts
+++ b/packages/experimental-loader/test/exports-only-mode.spec.ts
@@ -1,0 +1,38 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'exports-only-mode';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                // headless: false,
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('load the stylable exports', async () => {
+        const { page } = await projectRunner.openInBrowser();
+        const { classes, styleFunctionType } = await page.evaluate(() => {
+            const classes = document.querySelector('.exports-classes')!.textContent;
+            const styleFunctionType = document.querySelector('.exports-style-function')!
+                .textContent;
+
+            return {
+                classes,
+                styleFunctionType,
+            };
+        });
+        expect(JSON.parse(String(classes))).to.eql({
+            root: 'index__root',
+        });
+
+        expect(styleFunctionType).to.eql('function');
+    });
+});

--- a/packages/experimental-loader/test/projects/exports-only-mode/index.js
+++ b/packages/experimental-loader/test/projects/exports-only-mode/index.js
@@ -1,0 +1,6 @@
+import { classes, st } from './index.st.css';
+
+document.body.innerHTML = `
+    <div class="exports-classes">${JSON.stringify(classes)}</div>
+    <div class="exports-style-function">${typeof st}</div>
+`;

--- a/packages/experimental-loader/test/projects/exports-only-mode/index.st.css
+++ b/packages/experimental-loader/test/projects/exports-only-mode/index.st.css
@@ -1,0 +1,3 @@
+.root {
+    color: red;
+}

--- a/packages/experimental-loader/test/projects/exports-only-mode/webpack.config.ts
+++ b/packages/experimental-loader/test/projects/exports-only-mode/webpack.config.ts
@@ -1,0 +1,24 @@
+import HTMLWebpackPlugin from 'html-webpack-plugin';
+import { stylableLoaders } from '../../../src';
+import { noCollisionNamespace } from '@stylable/core';
+
+module.exports = {
+    mode: 'development',
+    entry: './index.js',
+    context: __dirname,
+    devtool: false,
+    plugins: [new HTMLWebpackPlugin()],
+    module: {
+        rules: [
+            {
+                test: /\.st\.css$/i,
+                use: [
+                    stylableLoaders.transform({
+                        resolveNamespace: noCollisionNamespace(),
+                        exportsOnly: true,
+                    }),
+                ],
+            },
+        ],
+    },
+};


### PR DESCRIPTION
Allow SSR builds to not extract css and get only the runtime stylesheet exported 