### PR TITLE
Fix numerical state validators

### DIFF
--- a/packages/core/src/state-validators.ts
+++ b/packages/core/src/state-validators.ts
@@ -118,7 +118,7 @@ export const systemValidators: Record<string, StateParamType> = {
                 };
             },
             minLength: (value: string, length: string) => {
-                const valid = value.length > Number(length);
+                const valid = value.length >= Number(length);
 
                 return {
                     res: value,
@@ -128,7 +128,7 @@ export const systemValidators: Record<string, StateParamType> = {
                 };
             },
             maxLength: (value: string, length: string) => {
-                const valid = value.length < Number(length);
+                const valid = value.length <= Number(length);
 
                 return {
                     res: value,

--- a/packages/core/src/state-validators.ts
+++ b/packages/core/src/state-validators.ts
@@ -181,7 +181,7 @@ export const systemValidators: Record<string, StateParamType> = {
         },
         subValidators: {
             min: (value: string, minValue: string) => {
-                const valid = Number(value) > Number(minValue);
+                const valid = Number(value) >= Number(minValue);
 
                 return {
                     res: value,
@@ -191,7 +191,7 @@ export const systemValidators: Record<string, StateParamType> = {
                 };
             },
             max: (value: string, maxValue: string) => {
-                const valid = Number(value) < Number(maxValue);
+                const valid = Number(value) <= Number(maxValue);
 
                 return {
                     res: value,

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -945,6 +945,28 @@ describe('pseudo-states', () => {
                         });
                     });
 
+                    it('should not warn when passing a value whose length equals minLength validator', () => {
+                        const config = {
+                            entry: `/entry.st.css`,
+                            files: {
+                                '/entry.st.css': {
+                                    namespace: 'entry',
+                                    content: `
+                                    .my-class {
+                                        -st-states: state1(string(minLength(7)));
+                                    }
+                                    |.my-class:state1(hello!!)| {}
+                                    `,
+                                },
+                            },
+                        };
+
+                        const res = expectWarningsFromTransform(config, []);
+                        expect(res).to.have.styleRules({
+                            1: '.entry__my-class[class~="entry---state1-7-hello!!"] {}',
+                        });
+                    });
+
                     it('should transform and warn when passing an invalid value to a maxLength validator', () => {
                         const config = {
                             entry: `/entry.st.css`,
@@ -972,6 +994,28 @@ describe('pseudo-states', () => {
                         ]);
                         expect(res).to.have.styleRules({
                             1: '.entry__my-class.entry---state1-4-user {}',
+                        });
+                    });
+
+                    it('should not warn when passing a value whose length equals maxLength validator', () => {
+                        const config = {
+                            entry: `/entry.st.css`,
+                            files: {
+                                '/entry.st.css': {
+                                    namespace: 'entry',
+                                    content: `
+                                    .my-class {
+                                        -st-states: state1(string(maxLength(3)));
+                                    }
+                                    |.my-class:state1(abc)| {}
+                                    `,
+                                },
+                            },
+                        };
+
+                        const res = expectWarningsFromTransform(config, []);
+                        expect(res).to.have.styleRules({
+                            1: '.entry__my-class.entry---state1-3-abc {}',
                         });
                     });
 

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -1254,6 +1254,50 @@ describe('pseudo-states', () => {
                             1: '.entry__my-class[class~="entry---state1-2-40"] {}',
                         });
                     });
+
+                    it('should not warn when value equals to min validator', () => {
+                        const config = {
+                            entry: `/entry.st.css`,
+                            files: {
+                                '/entry.st.css': {
+                                    namespace: 'entry',
+                                    content: `
+                                    .my-class{
+                                        -st-states: state1(number(min(3)));
+                                    }
+                                    |.my-class:state1(3)| {}
+                                    `,
+                                },
+                            },
+                        };
+
+                        const res = expectWarningsFromTransform(config, []);
+                        expect(res).to.have.styleRules({
+                            1: '.entry__my-class[class~="entry---state1-1-3"] {}',
+                        });
+                    });
+
+                    it('should not warn when value equals to max validator', () => {
+                        const config = {
+                            entry: `/entry.st.css`,
+                            files: {
+                                '/entry.st.css': {
+                                    namespace: 'entry',
+                                    content: `
+                                    .my-class{
+                                        -st-states: state1(number(max(3)));
+                                    }
+                                    |.my-class:state1(3)| {}
+                                    `,
+                                },
+                            },
+                        };
+
+                        const res = expectWarningsFromTransform(config, []);
+                        expect(res).to.have.styleRules({
+                            1: '.entry__my-class[class~="entry---state1-1-3"] {}',
+                        });
+                    });
                 });
             });
 


### PR DESCRIPTION
The state validators: min, max, minLength and maxLength - are not inclusive.

![image](https://user-images.githubusercontent.com/4023882/91174020-5f5d3800-e6e7-11ea-98b0-d9003d13dac1.png)

When defining a `min(0)` validator and using `controlButtonAmount(0)` we get:
`expected "0" to be larger than or equal to 0" as seen in the picture.

Same goes for the other three validators.
This PR fixes that issue.