### PR TITLE
Fix transform of mixins animation declarations

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -419,7 +419,7 @@ export class StylableTransformer {
         });
 
         if (mixinTransform) {
-            // override the keyframes for mixins since they dose not contain the @keyframes definition
+            // override the keyframes for mixins since they do not contain the @keyframes definition
             meta.keyframes.forEach((keyFrameAtRule) => {
                 const name = keyFrameAtRule.params;
                 keyframesExports[name] = {


### PR DESCRIPTION
When using css mixins, the `@keyframes` definition is not present in the partial AST and the transformer dose not know how to transform the `animation` declarations. 

This PR fixes that issue, but there is still the responsibility of making sure that the definitions are included in the built css.

Sine the usage of the mixin is only via css it might not include the file in the build. 
There are couple of solutions to that:
1. import the file with the `@keyframes` definition via `js` somewhere in the project
2. Stylable should be aware and not optimize this case.  (related to #906 )

This is still not solving the problem of issue #1271 