### PR TITLE
Update Experimental loader to use css-loader v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "chai-subset": "^1.6.0",
     "create-listening-server": "^1.0.0",
     "create-temp-directory": "^1.1.1",
-    "css-loader": "^3.6.0",
+    "css-loader": "^4.2.1",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",

--- a/packages/experimental-loader/package.json
+++ b/packages/experimental-loader/package.json
@@ -13,7 +13,7 @@
     "@stylable/core": "^3.8.4",
     "@stylable/optimizer": "^3.8.4",
     "@stylable/runtime": "^3.8.4",
-    "css-loader": "^3.6.0",
+    "css-loader": "^4.2.1",
     "decache": "^4.6.0"
   },
   "files": [

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -12,6 +12,7 @@ import { createRuntimeTargetCode } from './create-runtime-target-code';
 const { urlParser } = require('css-loader/dist/plugins');
 const { getImportCode, getModuleCode, sort } = require('css-loader/dist/utils');
 const decache = require('decache');
+const CSS_LOADER_API = require.resolve('css-loader/dist/runtime/api');
 export let stylable: Stylable;
 
 export interface LoaderOptions {
@@ -92,7 +93,7 @@ const stylableLoader: loader.Loader = function (content) {
     const urlPluginImports: LoaderImport[] = [
         {
             importName: '___CSS_LOADER_API_IMPORT___',
-            url: stringifyRequest(this, require.resolve('css-loader/dist/runtime/api')),
+            url: stringifyRequest(this, CSS_LOADER_API),
             index: -1,
         },
     ];

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -2,7 +2,7 @@ import { Stylable, processNamespace, StylableResults } from '@stylable/core';
 import { StylableOptimizer } from '@stylable/optimizer';
 import { loader } from 'webpack';
 import { getOptions, isUrlRequest, stringifyRequest } from 'loader-utils';
-import { Warning } from './warning';
+import { Warning, CssSyntaxError } from './warning';
 import postcss from 'postcss';
 import { addMetaDependencies } from './add-meta-dependencies';
 import { getStylable } from './cached-stylable-factory';
@@ -10,9 +10,8 @@ import { createRuntimeTargetCode } from './create-runtime-target-code';
 
 // TODO: maybe adopt the code
 const { urlParser } = require('css-loader/dist/plugins');
-const { getImportCode, getModuleCode } = require('css-loader/dist/utils');
+const { getImportCode, getModuleCode, sort } = require('css-loader/dist/utils');
 const decache = require('decache');
-
 export let stylable: Stylable;
 
 export interface LoaderOptions {
@@ -31,17 +30,15 @@ const defaultOptions: LoaderOptions = {
     },
 };
 interface UrlReplacement {
-    pluginName: string;
-    type: 'url-replacement';
-    value: { replacementName: string; importName: string; hash: string; needQuotes: boolean };
+    replacementName: string;
+    importName: string;
+    hash: string;
+    needQuotes: boolean;
 }
 interface LoaderImport {
-    pluginName: string;
-    type: 'import';
-    value: {
-        importName: string;
-        url: string;
-    };
+    importName: string;
+    url: string;
+    index: number;
 }
 
 const timedCacheOptions = { useTimer: true, timeout: 1000 };
@@ -92,11 +89,29 @@ const stylableLoader: loader.Loader = function (content) {
         return callback(null, createRuntimeTargetCode(res.meta.namespace, res.exports));
     }
 
-    const imports: LoaderImport[] = [];
+    const urlPluginImports: LoaderImport[] = [
+        {
+            importName: '___CSS_LOADER_API_IMPORT___',
+            url: stringifyRequest(this, require.resolve('css-loader/dist/runtime/api')),
+            index: -1,
+        },
+    ];
     const urlReplacements: UrlReplacement[] = [];
+
+    const urlResolver = (this as any).getResolve({
+        conditionNames: ['asset'],
+        mainFields: ['asset'],
+        mainFiles: [],
+        extensions: [],
+    });
 
     const plugins = [
         urlParser({
+            imports: urlPluginImports,
+            replacements: urlReplacements,
+            context: this.context,
+            rootContext: this.rootContext,
+            resolver: urlResolver,
             filter: (value: string) => isUrlRequest(value) && filterUrls(value, this),
             urlHandler: (url: string) => stringifyRequest(this, url),
         }),
@@ -117,31 +132,11 @@ const stylableLoader: loader.Loader = function (content) {
                 this.emitWarning(new Warning(warning));
             }
 
-            for (const message of result.messages) {
-                switch (message.type) {
-                    case 'import':
-                        imports.push(message.value);
-                        break;
-                    case 'url-replacement':
-                        urlReplacements.push(message.value);
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            const esModule = false;
-
-            const importCode = getImportCode(this, 'full', imports, esModule);
-            const moduleCode = getModuleCode(
-                result,
-                'full',
-                false /* sourceMap */,
-                [] /* apiImport */,
-                urlReplacements,
-                [] /* icssReplacement */,
-                esModule
-            );
+            const importCode = getImportCode(urlPluginImports.sort(sort), { esModule: false });
+            const moduleCode = getModuleCode(result, [], urlReplacements, {
+                modules: {},
+                sourceMap: false,
+            });
 
             return callback(
                 null,
@@ -150,14 +145,25 @@ const stylableLoader: loader.Loader = function (content) {
                 ${moduleCode}
 
                 // Patch exports with custom stylable API
-                exports.locals = ${JSON.stringify([res.meta.namespace, res.exports])}
+                ___CSS_LOADER_EXPORT___.locals = ${JSON.stringify([
+                    res.meta.namespace,
+                    res.exports,
+                ])}
 
-                module.exports = exports;
+                module.exports = ___CSS_LOADER_EXPORT___;
                 `
             );
         })
-        .catch(() => {
-            throw new Error('Failed to process css urls');
+        .catch((error) => {
+            if (error.file) {
+                this.addDependency(error.file);
+            }
+
+            callback(
+                error.name === 'CssSyntaxError'
+                    ? new CssSyntaxError(error)
+                    : new Error('Failed to process css urls. caused by:\n' + error.stack)
+            );
         });
 };
 

--- a/packages/experimental-loader/src/warning.ts
+++ b/packages/experimental-loader/src/warning.ts
@@ -1,5 +1,4 @@
 // Adopted from css-loader;
-
 export class Warning extends Error {
     constructor(warning: { text: string; line: number; column: number }) {
         super(String(warning));
@@ -15,6 +14,42 @@ export class Warning extends Error {
 
         this.message += text; // We don't need stack https://github.com/postcss/postcss/blob/master/docs/guidelines/runner.md#31-dont-show-js-stack-for-csssyntaxerror
 
+        this.stack = undefined;
+    }
+}
+
+interface PostCSSError {
+    reason: string;
+    line: string;
+    column: string;
+    showSourceCode(): string;
+}
+
+export class CssSyntaxError extends Error {
+    constructor(error: PostCSSError) {
+        super(error.toString());
+
+        const { reason, line, column } = error;
+
+        this.name = 'CssSyntaxError';
+
+        // Based on https://github.com/postcss/postcss/blob/master/lib/css-syntax-error.es6#L132
+        // We don't need `plugin` and `file` properties.
+        this.message = `${this.name}\n\n`;
+
+        if (typeof line !== 'undefined') {
+            this.message += `(${line}:${column}) `;
+        }
+
+        this.message += `${reason}`;
+
+        const code = error.showSourceCode();
+
+        if (code) {
+            this.message += `\n\n${code}\n`;
+        }
+
+        // We don't need stack https://github.com/postcss/postcss/blob/master/docs/guidelines/runner.md#31-dont-show-js-stack-for-csssyntaxerror
         this.stack = undefined;
     }
 }

--- a/packages/experimental-loader/src/warning.ts
+++ b/packages/experimental-loader/src/warning.ts
@@ -2,6 +2,8 @@
 export class Warning extends Error {
     constructor(warning: { text: string; line: number; column: number }) {
         super(String(warning));
+        Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
+
         const { text, line, column } = warning;
         this.name = 'Warning'; // Based on https://github.com/postcss/postcss/blob/master/lib/warning.es6#L74
         // We don't need `plugin` properties.
@@ -28,6 +30,7 @@ interface PostCSSError {
 export class CssSyntaxError extends Error {
     constructor(error: PostCSSError) {
         super(error.toString());
+        Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
 
         const { reason, line, column } = error;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3066,26 +3066,7 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-css-loader@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.2.0.tgz#b57efb92ac8f0cd85bf92d89df9634ef1f51b8bf"
-  integrity sha512-ko7a9b0iFpWtk9eSI/C8IICvZeGtYnjxYjw45rJprokXj/+kBd/siX4vAIBq9Uij8Jubc4jL1EvSnTjCEwaHSw==
-  dependencies:
-    camelcase "^6.0.0"
-    cssesc "^3.0.0"
-    icss-utils "^4.1.1"
-    loader-utils "^2.0.0"
-    normalize-path "^3.0.0"
-    postcss "^7.0.32"
-    postcss-modules-extract-imports "^2.0.0"
-    postcss-modules-local-by-default "^3.0.3"
-    postcss-modules-scope "^2.2.0"
-    postcss-modules-values "^3.0.0"
-    postcss-value-parser "^4.1.0"
-    schema-utils "^2.7.0"
-    semver "^7.3.2"
-
-css-loader@^4.2.1:
+css-loader@^4.1.1, css-loader@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.2.1.tgz#9f48fd7eae1219d629a3f085ba9a9102ca1141a7"
   integrity sha512-MoqmF1if7Z0pZIEXA4ZF9PgtCXxWbfzfJM+3p+OYfhcrwcqhaCRb74DSnfzRl7e024xEiCRn5hCvfUbTf2sgFA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3104,6 +3104,25 @@ css-loader@^4.1.1:
     schema-utils "^2.7.0"
     semver "^7.3.2"
 
+css-loader@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.2.1.tgz#9f48fd7eae1219d629a3f085ba9a9102ca1141a7"
+  integrity sha512-MoqmF1if7Z0pZIEXA4ZF9PgtCXxWbfzfJM+3p+OYfhcrwcqhaCRb74DSnfzRl7e024xEiCRn5hCvfUbTf2sgFA==
+  dependencies:
+    camelcase "^6.0.0"
+    cssesc "^3.0.0"
+    icss-utils "^4.1.1"
+    loader-utils "^2.0.0"
+    normalize-path "^3.0.0"
+    postcss "^7.0.32"
+    postcss-modules-extract-imports "^2.0.0"
+    postcss-modules-local-by-default "^3.0.3"
+    postcss-modules-scope "^2.2.0"
+    postcss-modules-values "^3.0.0"
+    postcss-value-parser "^4.1.0"
+    schema-utils "^2.7.0"
+    semver "^7.3.2"
+
 css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3066,25 +3066,6 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-css-loader@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
-  integrity sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==
-  dependencies:
-    camelcase "^5.3.1"
-    cssesc "^3.0.0"
-    icss-utils "^4.1.1"
-    loader-utils "^1.2.3"
-    normalize-path "^3.0.0"
-    postcss "^7.0.32"
-    postcss-modules-extract-imports "^2.0.0"
-    postcss-modules-local-by-default "^3.0.2"
-    postcss-modules-scope "^2.2.0"
-    postcss-modules-values "^3.0.0"
-    postcss-value-parser "^4.1.0"
-    schema-utils "^2.7.0"
-    semver "^6.3.0"
-
 css-loader@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.2.0.tgz#b57efb92ac8f0cd85bf92d89df9634ef1f51b8bf"
@@ -7414,7 +7395,7 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
-postcss-modules-local-by-default@^3.0.2, postcss-modules-local-by-default@^3.0.3:
+postcss-modules-local-by-default@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0"
   integrity sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==


### PR DESCRIPTION
This might be a breaking changes since it requires minimum webpack version 4.27.0

closes #1282