### PR TITLE
Allow force state plugin to use function for namespace mapping 

### DIFF
--- a/packages/core/test/mixins/js-mixins.spec.ts
+++ b/packages/core/test/mixins/js-mixins.spec.ts
@@ -75,6 +75,42 @@ describe('Javascript Mixins', () => {
         expect(rule.nodes![0].toString()).to.equal('color: red');
     });
 
+    it('simple mixin with fallback', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'style',
+                    content: `
+                    :import {
+                        -st-from: "./mixin";
+                        -st-default: mixin;
+                    }
+                    .container {
+                        -st-mixin: mixin;
+                    }
+                `,
+                },
+                '/mixin.js': {
+                    content: `
+                    module.exports = function() {
+                        return {
+                            color: ["red", "blue"]
+                        }
+                    }
+                `,
+                },
+            },
+        });
+
+        const rule = result.nodes![0] as postcss.Rule;
+
+        expect(rule.selector).to.equal('.style__container');
+        expect(rule.nodes![0].toString()).to.equal('color: red');
+        expect(rule.nodes![1].toString()).to.equal('color: blue');
+    });
+
+
     it('simple mixin and remove all -st-mixins', () => {
         const result = generateStylableRoot({
             entry: `/style.st.css`,

--- a/packages/webpack-extensions/src/stylable-forcestates-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-forcestates-plugin.ts
@@ -11,7 +11,6 @@ import postcss from 'postcss';
 
 // This transformation is applied on target AST code
 // Not Stylable source AST
-
 const nativePseudoClassesMap = nativePseudoClasses.reduce((acc, name: string) => {
     acc[name] = true;
     return acc;
@@ -21,8 +20,10 @@ export const OVERRIDE_STATE_PREFIX = 'stylable-force-state-';
 
 const { hasOwnProperty } = Object.prototype;
 
-const MATCH_STATE_CLASS = new RegExp(`^(.+?)${pseudoStates.booleanStateDelimiter}(.+)`);
-const MATCH_STATE_ATTR = new RegExp(`^class~="(.+?)${pseudoStates.booleanStateDelimiter}(.+)"`);
+export const MATCH_STATE_CLASS = new RegExp(`^(.+?)${pseudoStates.booleanStateDelimiter}(.+)`);
+export const MATCH_STATE_ATTR = new RegExp(
+    `^class~="(.+?)${pseudoStates.booleanStateDelimiter}(.+)"`
+);
 
 export function createDataAttr(dataAttrPrefix: string, stateName: string, param?: string) {
     const paramWithValueExtraDil = param !== undefined ? pseudoStates.stateMiddleDelimiter : '';
@@ -32,9 +33,14 @@ export function createDataAttr(dataAttrPrefix: string, stateName: string, param?
 
 export function applyStylableForceStateSelectors(
     outputAst: postcss.Root,
-    namespaceMapping = {} as Record<string, boolean>,
+    namespaceMapping: Record<string, boolean> | ((namespace: string) => boolean) = {},
     dataPrefix = OVERRIDE_STATE_PREFIX
 ) {
+    const isKnownNamespace =
+        typeof namespaceMapping === 'function'
+            ? namespaceMapping
+            : (name: string) => hasOwnProperty.call(namespaceMapping, name);
+
     const mapping: Record<string, string> = {};
     addForceStateSelectors(outputAst, {
         getForceStateAttrContentFromNative(name) {
@@ -53,11 +59,11 @@ export function applyStylableForceStateSelectors(
         },
         isStateClassName(name) {
             const parts = name.match(MATCH_STATE_CLASS);
-            return parts ? hasOwnProperty.call(namespaceMapping, parts[1]) : false;
+            return parts ? isKnownNamespace(parts[1]) : false;
         },
         isStateAttr(content) {
             const parts = content.match(MATCH_STATE_ATTR);
-            return parts ? hasOwnProperty.call(namespaceMapping, parts[1]) : false;
+            return parts ? isKnownNamespace(parts[1]) : false;
         },
         onMapping(key, value) {
             mapping[key] = value;

--- a/packages/webpack-extensions/test/unit/forcestates-plugin.spec.ts
+++ b/packages/webpack-extensions/test/unit/forcestates-plugin.spec.ts
@@ -36,6 +36,33 @@ describe('stylable-forcestates-plugin', () => {
             '.entry__root.entry--myState,.entry__root[stylable-force-state-myState]'
         );
     });
+    it('should mark a boolean state as forced using a data-attribute selector (namespace mapping function)', () => {
+        const res = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                    .root {
+                        -st-states: myState;
+                    }
+
+                    .root:myState {
+                        color: green;
+                    }
+                    `,
+                },
+            },
+        });
+
+        applyStylableForceStateSelectors(res.meta.outputAst!, (name) => {
+            return name === 'entry';
+        });
+
+        expect((res.meta.outputAst!.nodes![1] as postcss.Rule).selector).to.equal(
+            '.entry__root.entry--myState,.entry__root[stylable-force-state-myState]'
+        );
+    });
 
     it('should mark a native state as forced using a data-attribute selector', () => {
         const res = generateStylableResult({


### PR DESCRIPTION
* Allow force-states-plugin to use function for namespace mapping
* Export useful regexp for state name matching
* Add test for js fallback decl support