### PR TITLE
Added generateScopedVar for stylable-utils

### DIFF
--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -22,7 +22,7 @@ import {
 } from './selector-utils';
 import { ImportSymbol } from './stylable-meta';
 import { valueMapping, mixinDeclRegExp } from './stylable-value-parsers';
-import {StylableResolver} from './stylable-resolver';
+import { StylableResolver } from './stylable-resolver';
 
 export const CUSTOM_SELECTOR_RE = /:--[\w-]+/g;
 
@@ -366,9 +366,14 @@ export function isCSSVarProp(value: string) {
     return value.startsWith('--');
 }
 
-export function generateScopedVar(resolver: StylableResolver, meta: StylableMeta, symbolName: string) {
+export function scopeCSSVar(resolver: StylableResolver, meta: StylableMeta, symbolName: string) {
     const importedVar = resolver.deepResolve(meta.mappedSymbols[symbolName]);
-    if (importedVar && importedVar._kind === 'css' && importedVar.symbol && importedVar.symbol._kind === 'cssVar') {
+    if (
+        importedVar &&
+        importedVar._kind === 'css' &&
+        importedVar.symbol &&
+        importedVar.symbol._kind === 'cssVar'
+    ) {
         return importedVar.symbol.global
             ? importedVar.symbol.name
             : generateScopedCSSVar(importedVar.meta.namespace, importedVar.symbol.name.slice(2));

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -22,6 +22,7 @@ import {
 } from './selector-utils';
 import { ImportSymbol } from './stylable-meta';
 import { valueMapping, mixinDeclRegExp } from './stylable-value-parsers';
+import {StylableResolver} from './stylable-resolver';
 
 export const CUSTOM_SELECTOR_RE = /:--[\w-]+/g;
 
@@ -363,6 +364,21 @@ export function generateScopedCSSVar(namespace: string, varName: string) {
 
 export function isCSSVarProp(value: string) {
     return value.startsWith('--');
+}
+
+export function generateScopedVar(resolver: StylableResolver, meta: StylableMeta, symbolName: string) {
+    const importedVar = resolver.deepResolve(meta.mappedSymbols[symbolName]);
+    if (importedVar && importedVar._kind === 'css' && importedVar.symbol && importedVar.symbol._kind === 'cssVar') {
+        return importedVar.symbol.global
+            ? importedVar.symbol.name
+            : generateScopedCSSVar(importedVar.meta.namespace, importedVar.symbol.name.slice(2));
+    }
+    const cssVar = meta.cssVars[symbolName];
+    if (cssVar?.global) {
+        return symbolName;
+    } else {
+        return generateScopedCSSVar(meta.namespace, symbolName.slice(2));
+    }
 }
 
 export function isValidClassName(className: string) {

--- a/packages/core/test/stylable-utils.spec.ts
+++ b/packages/core/test/stylable-utils.spec.ts
@@ -1,0 +1,20 @@
+import {generateInfra} from '@stylable/core-test-kit';
+import {expect} from 'chai';
+import {generateScopedVar} from '@stylable/core';
+
+describe('stylable utils', () => {
+    describe('generate', () => {
+        it('should resolve classes', () => {
+            const { resolver, fileProcessor } = generateInfra({
+                files: {
+                    '/entry.st.css': {
+                        content: ``,
+                    },
+                },
+            });
+
+            const entryMeta = fileProcessor.process('/entry.st.css');
+            expect(generateScopedVar(resolver, entryMeta, '--someVar')).to.equal('--entry1466596548-someVar');
+        });
+    });
+})


### PR DESCRIPTION
Feature: Added utility `scopeCSSVar` which generates the scoped css variable name from local name