### PR TITLE
core: fix regression that causing diagnostics to be shared across files

### DIFF
--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -59,7 +59,7 @@ export function generateInfra(
         undefined,
         undefined,
         undefined,
-        diagnostics
+        () => diagnostics
     );
     const resolver = new StylableResolver(fileProcessor, requireModule);
 

--- a/packages/core/src/create-infra-structure.ts
+++ b/packages/core/src/create-infra-structure.ts
@@ -19,7 +19,7 @@ export function createInfrastructure(
     resolveNamespace?: typeof processNamespace,
     timedCacheOptions?: Omit<TimedCacheOptions, 'createKey'>,
     resolveModule = createDefaultResolver(fileSystem, resolveOptions),
-    diagnostics = new Diagnostics()
+    createDiagnostics?: (from: string) => Diagnostics /* only for tests */
 ): StylableInfrastructure {
     let resolvePath = (context: string | undefined = projectRoot, moduleId: string) => {
         if (!path.isAbsolute(moduleId) && !moduleId.startsWith('.')) {
@@ -38,9 +38,10 @@ export function createInfrastructure(
 
     const fileProcessor = cachedProcessFile<StylableMeta>(
         (from, content) => {
+            const resolvedFrom = resolvePath(projectRoot, from);
             return process(
-                safeParse(content, { from: resolvePath(projectRoot, from) }),
-                diagnostics,
+                safeParse(content, { from: resolvedFrom }),
+                createDiagnostics?.(resolvedFrom),
                 resolveNamespace
             );
         },

--- a/packages/core/src/create-infra-structure.ts
+++ b/packages/core/src/create-infra-structure.ts
@@ -19,7 +19,7 @@ export function createInfrastructure(
     resolveNamespace?: typeof processNamespace,
     timedCacheOptions?: Omit<TimedCacheOptions, 'createKey'>,
     resolveModule = createDefaultResolver(fileSystem, resolveOptions),
-    createDiagnostics?: (from: string) => Diagnostics /* only for tests */
+    createDiagnostics?: (from: string) => Diagnostics
 ): StylableInfrastructure {
     let resolvePath = (context: string | undefined = projectRoot, moduleId: string) => {
         if (!path.isAbsolute(moduleId) && !moduleId.startsWith('.')) {

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -120,7 +120,7 @@ export const processorWarnings = {
         return `cannot use "@keyframes" inside of "@st-scope"`;
     },
     MISSING_SCOPING_PARAM() {
-        return '"@st-scope" missing scoping selector param';
+        return '"@st-scope" missing scoping selector parameter';
     },
     ILLEGAL_GLOBAL_CSS_VAR(name: string) {
         return `"@st-global-custom-property" received the value "${name}", but it must begin with "--" (double-dash)`;

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -120,7 +120,7 @@ export const processorWarnings = {
         return `cannot use "@keyframes" inside of "@st-scope"`;
     },
     MISSING_SCOPING_PARAM() {
-        return '"@st-scope" must receive a simple selector or stylesheet "root" as its scoping parameter';
+        return '"@st-scope" missing scoping selector param';
     },
     ILLEGAL_GLOBAL_CSS_VAR(name: string) {
         return `"@st-global-custom-property" received the value "${name}", but it must begin with "--" (double-dash)`;

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -38,6 +38,25 @@ describe('diagnostics', () => {
         });
     });
 
+    it('should not duplicate diagnostics within multiple runs on the same file', () => {
+        const filePath = '/style.st.css';
+        const files = {
+            [filePath]: '.gaga .root{}',
+        }
+        const fs = createMemoryFs(files);
+
+        const stylableLSP = new StylableLanguageService({
+            fs,
+            stylable: new Stylable('/', fs, require),
+        });
+    
+        const diagnostics1 =  stylableLSP.diagnose(filePath);
+        const diagnostics2 =  stylableLSP.diagnose(filePath);
+
+        expect(diagnostics1).to.have.lengthOf(1)
+        expect(diagnostics2).to.have.lengthOf(1)
+    });
+
     it('should create cross file errors', () => {
         const filePathA = '/style.css';
         const filePathB = '/import-style.st.css';


### PR DESCRIPTION
In our tests we use global diagnostics that are shared across all files. 

When we updated our test infra we accidentally introduced this behavior to the core infrastructure.