### PR TITLE
Remove package.json from fs-manifest

### DIFF
--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -156,9 +156,6 @@ const convertToFsMetadata = (
     const normalizedMetadata: ComponentsMetadata = {
         ...pkg,
         fs: {
-            [`/${manifest.name}/package.json`]: {
-                content: JSON.stringify(pkg),
-            },
             [`/${manifest.name}/index.st.css`]: {
                 metadata: {
                     /* naive package name to css class might need to support more characters */

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/fs-manifest.spec.ts
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/fs-manifest.spec.ts
@@ -47,12 +47,6 @@ describe(`(${__dirname})`, () => {
                 },
             },
             fs: {
-                [`/manifest-plugin-test/package.json`]: {
-                    content: JSON.stringify({
-                        name: 'manifest-plugin-test',
-                        version: '0.0.0-test',
-                    }),
-                },
                 [`/manifest-plugin-test/index.st.css`]: {
                     content: `:import{-st-from: "/${compHash}.st.css";-st-default: Button;} Button{}${EOL}`,
                     metadata: {


### PR DESCRIPTION
Our integration points dose not handle well other file types in the fs object. so we only emit st.css files