### PR TITLE
refactor: use native node apis where possible

### DIFF
--- a/packages/eslint-plugin-stylable/package.json
+++ b/packages/eslint-plugin-stylable/package.json
@@ -10,7 +10,6 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@file-services/node": "^4.0.0",
     "@stylable/core": "^3.10.1",
     "@typescript-eslint/experimental-utils": "^4.1.1"
   },

--- a/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
+++ b/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
@@ -1,4 +1,5 @@
-import { nodeFs } from '@file-services/node';
+import fs from 'fs';
+import path from 'path';
 import { Stylable, createDefaultResolver, StylableExports, StylableMeta } from '@stylable/core';
 import {
     ESLintUtils,
@@ -20,11 +21,11 @@ export default createRule({
     defaultOptions: [{ exposeDiagnosticsReports: false, resolveOptions: {} }], // TODO: allow to pass resolve config
     create(context, options) {
         const [{ exposeDiagnosticsReports, resolveOptions }] = options as Options;
-        const moduleResolver = createDefaultResolver(nodeFs, resolveOptions);
+        const moduleResolver = createDefaultResolver(fs, resolveOptions);
 
         const stylable = Stylable.create({
-            fileSystem: nodeFs,
-            projectRoot: '/',
+            fileSystem: fs,
+            projectRoot: process.cwd(),
             resolveModule: moduleResolver,
             requireModule: require,
         });
@@ -51,7 +52,7 @@ export default createRule({
                     return;
                 }
                 const fileName = context.getFilename();
-                const dirName = nodeFs.dirname(fileName);
+                const dirName = path.dirname(fileName);
                 const fullPath = moduleResolver(dirName, importRequest);
                 const meta = stylable.process(fullPath, dirName);
                 const { exports } = stylable.transform(meta);

--- a/packages/eslint-plugin-stylable/tests/stylable-es-lint.spec.ts
+++ b/packages/eslint-plugin-stylable/tests/stylable-es-lint.spec.ts
@@ -21,7 +21,7 @@ fs.writeFileSync(
     path.join(tmp.path, 'index.st.css'),
     `
 :vars {
-  key: "value"; u
+  key: "value";
 }
 .root {
   --cssVar: green;

--- a/packages/eslint-plugin-stylable/tests/stylable-es-lint.spec.ts
+++ b/packages/eslint-plugin-stylable/tests/stylable-es-lint.spec.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+import fs from 'fs';
 import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 import StylableLint from '../src/stylable-es-lint';
-import { nodeFs } from '@file-services/node';
 import { createTempDirectorySync } from 'create-temp-directory';
 
 // mock afterAll for RuleTester (should be fixed in next version)
@@ -14,13 +15,13 @@ const tester = new ESLintUtils.RuleTester({
 });
 
 const tmp = createTempDirectorySync('stylable-eslint');
-const filename = nodeFs.join(tmp.path, 'index.ts');
+const filename = path.join(tmp.path, 'index.ts');
 
-nodeFs.writeFileSync(
-    nodeFs.join(tmp.path, 'index.st.css'),
+fs.writeFileSync(
+    path.join(tmp.path, 'index.st.css'),
     `
 :vars {
-  key: "value"; 
+  key: "value"; u
 }
 .root {
   --cssVar: green;

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -15,7 +15,7 @@
     "typescript": ">=3.6"
   },
   "dependencies": {
-    "@file-services/node": "^4.0.0",
+    "@file-services/types": "^4.0.0",
     "@file-services/typescript": "^4.0.0",
     "@stylable/core": "^3.10.1",
     "css-selector-tokenizer": "^0.7.3",

--- a/packages/language-service/src/lib/typescript-support.ts
+++ b/packages/language-service/src/lib/typescript-support.ts
@@ -1,9 +1,9 @@
-import { IFileSystem } from '@file-services/types';
+import { IFileSystemSync } from '@file-services/types';
 import { createBaseHost, createLanguageServiceHost } from '@file-services/typescript';
 import ts from 'typescript';
 import { ExtendedTsLanguageService } from './types';
 
-export function typescriptSupport(fileSystem: IFileSystem) {
+export function typescriptSupport(fileSystem: IFileSystemSync) {
     let openedFiles: string[] = [];
     const baseHost = createBaseHost(fileSystem);
     const tsLanguageServiceHost = createLanguageServiceHost(

--- a/packages/language-service/test-kit/asserters.ts
+++ b/packages/language-service/test-kit/asserters.ts
@@ -1,5 +1,5 @@
-import fs from '@file-services/node';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { NodeBase } from 'postcss';
 import { ColorInformation } from 'vscode-css-languageservice';
 import {

--- a/packages/language-service/test-kit/completions-asserters.ts
+++ b/packages/language-service/test-kit/completions-asserters.ts
@@ -1,6 +1,6 @@
-import fs from '@file-services/node';
+import path from 'path';
+import fs from 'fs';
 import { expect } from 'chai';
-import * as path from 'path';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { ProviderPosition, ProviderRange } from '../src/lib/completion-providers';

--- a/packages/language-service/test-kit/stylable-fixtures-lsp.ts
+++ b/packages/language-service/test-kit/stylable-fixtures-lsp.ts
@@ -1,9 +1,10 @@
 import fs from '@file-services/node';
+import path from 'path';
 import { Stylable } from '@stylable/core';
 import { StylableLanguageService } from '../src/lib/service';
 
-export const CASES_PATH = fs.join(
-    fs.dirname(fs.findClosestFileSync(__dirname, 'package.json')!),
+export const CASES_PATH = path.join(
+    path.dirname(require.resolve('@stylable/language-service/package.json')),
     'test',
     'fixtures',
     'server-cases'

--- a/packages/language-service/test/lib/definitions.spec.ts
+++ b/packages/language-service/test/lib/definitions.spec.ts
@@ -1,7 +1,7 @@
+import path from 'path';
 import { expect } from 'chai';
-import * as path from 'path';
-
 import { URI } from 'vscode-uri';
+
 import { createRange, ProviderPosition } from '../../src/lib/completion-providers';
 import * as asserters from '../../test-kit/asserters';
 import { CASES_PATH } from '../../test-kit/stylable-fixtures-lsp';

--- a/packages/language-service/test/lib/references.spec.ts
+++ b/packages/language-service/test/lib/references.spec.ts
@@ -1,5 +1,5 @@
+import path from 'path';
 import { expect } from 'chai';
-import * as path from 'path';
 import { URI } from 'vscode-uri';
 
 import { createRange } from '../../src/lib/completion-providers';


### PR DESCRIPTION
no reason for `eslint-plugin-stylable` to install @file-services/node. reduce tree.