### PR TITLE
core: fix bug where odd spacings in '@st-global-custom-property' would break

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -264,9 +264,13 @@ export class StylableProcessor {
                     this.meta.scopes.push(atRule);
                     break;
                 case 'st-global-custom-property': {
-                    const cssVars = atRule.params.split(',');
+                    const cssVarsByComma = atRule.params.split(',');
+                    const cssVarsBySpacing = atRule.params
+                        .trim()
+                        .split(/\s+/g)
+                        .filter((s) => s !== ',');
 
-                    if (atRule.params.trim().split(/\s+/g).length > cssVars.length) {
+                    if (cssVarsBySpacing.length > cssVarsByComma.length) {
                         this.diagnostics.warn(
                             atRule,
                             processorWarnings.GLOBAL_CSS_VAR_MISSING_COMMA(atRule.params),
@@ -275,7 +279,7 @@ export class StylableProcessor {
                         break;
                     }
 
-                    for (const entry of cssVars) {
+                    for (const entry of cssVarsByComma) {
                         const cssVar = entry.trim();
 
                         if (isCSSVarProp(cssVar)) {

--- a/packages/core/test/css-vars.spec.ts
+++ b/packages/core/test/css-vars.spec.ts
@@ -385,8 +385,7 @@ describe('css custom-properties (vars)', () => {
                 },
             });
 
-            const decl = (meta.outputAst!.nodes[0] as postcss.Rule)
-                .nodes[0] as postcss.Declaration;
+            const decl = (meta.outputAst!.nodes[0] as postcss.Rule).nodes[0] as postcss.Declaration;
 
             expect(meta.diagnostics.reports.length).to.equal(0);
             expect(meta.transformDiagnostics!.reports.length).to.equal(0);
@@ -630,6 +629,49 @@ describe('css custom-properties (vars)', () => {
                 expect(decl1.value).to.equal('green');
                 expect(decl2.prop).to.equal('--myVar2');
                 expect(decl2.value).to.equal('red');
+            });
+
+            it('should support any spacing between global variable definitions', () => {
+                const res = generateStylableResult({
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            @st-global-custom-property --myVar1      ,--myVar2,
+                              --myVar3  ,  --myVar4  ;
+
+                            .root {
+                                --myVar1: 1;
+                                --myVar2: 2;
+                                --myVar3: 3;
+                                --myVar4: 4;
+                            }
+                            `,
+                        },
+                    },
+                });
+                expect(
+                    res.meta.diagnostics.reports,
+                    'no diagnostics reported for native states'
+                ).to.eql([]);
+
+                const decl1 = (res.meta.outputAst!.nodes[0] as postcss.Rule)
+                    .nodes[0] as postcss.Declaration;
+                const decl2 = (res.meta.outputAst!.nodes[0] as postcss.Rule)
+                    .nodes[1] as postcss.Declaration;
+                const decl3 = (res.meta.outputAst!.nodes[0] as postcss.Rule)
+                    .nodes[2] as postcss.Declaration;
+                const decl4 = (res.meta.outputAst!.nodes[0] as postcss.Rule)
+                    .nodes[3] as postcss.Declaration;
+                expect(decl1.prop).to.equal('--myVar1');
+                expect(decl1.value).to.equal('1');
+                expect(decl2.prop).to.equal('--myVar2');
+                expect(decl2.value).to.equal('2');
+                expect(decl3.prop).to.equal('--myVar3');
+                expect(decl3.value).to.equal('3');
+                expect(decl4.prop).to.equal('--myVar4');
+                expect(decl4.value).to.equal('4');
             });
 
             it('mixed global and scoped var declarations', () => {


### PR DESCRIPTION
```css
@st-global-custom-property a, b; /* doesn't break */
```

```css
@st-global-custom-property a , b; /* breaks */
```

The solution there should still probably be replaced by a proper parser that can handle more than spacings. (e.g. comments)