### PR TITLE
Add support for metadata format from manifest plugin

### DIFF
--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -103,8 +103,9 @@ export class ProjectRunner {
               };
     }
     public loadTestConfig(configName?: string, webpackOptions: webpack.Configuration = {}) {
+        const config = require(join(this.projectDir, configName || 'webpack.config'));
         return {
-            ...require(join(this.projectDir, configName || 'webpack.config')),
+            ...(config.default || config),
             ...webpackOptions,
         };
     }

--- a/packages/webpack-extensions/src/index.ts
+++ b/packages/webpack-extensions/src/index.ts
@@ -5,3 +5,5 @@ export * from './stylable-metadata-plugin';
 export * from './component-metadata-builder';
 export * from './hash-content-util';
 export * from './stylable-metadata-loader';
+export * from './stylable-manifest-plugin';
+export * from './types';

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -1,11 +1,11 @@
-import webpack from 'webpack';
-import { RawSource } from 'webpack-sources';
-import { createMetadataForStylesheet } from './create-metadata-stylesheet';
-import { Stylable } from '@stylable/core';
-import { resolveNamespace } from '@stylable/node';
-import { hashContent } from './hash-content-util';
 import { basename } from 'path';
 import { EOL } from 'os';
+import webpack from 'webpack';
+import { RawSource } from 'webpack-sources';
+import { Stylable } from '@stylable/core';
+import { resolveNamespace } from '@stylable/node';
+import { createMetadataForStylesheet } from './create-metadata-stylesheet';
+import { hashContent } from './hash-content-util';
 import { ComponentsMetadata } from './component-metadata-builder';
 import { Metadata, Manifest } from './types';
 

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -6,8 +6,13 @@ import { resolveNamespace } from '@stylable/node';
 import { hashContent } from './hash-content-util';
 import { basename } from 'path';
 import { EOL } from 'os';
+import { ComponentsMetadata } from './component-metadata-builder';
+import { Metadata, Manifest } from './types';
 
 export interface Options {
+    outputType: 'manifest' | 'fs-manifest';
+    package: { name: string; version: string };
+    packageAlias: Record<string, string>;
     contentHashLength?: number;
     exposeNamespaceMapping: boolean;
     resolveNamespace(namespace: string, filePath: string): string;
@@ -16,20 +21,13 @@ export interface Options {
     getOutputFileName(contentHash: string): string;
 }
 
-export interface Metadata {
-    entry: string;
-    stylesheetMapping: Record<string, string>;
-    namespaceMapping?: Record<string, string>;
-}
-
-export interface Manifest {
-    stylesheetMapping: Record<string, string>;
-    namespaceMapping: Record<string, string>;
-    componentsEntries: Record<string, string>;
-    componentsIndex: string;
-}
-
 const defaultOptions: Options = {
+    package: {
+        name: 'default-name',
+        version: '0.0.0-default',
+    },
+    outputType: 'manifest',
+    packageAlias: {},
     resolveNamespace,
     exposeNamespaceMapping: true,
     filterComponents(resourcePath) {
@@ -89,6 +87,8 @@ export class StylableManifestPlugin {
                 return manifest;
             },
             {
+                name: this.options.package.name,
+                version: this.options.package.version,
                 componentsIndex: '',
                 componentsEntries: {},
                 stylesheetMapping: {},
@@ -96,6 +96,20 @@ export class StylableManifestPlugin {
             }
         );
 
+        if (this.options.outputType === 'fs-manifest') {
+            this.emitJSONAsset(
+                convertToFsMetadata(manifest, this.options.packageAlias),
+                compilation
+            );
+        } else {
+            this.emitJSONAsset(manifest, compilation);
+        }
+    }
+
+    private emitJSONAsset(
+        manifest: Manifest | ComponentsMetadata,
+        compilation: webpack.compilation.Compilation
+    ) {
         const manifestContent = JSON.stringify(manifest);
 
         const contentHash = hashContent(manifestContent, this.options.contentHashLength);
@@ -131,3 +145,47 @@ export class StylableManifestPlugin {
         });
     }
 }
