### PR TITLE
Fix Removing stylable modules that are used in JavaScript

### DIFF
--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -313,10 +313,7 @@ export class StylableWebpackPlugin {
                         return chunk.containsModule(r.module);
                     }
                 });
-                if (!shouldKeep) {
-                    if (m.buildInfo.isImportedByNonStylable) {
-                        return;
-                    }
+                if (!shouldKeep && !m.buildInfo.isImportedByNonStylable) {
                     chunk.removeModule(m);
                 }
             });

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -314,10 +314,8 @@ export class StylableWebpackPlugin {
                     }
                 });
                 if (!shouldKeep) {
-                    if ((m as any).chunksIterable.size === 1) {
-                        if (m.buildInfo.isImportedByNonStylable) {
-                            return;
-                        }
+                    if (m.buildInfo.isImportedByNonStylable) {
+                        return;
                     }
                     chunk.removeModule(m);
                 }


### PR DESCRIPTION
I failed to reproduce the scenario that cause webpack to split modules in a way that the original reason is not in the same chunks of imported stylable file.

This PR fixes that problem by never removing Stylable files that used in JavaScript imports