### PR TITLE
webpack-extensions: add the ability to modify the resource path for the metadata fs output

### DIFF
--- a/packages/webpack-extensions/src/component-metadata-builder.ts
+++ b/packages/webpack-extensions/src/component-metadata-builder.ts
@@ -32,7 +32,7 @@ export interface ComponentsMetadata {
 
 export class ComponentMetadataBuilder {
     private output: ComponentsMetadata;
-    constructor(private context: string, name: string, version: string) {
+    constructor(public context: string, name: string, version: string) {
         this.output = {
             version,
             name,
@@ -96,7 +96,7 @@ export class ComponentMetadataBuilder {
         }
     }
     public createIndex() {
-        const indexPath = this.localResourcePath('/index.st.css');
+        const indexPath = join(this.context, 'index.st.css');
         const namespace = this.output.name + '-index';
         if (this.output.fs[indexPath]) {
             throw new Error('Duplicate index');
@@ -110,7 +110,7 @@ export class ComponentMetadataBuilder {
 
             return source + `:import {-st-from: "${from}"; -st-default: ${name}} .root ${name}{}\n`;
         }, '');
-        this.addSource('/index.st.css', source, { namespace, depth: maxDepth });
+        this.addSource(indexPath, source, { namespace, depth: maxDepth });
     }
     private validate() {
         const errors = [];
@@ -156,8 +156,12 @@ export class ComponentMetadataBuilder {
 }
 
 function normPath(resource: string, context = '') {
-    const v = resource.replace(context, '').replace(/\\/g, '/');
-    return v.startsWith('/') ? v : `/${v}`;
+    let norm = resource.replace(context, '');
+    if (norm === resource) {
+        throw new Error(`cannot use resource "${resource}" outside the context "${context}"`);
+    }
+    norm = norm.replace(/\\/g, '/');
+    return norm.startsWith('/') ? norm : `/${norm}`;
 }
 
 function cloneObject<T = object>(obj: T) {

--- a/packages/webpack-extensions/src/stylable-metadata-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-plugin.ts
@@ -64,10 +64,10 @@ export class StylableMetadataPlugin {
         for (const module of stylableModules) {
             const namespace = module.buildInfo.stylableMeta.namespace;
             const depth = module.buildInfo.runtimeInfo.depth;
-            let resource = module.resource;
-            if (this.options.normalizeModulePath) {
-                resource = this.options.normalizeModulePath(resource, builder);
-            }
+            const resource = this.options.normalizeModulePath
+                ? this.options.normalizeModulePath(module.resource, builder)
+                : module.resource;
+            
             builder.addSource(
                 resource,
                 compilation.inputFileSystem.readFileSync(resource).toString(),

--- a/packages/webpack-extensions/src/stylable-metadata-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-plugin.ts
@@ -15,6 +15,7 @@ export interface MetadataOptions {
     version: string;
     configExtension?: string;
     context?: string;
+    normalizeModulePath?: (resource: string, builder: ComponentMetadataBuilder) => string;
     renderSnapshot?: (
         moduleExports: any,
         component: any,
@@ -63,10 +64,13 @@ export class StylableMetadataPlugin {
         for (const module of stylableModules) {
             const namespace = module.buildInfo.stylableMeta.namespace;
             const depth = module.buildInfo.runtimeInfo.depth;
-
+            let resource = module.resource;
+            if (this.options.normalizeModulePath) {
+                resource = this.options.normalizeModulePath(resource, builder);
+            }
             builder.addSource(
-                module.resource,
-                compilation.inputFileSystem.readFileSync(module.resource).toString(),
+                resource,
+                compilation.inputFileSystem.readFileSync(resource).toString(),
                 { namespace, depth }
             );
 
@@ -81,11 +85,11 @@ export class StylableMetadataPlugin {
                 continue;
             }
 
-            builder.addComponent(module.resource, componentConfig, namespace);
+            builder.addComponent(resource, componentConfig, namespace);
 
             this.handleVariants(
                 componentConfig,
-                dirname(module.resource),
+                dirname(resource),
                 compilation,
                 builder,
                 namespace,

--- a/packages/webpack-extensions/test/e2e/projects/metadata-plugin-project/webpack.config.ts
+++ b/packages/webpack-extensions/test/e2e/projects/metadata-plugin-project/webpack.config.ts
@@ -19,6 +19,9 @@ export default {
             renderSnapshot(_exp, res) {
                 return `<snapshot>${basename(res.resource)}</snapshot>`;
             },
+            normalizeModulePath(resource) {
+                return resource;
+            },
         }),
         new HtmlWebpackPlugin(),
     ],


### PR DESCRIPTION
Allow consumers to modify the module file path before it is injected to the metadata.
This allows projects that use symlinks to resolve the module file path in dev mode.