+
+/* This supports output of prevues version of the metadata plugin */
+const convertToFsMetadata = (
+    manifest: Manifest,
+    packages: Record<string, string>
+): ComponentsMetadata => {
+    const pkg = { name: manifest.name, version: manifest.version };
+
+    const normalizedMetadata: ComponentsMetadata = {
+        ...pkg,
+        fs: {
+            [`/${manifest.name}/package.json`]: {
+                content: JSON.stringify(pkg),
+            },
+            [`/${manifest.name}/index.st.css`]: {
+                metadata: {
+                    /* naive package name to css class might need to support more characters */
+                    namespace: manifest.name.replace(/[@/]/g, '_'),
+                },
+                content: manifest.componentsIndex,
+            },
+        },
+        components: {},
+        packages,
+    };
+    Object.keys(manifest.stylesheetMapping).forEach((filePath) => {
+        normalizedMetadata.fs[filePath] = {
+            metadata: {
+                namespace: manifest.namespaceMapping[filePath],
+            },
+            content: manifest.stylesheetMapping[filePath],
+        };
+    });
+    Object.keys(manifest.componentsEntries).forEach((id) => {
+        const stylesheetPath = manifest.componentsEntries[id];
+        const namespace = manifest.namespaceMapping[stylesheetPath];
+        normalizedMetadata.components[id] = {
+            id,
+            stylesheetPath,
+            namespace,
+        };
+    });
+    return normalizedMetadata;
+};

--- a/packages/webpack-extensions/src/stylable-metadata-loader.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-loader.ts
@@ -12,12 +12,6 @@ export interface LoaderOptions {
     resolveNamespace(namespace: string, filePath: string): string;
 }
 
