### PR TITLE
language-service: fix diagnosis to use the correct stylable processor instance

### DIFF
--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -70,7 +70,7 @@ export class Stylable {
         protected resolveOptions: any = {},
         public optimizer?: IStylableOptimizer,
         protected mode: 'production' | 'development' = 'production',
-        protected resolveNamespace?: typeof processNamespace,
+        public resolveNamespace?: typeof processNamespace,
         protected timedCacheOptions: Omit<TimedCacheOptions, 'createKey'> = {
             timeout: 1,
             useTimer: true,

--- a/packages/language-service/src/lib/diagnosis.ts
+++ b/packages/language-service/src/lib/diagnosis.ts
@@ -1,4 +1,4 @@
-import { Diagnostic as StylableDiagnostic, process, safeParse, Stylable } from '@stylable/core';
+import { Diagnostic as StylableDiagnostic, Stylable } from '@stylable/core';
 import { Diagnostic, Range } from 'vscode-languageserver-types';
 import { CssService } from './css-service';
 
@@ -12,24 +12,13 @@ export function createDiagnosis(
     if (!filePath.endsWith('.st.css')) {
         return [];
     }
-    const docPostCSSRoot = safeParse(content, { from: filePath });
 
-    if (docPostCSSRoot.source) {
-        const { input } = docPostCSSRoot.source;
-
-        // postcss runs path.resolve, which messes up in-memory fs implementation on windows
-        Object.defineProperty(input, 'from', { value: filePath });
-        input.file = filePath;
-    }
-
-    const meta = process(docPostCSSRoot);
-
-    stylable.fileProcessor.add(filePath, meta);
+    const meta = stylable.fileProcessor.processContent(content, filePath);
 
     try {
         stylable.transform(meta);
     } catch {
-        /**/
+        /*TODO: report this failure to transform */
     }
 
     const cleanDoc = cssService.createSanitizedDocument(meta.rawAst, filePath, version);


### PR DESCRIPTION
- also, make `namespaceResolver` public on `Stylable` instances