### PR TITLE
Experimental loader emit diagnostics as webpack errors and warnings

### DIFF
--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -208,6 +208,29 @@ export class ProjectRunner {
         return this.stats!.compilation.errors.slice();
     }
 
+    public getBuildErrorMessagesDeep() {
+        function getErrors(compilations: webpack.compilation.Compilation[]) {
+            return compilations.reduce((errors, compilation) => {
+                errors.push(...compilation.errors);
+                errors.push(...getErrors(compilation.children));
+                return errors;
+            }, [] as any[]);
+        }
+
+        return getErrors([this.stats!.compilation]);
+    }
+    public getBuildWarningsMessagesDeep() {
+        function getWarnings(compilations: webpack.compilation.Compilation[]) {
+            return compilations.reduce((warnings, compilation) => {
+                warnings.push(...compilation.warnings);
+                warnings.push(...getWarnings(compilation.children));
+                return warnings;
+            }, [] as any[]);
+        }
+
+        return getWarnings([this.stats!.compilation]);
+    }
+
     public getBuildAsset(assetPath: string) {
         return this.getBuildAssets()[normalize(assetPath)].source();
     }

--- a/packages/experimental-loader/README.md
+++ b/packages/experimental-loader/README.md
@@ -65,6 +65,7 @@ interface LoaderOptions {
 | `resolveNamespace` | override default stylesheet namespace process |
 | `filterUrls`       | filter urls from webpack process              |
 | `exportsOnly`      | only export the runtime stylesheet            |
+| `alwaysEmitErrors` | always emit stylable diagnostics as errors    |
 
 ## SSR (exportsOnly)
 

--- a/packages/experimental-loader/README.md
+++ b/packages/experimental-loader/README.md
@@ -66,7 +66,7 @@ interface LoaderOptions {
 | `resolveNamespace` | override default stylesheet namespace process |
 | `filterUrls`       | filter urls from webpack process              |
 | `exportsOnly`      | only export the runtime stylesheet            |
-| `alwaysEmitErrors` | always emit stylable diagnostics as errors    |
+| `alwaysEmitErrors` | always emit Stylable diagnostics as errors    |
 
 ## SSR (exportsOnly)
 

--- a/packages/experimental-loader/README.md
+++ b/packages/experimental-loader/README.md
@@ -57,6 +57,7 @@ interface LoaderOptions {
   resolveNamespace?(namespace: string, filePath: string): string;
   filterUrls?(url: string, ctx: loader.LoaderContext): boolean;
   exportsOnly?: boolean;
+  alwaysEmitErrors?: boolean;
 }
 ```
 

--- a/packages/experimental-loader/test/errors-integration.spec.ts
+++ b/packages/experimental-loader/test/errors-integration.spec.ts
@@ -1,0 +1,27 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'errors-integration';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            throwOnBuildError: false,
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                // headless: false,
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('emit errors and warnings from loader', () => {
+        const errors = projectRunner.getBuildErrorMessagesDeep();
+        const warnings = projectRunner.getBuildWarningsMessagesDeep();
+        expect(errors[0].message).to.include(`"-st-from" cannot be empty`);
+        expect(warnings[0].message).to.include(`cannot resolve '-st-extends' type for 'Unknown'`);
+    });
+});

--- a/packages/experimental-loader/test/projects/errors-integration/index.js
+++ b/packages/experimental-loader/test/projects/errors-integration/index.js
@@ -1,0 +1,1 @@
+import './index.st.css';

--- a/packages/experimental-loader/test/projects/errors-integration/index.st.css
+++ b/packages/experimental-loader/test/projects/errors-integration/index.st.css
@@ -1,0 +1,8 @@
+:import {
+    -st-from: "";
+    -st-default: NotFound;
+}
+
+.root {
+    -st-extends: Unknown;
+}

--- a/packages/experimental-loader/test/projects/errors-integration/webpack.config.ts
+++ b/packages/experimental-loader/test/projects/errors-integration/webpack.config.ts
@@ -1,37 +1,17 @@
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import HTMLWebpackPlugin from 'html-webpack-plugin';
 import { stylableLoaders } from '../../../src';
-import { noCollisionNamespace } from '@stylable/core';
 
 module.exports = {
     mode: 'development',
     entry: './index.js',
     context: __dirname,
     devtool: false,
-    plugins: [new MiniCssExtractPlugin(), new HTMLWebpackPlugin()],
     module: {
         rules: [
             {
-                test: /\.(png|jpg|gif)$/i,
-                use: [
-                    {
-                        loader: 'url-loader',
-                        options: {
-                            limit: 8192,
-                        },
-                    },
-                ],
-            },
-            {
                 test: /\.st\.css$/i,
                 use: [
-                    stylableLoaders.runtime(),
-                    {
-                        loader: MiniCssExtractPlugin.loader,
-                        options: { esModule: true, reloadAll: true },
-                    },
                     stylableLoaders.transform({
-                        resolveNamespace: noCollisionNamespace(),
+                        exportsOnly: true,
                     }),
                 ],
             },

--- a/packages/experimental-loader/test/projects/errors-integration/webpack.config.ts
+++ b/packages/experimental-loader/test/projects/errors-integration/webpack.config.ts
@@ -1,0 +1,40 @@
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import HTMLWebpackPlugin from 'html-webpack-plugin';
+import { stylableLoaders } from '../../../src';
+import { noCollisionNamespace } from '@stylable/core';
+
+module.exports = {
+    mode: 'development',
+    entry: './index.js',
+    context: __dirname,
+    devtool: false,
+    plugins: [new MiniCssExtractPlugin(), new HTMLWebpackPlugin()],
+    module: {
+        rules: [
+            {
+                test: /\.(png|jpg|gif)$/i,
+                use: [
+                    {
+                        loader: 'url-loader',
+                        options: {
+                            limit: 8192,
+                        },
+                    },
+                ],
+            },
+            {
+                test: /\.st\.css$/i,
+                use: [
+                    stylableLoaders.runtime(),
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: { esModule: true, reloadAll: true },
+                    },
+                    stylableLoaders.transform({
+                        resolveNamespace: noCollisionNamespace(),
+                    }),
+                ],
+            },
+        ],
+    },
+};


### PR DESCRIPTION
`experimental-loader` now emits webpack errors and warnings from Stylable diagnostics.
Add option to always emit errors even for warnings by settings `alwaysEmitErrors: true` 