-export interface Metadata {
-    entry: string;
-    stylesheetMapping: Record<string, string>;
-    namespaceMapping?: Record<string, string>;
-}
-
 const defaultOptions: LoaderOptions = {
     resolveNamespace: processNamespace,
     exposeNamespaceMapping: false,

--- a/packages/webpack-extensions/src/types.ts
+++ b/packages/webpack-extensions/src/types.ts
@@ -1,0 +1,14 @@
+export interface Metadata {
+    entry: string;
+    stylesheetMapping: Record<string, string>;
+    namespaceMapping?: Record<string, string>;
+}
+
+export interface Manifest {
+    name: string;
+    version: string;
+    stylesheetMapping: Record<string, string>;
+    namespaceMapping: Record<string, string>;
+    componentsEntries: Record<string, string>;
+    componentsIndex: string;
+}

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/fs-manifest.spec.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/fs-manifest.spec.ts
@@ -1,0 +1,90 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { hashContent } from '../../../../src/hash-content-util';
+import { EOL } from 'os';
+import { ComponentsMetadata } from '@stylable/webpack-extensions/src';
+
+describe(`(${__dirname})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: __dirname,
+            puppeteerOptions: {
+                // headless: false
+            },
+            configName: 'webpack.fs-manifest.config'
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('Should generate manifest for the current build', () => {
+        const assets = projectRunner.getBuildAssets();
+        const manifestKey = Object.keys(assets).find((key) => key.startsWith('stylable.manifest'))!;
+        const source = assets[manifestKey].source();
+
+        const compContent = readFileSync(
+            join(projectRunner.projectDir, 'Button.comp.st.css'),
+            'utf-8'
+        );
+        const commonContent = readFileSync(
+            join(projectRunner.projectDir, 'common.st.css'),
+            'utf-8'
+        );
+        const commonHash = hashContent(commonContent);
+        const compHash = hashContent(compContent);
+
+        // {
+        //     componentsIndex: `:import{-st-from: "/${compHash}.st.css";-st-default: Button;} Button{}${EOL}`,
+        //     componentsEntries: { Button: `/${compHash}.st.css` },
+        //     stylesheetMapping: {
+        //         [`/${compHash}.st.css`]: compContent.replace(
+        //             './common.st.css',
+        //             `/${commonHash}.st.css`
+        //         ),
+        //         [`/${commonHash}.st.css`]: commonContent,
+        //     },
+        //     namespaceMapping: {
+        //         [`/${commonHash}.st.css`]: 'common911354609',
+        //         [`/${compHash}.st.css`]: 'Buttoncomp1090430236',
+        //     },
+        // }
+        const fsMetadata: ComponentsMetadata = {
+            name: 'manifest-plugin-test',
+            version: '0.0.0-test',
+            components: {
+                Button: {
+                    id: 'Button',
+                    namespace: 'Buttoncomp1090430236',
+                    stylesheetPath: `/${compHash}.st.css`,
+                },
+            },
+            fs: {
+                [`/manifest-plugin-test/package.json`]: {
+                    content: JSON.stringify({
+                        name: 'manifest-plugin-test',
+                        version: '0.0.0-test',
+                    }),
+                },
+                [`/manifest-plugin-test/index.st.css`]: {
+                    content: `:import{-st-from: "/${compHash}.st.css";-st-default: Button;} Button{}${EOL}`,
+                    metadata: {
+                        namespace: 'manifest-plugin-test',
+                    },
+                },
+                [`/${compHash}.st.css`]: {
+                    content: compContent.replace('./common.st.css', `/${commonHash}.st.css`),
+                    metadata: { namespace: 'Buttoncomp1090430236' },
+                },
+                [`/${commonHash}.st.css`]: {
+                    content: commonContent,
+                    metadata: { namespace: 'common911354609' },
+                },
+            },
+            packages: {},
+        };
+        expect(JSON.parse(source)).to.deep.include(fsMetadata);
+    });
+});

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/fs-manifest.spec.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/fs-manifest.spec.ts
@@ -1,10 +1,10 @@
-import { StylableProjectRunner } from '@stylable/e2e-test-kit';
-import { expect } from 'chai';
 import { readFileSync } from 'fs';
-import { join } from 'path';
-import { hashContent } from '../../../../src/hash-content-util';
 import { EOL } from 'os';
+import { join } from 'path';
+import { expect } from 'chai';
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { ComponentsMetadata } from '@stylable/webpack-extensions/src';
+import { hashContent } from '../../../../src/hash-content-util';
 
 describe(`(${__dirname})`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/manifest.spec.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/manifest.spec.ts
@@ -35,6 +35,8 @@ describe(`(${__dirname})`, () => {
         const compHash = hashContent(compContent);
 
         expect(JSON.parse(source)).to.deep.include({
+            name: 'manifest-plugin-test',
+            version: '0.0.0-test',
             componentsIndex: `:import{-st-from: "/${compHash}.st.css";-st-default: Button;} Button{}${EOL}`,
             componentsEntries: { Button: `/${compHash}.st.css` },
             stylesheetMapping: {

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.config.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.config.ts
@@ -28,4 +28,4 @@ const config: Configuration = {
     },
 };
 
-module.exports = config;
+export default config;

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.fs-manifest.config.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.fs-manifest.config.ts
@@ -10,7 +10,12 @@ const config: Configuration = {
     output: {
         library: 'metadata',
     },
-    plugins: [new StylableManifestPlugin({ package: require('./package.json') })],
+    plugins: [
+        new StylableManifestPlugin({
+            outputType: 'fs-manifest',
+            package: require('./package.json'),
+        }),
+    ],
     resolve: {
         extensions: ['.ts', '.tsx', '.mjs', '.js', '.json'],
     },

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.fs-manifest.config.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.fs-manifest.config.ts
@@ -1,6 +1,6 @@
-import { StylableManifestPlugin } from '../../../../src/stylable-manifest-plugin';
-import { stylableLoaders } from '@stylable/experimental-loader';
 import { Configuration } from 'webpack';
+import { stylableLoaders } from '@stylable/experimental-loader';
+import { StylableManifestPlugin } from '../../../../src/stylable-manifest-plugin';
 
 const config: Configuration = {
     mode: 'development',
@@ -33,4 +33,4 @@ const config: Configuration = {
     },
 };
 
-module.exports = config;
+export default config;


### PR DESCRIPTION
* Allow the manifest plugin to output fs metadata.
* Export StylableManifestPlugin from index
