### PR TITLE
Allow using JavaScript string values as Stylable import

### DIFF
--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -204,6 +204,18 @@ export function processDeclarationValue(
                                             );
                                         }
                                     }
+                                } else if (
+                                    resolvedVar._kind === 'js' &&
+                                    typeof resolvedVar.symbol === 'string'
+                                ) {
+                                    parsedNode.resolvedValue = valueHook
+                                        ? valueHook(
+                                              resolvedVar.symbol,
+                                              varName,
+                                              false,
+                                              passedThrough
+                                          )
+                                        : resolvedVar.symbol;
                                 } else if (resolvedVar._kind === 'js' && diagnostics && node) {
                                     // ToDo: provide actual exported id (default/named as x)
                                     diagnostics.warn(

--- a/packages/core/test/mixins/js-mixins.spec.ts
+++ b/packages/core/test/mixins/js-mixins.spec.ts
@@ -7,6 +7,95 @@ import { expect } from 'chai';
 import postcss from 'postcss';
 
 describe('Javascript Mixins', () => {
+    it('javascript value', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./values";
+                        -st-named: myValue;
+                    }
+                    .container {
+                        background: value(myValue);
+                    }
+                `,
+                },
+                '/values.js': {
+                    content: `
+                    module.exports.myValue = 'red'; 
+                `,
+                },
+            },
+        });
+        const rule = result.nodes![0] as postcss.Rule;
+        expect(rule.nodes![0].toString()).to.equal('background: red');
+    });
+
+    it('javascript value in var definition', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./values";
+                        -st-named: myValue;
+                    }
+                    :vars {
+                        myCSSValue: value(myValue);
+                    }
+                    .container {
+                        background: value(myCSSValue);
+                    }
+                `,
+                },
+                '/values.js': {
+                    content: `
+                    module.exports.myValue = 'red'; 
+                `,
+                },
+            },
+        });
+        const rule = result.nodes![0] as postcss.Rule;
+        expect(rule.nodes![0].toString()).to.equal('background: red');
+    });
+
+    it('javascript value dose re-export to css', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./x.st.css";
+                        -st-named: myValue;
+                    }
+                    .container {
+                        background: value(myValue);
+                    }
+                `,
+                },
+                '/x.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./values";
+                        -st-named: myValue;
+                    }
+                `,
+                },
+                '/values.js': {
+                    content: `
+                    module.exports.myValue = 'red'; 
+                `,
+                },
+            },
+        });
+        const rule = result.nodes![0] as postcss.Rule;
+        expect(rule.nodes![0].toString()).to.equal('background: red');
+    });
+
     it('simple mixin', () => {
         const result = generateStylableRoot({
             entry: `/style.st.css`,
@@ -109,7 +198,6 @@ describe('Javascript Mixins', () => {
         expect(rule.nodes![0].toString()).to.equal('color: red');
         expect(rule.nodes![1].toString()).to.equal('color: blue');
     });
-
 
     it('simple mixin and remove all -st-mixins', () => {
         const result = generateStylableRoot({

--- a/packages/stylable.io/docs/references/extending-through-js.md
+++ b/packages/stylable.io/docs/references/extending-through-js.md
@@ -11,6 +11,7 @@ This enables developers greater freedom in generating CSS from code to provide c
 ## Plugin types
 
  **Stylable** supports the following types of plugins:
+* Values - string values exported from a javascript module.
 * [Formatters]('./formatters.md) - functions for manipulating single CSS declaration values.
 * [Mixins]('./mixins.md) - functions for generating a CSS fragment that can include single or multiple rulesets and declarations. 
 
@@ -48,6 +49,31 @@ Using these types enables the consumers of the plugin to receive code hinting an
 | &nbsp;&nbsp;&nbsp; | max&nbsp;&nbsp; | number |
 | &nbsp;&nbsp;&nbsp; | multiplesOf&nbsp;&nbsp; | number |
 | stEnum&nbsp;&nbsp; | allowedValues&nbsp;&nbsp; | string[] |
+
+
+
+## Extending through values
+
+Values are strings exported via JavaScript modules they can be used inside a Stylable value() function.
+
+```css 
+:import {
+    -st-from: "../my-js-values.js";
+    -st-named: myValue;
+}
+
+.myClass {
+    color: value(myValue);
+}
+```
+
+Uses the following TypeScript code:
+
+```ts
+/*my-js-values.ts*/
+export const myValue = 'red';
+```
+
 
 ## Extending through formatters
 


### PR DESCRIPTION
Allow usage of imported JavaScript string values inside Stylable value() function.

```css 
:import {
    -st-from: "../my-js-values.js";
    -st-named: myValue;
}

.myClass {
    color: value(myValue);
}
``` 