### PR TITLE
refactor: decouple language-service from vscode

### DIFF
--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -23,7 +23,6 @@
     "postcss": "^8.1.1",
     "postcss-value-parser": "^4.1.0",
     "vscode-css-languageservice": "^4.3.4",
-    "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-uri": "^2.1.2"
   },

--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -1,7 +1,6 @@
 import { IFileSystem } from '@file-services/types';
 import path from 'path';
 import * as postcss from 'postcss';
-import { getCSSLanguageService, Stylesheet } from 'vscode-css-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
     Color,
@@ -9,11 +8,13 @@ import {
     ColorPresentation,
     CompletionItem,
     Diagnostic,
+    getCSSLanguageService,
     Hover,
     Location,
     Position,
     Range,
-} from 'vscode-languageserver-types';
+    Stylesheet,
+} from 'vscode-css-languageservice';
 import { URI } from 'vscode-uri';
 import { createMeta } from './provider';
 

--- a/packages/language-service/src/lib/dedupe-refs.ts
+++ b/packages/language-service/src/lib/dedupe-refs.ts
@@ -1,4 +1,4 @@
-import { Location } from 'vscode-languageserver-types';
+import { Location } from 'vscode-css-languageservice';
 
 export function dedupeRefs(refs: Location[]): Location[] {
     const res: Location[] = [];

--- a/packages/language-service/src/lib/diagnosis.ts
+++ b/packages/language-service/src/lib/diagnosis.ts
@@ -1,5 +1,5 @@
 import { Diagnostic as StylableDiagnostic, Stylable } from '@stylable/core';
-import { Diagnostic, Range } from 'vscode-languageserver-types';
+import { Diagnostic, Range } from 'vscode-css-languageservice';
 import { CssService } from './css-service';
 
 export function createDiagnosis(

--- a/packages/language-service/src/lib/feature/color-provider.ts
+++ b/packages/language-service/src/lib/feature/color-provider.ts
@@ -1,7 +1,6 @@
 import { IFileSystem } from '@file-services/types';
 import { evalDeclarationValue, Stylable, valueMapping } from '@stylable/core';
-import { Color, ColorInformation, ColorPresentation } from 'vscode-css-languageservice';
-import { ColorPresentationParams } from 'vscode-languageserver-protocol';
+import { Color, Range, ColorInformation, ColorPresentation } from 'vscode-css-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { ProviderPosition, ProviderRange } from '../completion-providers';
@@ -103,15 +102,16 @@ export function resolveDocumentColors(
 export function getColorPresentation(
     cssService: CssService,
     document: TextDocument,
-    params: ColorPresentationParams
+    color: Color,
+    range: Range
 ): ColorPresentation[] {
     const src = document.getText();
-    const res = fixAndProcess(src, new ProviderPosition(0, 0), params.textDocument.uri);
+    const res = fixAndProcess(src, new ProviderPosition(0, 0), document.uri);
     const meta = res.processed.meta!;
 
     const wordStart = new ProviderPosition(
-        params.range.start.line + 1,
-        params.range.start.character + 1
+        range.start.line + 1,
+        range.start.character + 1
     );
     let noPicker = false;
     meta.rawAst.walkDecls(valueMapping.named, (node) => {
@@ -130,5 +130,5 @@ export function getColorPresentation(
     if (noPicker) {
         return [];
     }
-    return cssService.getColorPresentations(document, params.color, params.range);
+    return cssService.getColorPresentations(document, color, range);
 }

--- a/packages/language-service/src/lib/feature/formatting.ts
+++ b/packages/language-service/src/lib/feature/formatting.ts
@@ -1,6 +1,6 @@
 import { css } from 'js-beautify';
 import { TextDocument, Range } from 'vscode-languageserver-textdocument';
-import { FormattingOptions } from 'vscode-languageserver';
+import { FormattingOptions } from 'vscode-css-languageservice';
 
 export interface JSBeautifyFormatCSSOptions {
     indent_size?: number;

--- a/packages/language-service/src/lib/feature/pseudo-class.ts
+++ b/packages/language-service/src/lib/feature/pseudo-class.ts
@@ -1,5 +1,9 @@
 import postcssValueParser from 'postcss-value-parser';
-import { ParameterInformation, SignatureHelp, SignatureInformation } from 'vscode-languageserver';
+import {
+    ParameterInformation,
+    SignatureHelp,
+    SignatureInformation,
+} from 'vscode-css-languageservice';
 import { StateParsedValue, systemValidators } from '@stylable/core';
 import { ProviderPosition } from '../completion-providers';
 

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -27,7 +27,7 @@ import {
     Position,
     SignatureHelp,
     SignatureInformation,
-} from 'vscode-languageserver';
+} from 'vscode-css-languageservice';
 import { URI } from 'vscode-uri';
 
 import {

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -1,6 +1,5 @@
 import { IFileSystem, IFileSystemStats } from '@file-services/types';
 import { Stylable, safeParse } from '@stylable/core';
-import { ColorPresentationParams } from 'vscode-languageserver-protocol';
 import { Range, TextDocument } from 'vscode-languageserver-textdocument';
 import {
     Color,
@@ -16,7 +15,7 @@ import {
     SignatureHelp,
     TextEdit,
     WorkspaceEdit,
-} from 'vscode-languageserver-types';
+} from 'vscode-css-languageservice';
 import { URI } from 'vscode-uri';
 
 import { ProviderPosition, ProviderRange } from './completion-providers';
@@ -183,7 +182,7 @@ export class StylableLanguageService {
                 end: doc.positionAt(offset.end),
             };
 
-            return getColorPresentation(this.cssService, doc, { color, range, textDocument: doc });
+            return getColorPresentation(this.cssService, doc, color, range);
         }
 
         return [];
@@ -372,8 +371,8 @@ export class StylableLanguageService {
         return resolveDocumentColors(this.stylable, this.cssService, document, this.fs);
     }
 
-    public getColorPresentation(document: TextDocument, params: ColorPresentationParams) {
-        return getColorPresentation(this.cssService, document, params);
+    public getColorPresentation(document: TextDocument, color: Color, range: Range) {
+        return getColorPresentation(this.cssService, document, color, range);
     }
 
     public diagnose(filePath: string): Diagnostic[] {

--- a/packages/language-service/src/lib/types.ts
+++ b/packages/language-service/src/lib/types.ts
@@ -1,26 +1,4 @@
 import ts from 'typescript';
-import {
-    Command,
-    CompletionItem,
-    Diagnostic,
-    Location,
-    ParameterInformation,
-    Position,
-    Range,
-    TextEdit,
-} from 'vscode-css-languageservice';
-
-export interface LSPTypeHelpers {
-    // TODO: remove me?
-    CompletionItem: typeof CompletionItem;
-    TextEdit: typeof TextEdit;
-    Location: typeof Location;
-    Range: typeof Range;
-    Position: typeof Position;
-    Command: typeof Command;
-    ParameterInformation: typeof ParameterInformation;
-    Diagnostic: typeof Diagnostic;
-}
 
 export interface ExtendedTsLanguageService {
     setOpenedFiles: (files: string[]) => void;

--- a/packages/language-service/src/lib/types.ts
+++ b/packages/language-service/src/lib/types.ts
@@ -4,20 +4,11 @@ import {
     CompletionItem,
     Diagnostic,
     Location,
-    NotificationType,
     ParameterInformation,
     Position,
     Range,
     TextEdit,
-} from 'vscode-languageserver';
-import { ColorPresentationRequest, DocumentColorRequest } from 'vscode-languageserver-protocol';
-
-export interface NotificationTypes {
-    // TODO: remove me?
-    openDoc: NotificationType<string, void>;
-    colorRequest: typeof DocumentColorRequest;
-    colorPresentationRequest: typeof ColorPresentationRequest;
-}
+} from 'vscode-css-languageservice';
 
 export interface LSPTypeHelpers {
     // TODO: remove me?

--- a/packages/language-service/test-kit/asserters.ts
+++ b/packages/language-service/test-kit/asserters.ts
@@ -8,9 +8,9 @@ import {
     Location,
     ParameterInformation,
     SignatureHelp,
-} from 'vscode-languageserver';
+    Range,
+} from 'vscode-css-languageservice';
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
-import { Range, TextDocumentIdentifier } from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { ProviderPosition } from '../src/lib/completion-providers';
 import { createMeta, ProviderLocation } from '../src/lib/provider';
@@ -96,9 +96,5 @@ export function getDocColorPresentation(
     const src: string = fs.readFileSync(fullPath).toString();
     const doc = TextDocument.create(URI.file(fullPath).toString(), 'stylable', 1, src);
 
-    return stylableLSP.getColorPresentation(doc, {
-        textDocument: TextDocumentIdentifier.create(doc.uri),
-        color,
-        range,
-    });
+    return stylableLSP.getColorPresentation(doc, color, range);
 }

--- a/packages/language-service/test/lib/colors.spec.ts
+++ b/packages/language-service/test/lib/colors.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
-import { Color } from 'vscode-languageserver-protocol';
+import { Color } from 'vscode-css-languageservice';
 import { createRange } from '../../src/lib/completion-providers';
 import { getDocColorPresentation, getDocumentColors } from '../../test-kit/asserters';
 
 export function createColor(red: number, green: number, blue: number, alpha: number): Color {
-    return { red, green, blue, alpha } as Color;
+    return { red, green, blue, alpha };
 }
 
 describe('Colors', () => {

--- a/packages/language-service/test/lib/signatures.spec.ts
+++ b/packages/language-service/test/lib/signatures.spec.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { ParameterInformation, SignatureHelp, SignatureInformation } from 'vscode-languageserver';
+import {
+    ParameterInformation,
+    SignatureHelp,
+    SignatureInformation,
+} from 'vscode-css-languageservice';
 import { getSignatureHelp } from '../../test-kit/asserters';
 
 describe('Signature Help', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9719,40 +9719,15 @@ vscode-css-languageservice@^4.3.4:
     vscode-nls "^5.0.0"
     vscode-uri "^2.1.2"
 
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageserver-protocol@^3.15.3:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
-  dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
-
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
 
-vscode-languageserver-types@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
-
 vscode-languageserver-types@3.16.0-next.2:
   version "3.16.0-next.2"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
   integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
-
-vscode-languageserver@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz#d76afc68172c27d4327ee74332b468fbc740d762"
-  integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
-  dependencies:
-    vscode-languageserver-protocol "^3.15.3"
 
 vscode-nls@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- remove direct dependency and imports to `vscode-languageserver`, `vscode-languageserver-types`, `vscode-languageserver-protocol`.
- instead, import relevant types from `vscode-css-languageservice`, which reexports the ones it's compatible with.
- remove unused `NotificationTypes` and `LSPTypeHelpers` interfaces. aren't used in `stylable-intelligence` as well.