### PR TITLE
Add support for content hash in webpack css output

### DIFF
--- a/packages/webpack-plugin/src/hash-content-util.ts
+++ b/packages/webpack-plugin/src/hash-content-util.ts
@@ -1,0 +1,8 @@
+const createHash = require('webpack/lib/util/createHash');
+
+export function hashContent(source: string, length?: number) {
+    const hash = createHash('sha1');
+    hash.update(source || '');
+    const hashId = hash.digest('hex');
+    return length !== undefined ? hashId.slice(0, length) : hashId;
+}

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -36,6 +36,7 @@ import {
 import { isImportedByNonStylable, rewriteUrl, isStylableModule } from './utils';
 import { dirname } from 'path';
 import findConfig from 'find-config';
+import { hashContent } from '@stylable/webpack-extensions/src';
 
 const { connectChunkAndModule } = require('webpack/lib/GraphHelpers');
 const MultiModule = require('webpack/lib/MultiModule');
@@ -335,11 +336,14 @@ export class StylableWebpackPlugin {
                     compilation.mainTemplate,
                     chunk.hash || compilation.hash
                 );
+                const source = cssSources.join(EOL);
+                
                 const cssBundleFilename = compilation.getPath(this.options.filename, {
                     chunk,
                     hash: compilation.hash,
+                    contentHash: hashContent(source),
                 });
-                compilation.assets[cssBundleFilename] = new RawSource(cssSources.join(EOL));
+                compilation.assets[cssBundleFilename] = new RawSource(source);
                 chunk.files.push(cssBundleFilename);
             }
         } else {
@@ -349,11 +353,13 @@ export class StylableWebpackPlugin {
                     compilation.mainTemplate,
                     compilation.hash
                 );
+                const source = cssSources.join(EOL)
                 const cssBundleFilename = compilation.getPath(this.options.filename, {
                     chunk,
                     hash: compilation.hash,
+                    contentHash: hashContent(source),
                 });
-                compilation.assets[cssBundleFilename] = new RawSource(cssSources.join(EOL));
+                compilation.assets[cssBundleFilename] = new RawSource(source);
                 chunk.files.push(cssBundleFilename);
             }
         }

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -36,7 +36,7 @@ import {
 import { isImportedByNonStylable, rewriteUrl, isStylableModule } from './utils';
 import { dirname } from 'path';
 import findConfig from 'find-config';
-import { hashContent } from '@stylable/webpack-extensions/src';
+import { hashContent } from './hash-content-util';
 
 const { connectChunkAndModule } = require('webpack/lib/GraphHelpers');
 const MultiModule = require('webpack/lib/MultiModule');

--- a/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/src/index.js
@@ -1,0 +1,4 @@
+import { classes } from './index.st.css';
+
+document.documentElement.classList.add(classes.root);
+window.backgroundColorAtLoadTime = getComputedStyle(document.documentElement).backgroundColor;

--- a/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/src/index.st.css
@@ -1,0 +1,3 @@
+.root {
+    background-color: red; 
+}

--- a/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/webpack.config.js
@@ -6,8 +6,7 @@ module.exports = {
     context: __dirname,
     devtool: 'source-map',
     plugins: [new StylableWebpackPlugin({
-        outputCSS: true,
-        includeCSSInJS: false,
+        outputCSS: true, // enable emit css in dev mode
         filename: 'output.[contenthash:5].css'
     }), new HtmlWebpackPlugin()],
 };

--- a/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/simplest-project-content-hash/webpack.config.js
@@ -1,0 +1,13 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [new StylableWebpackPlugin({
+        outputCSS: true,
+        includeCSSInJS: false,
+        filename: 'output.[contenthash:5].css'
+    }), new HtmlWebpackPlugin()],
+};

--- a/packages/webpack-plugin/test/e2e/simplest-project-content-hash.spec.ts
+++ b/packages/webpack-plugin/test/e2e/simplest-project-content-hash.spec.ts
@@ -1,0 +1,26 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'simplest-project-content-hash';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                // headless: false
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('renders css', () => {
+        const assets =projectRunner.getBuildAssets();
+        const file = Object.keys(assets).find((path)=>path.match(/output\.\w+\.css/))!
+        expect(assets[file].emitted, 'should emit file with content hash').to.equal(true);
+    });
+
+});


### PR DESCRIPTION
Add support to webpack plugin to allow filename output path config to include `[contenthash]`