### PR TITLE
Fix lint error on computed member identifier

### DIFF
--- a/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
+++ b/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
@@ -89,7 +89,7 @@ export default createRule({
                                 return;
                             }
 
-                            const accessor = getMemberAccessor(parent.property);
+                            const accessor = getMemberAccessor(parent.property, parent.computed);
 
                             if (accessor !== undefined && !exports[exportName][accessor]) {
                                 context.report({
@@ -141,8 +141,8 @@ function getStylableRequest(importStatement: esTree.ImportDeclaration) {
     return;
 }
 
-function getMemberAccessor(property: esTree.Expression) {
-    if (isIdentifier(property)) {
+function getMemberAccessor(property: esTree.Expression, isComputed: boolean) {
+    if (isIdentifier(property) && !isComputed) {
         return property.name;
     } else if (property.type === AST_NODE_TYPES.Literal && typeof property.value === 'string') {
         return property.value;

--- a/packages/eslint-plugin-stylable/tests/stylable-es-lint.spec.ts
+++ b/packages/eslint-plugin-stylable/tests/stylable-es-lint.spec.ts
@@ -83,6 +83,10 @@ tester.run('basic unknown locals discovery', StylableLint, {
         },
         {
             filename,
+            code: "import {classes as XYZ} from './index.st.css'; const x = ''; const a = XYZ[x]",
+        },
+        {
+            filename,
             code: "import {keyframes as XYZ} from './index.st.css'; const a = XYZ.test",
         },
         {


### PR DESCRIPTION
fix `classes[x]` lint error. as we can't know the end value.