### PR TITLE
Barak/st scope annotation

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -181,12 +181,12 @@ export class StylableProcessor {
 
             if (scopingRule.selector) {
                 atRule.walkRules((rule) => {
-                    rule.replaceWith(
-                        rule.clone({
-                            selector: scopeSelector(scopingRule.selector, rule.selector, false)
-                                .selector,
-                        })
-                    );
+                    const scopedRule = rule.clone({
+                        selector: scopeSelector(scopingRule.selector, rule.selector, false)
+                            .selector,
+                    });
+                    (scopedRule as SRule).stScope = atRule.params;
+                    rule.replaceWith(scopedRule);
                 });
             }
 
@@ -792,6 +792,7 @@ export interface SRule extends postcss.Rule {
     isSimpleSelector: boolean;
     selectorType: 'class' | 'element' | 'complex';
     mixins?: RefedMixin[];
+    stScope?: string;
 }
 
 // TODO: maybe put under stylable namespace object in v2

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -185,7 +185,7 @@ export class StylableProcessor {
                         selector: scopeSelector(scopingRule.selector, rule.selector, false)
                             .selector,
                     });
-                    (scopedRule as SRule).stScope = atRule.params;
+                    (scopedRule as SRule).stScopeSelector = atRule.params;
                     rule.replaceWith(scopedRule);
                 });
             }
@@ -792,7 +792,7 @@ export interface SRule extends postcss.Rule {
     isSimpleSelector: boolean;
     selectorType: 'class' | 'element' | 'complex';
     mixins?: RefedMixin[];
-    stScope?: string;
+    stScopeSelector?: string;
 }
 
 // TODO: maybe put under stylable namespace object in v2

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -46,7 +46,9 @@ describe('@st-scope', () => {
             );
 
             shouldReportNoDiagnostics(meta);
-            expect((meta.ast.nodes![0] as SRule).stScope).to.equal('.root');
+            const rule = meta.ast.nodes![0] as SRule;
+            expect(rule.stScope).to.equal('.root');
+            expect(rule.clone().stScope, 'clone rules preserve stScope').to.equal('.root');
         });
 
         it('should parse "@st-scope" directives with a new class', () => {

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@stylable/core-test-kit';
 import { expect, use } from 'chai';
 import { AtRule, Declaration, Rule } from 'postcss';
-import { processorWarnings } from '../src';
+import { processorWarnings, SRule } from '../src';
 import { transformerWarnings } from '../src/stylable-transformer';
 // import { generateStylableResult, processSource } from './utils/generate-test-util';
 
@@ -34,6 +34,19 @@ describe('@st-scope', () => {
                     params: '.root',
                 },
             ]);
+        });
+        it('should annotate rules under "@st-scope"', () => {
+            const meta = processSource(
+                `
+                @st-scope .root{
+                    .part {}
+                }
+            `,
+                { from: 'path/to/style.css' }
+            );
+
+            shouldReportNoDiagnostics(meta);
+            expect((meta.ast.nodes![0] as SRule).stScope).to.equal('.root');
         });
 
         it('should parse "@st-scope" directives with a new class', () => {

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -47,8 +47,8 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
             const rule = meta.ast.nodes![0] as SRule;
-            expect(rule.stScope).to.equal('.root');
-            expect(rule.clone().stScope, 'clone rules preserve stScope').to.equal('.root');
+            expect(rule.stScopeSelector).to.equal('.root');
+            expect(rule.clone().stScopeSelector, 'clone rules preserve stScope').to.equal('.root');
         });
 
         it('should parse "@st-scope" directives with a new class', () => {


### PR DESCRIPTION
Allow editing tools to identify rule that used to be under `@st-scope` 