### PR TITLE
fix(runtime): compat with noUncheckedIndexedAccess

### DIFF
--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -22,7 +22,7 @@ export interface StylableExports {
 }
 
 export type STFunction = (
-    context: string,
+    context: string | undefined,
     stateOrClass?: string | StateMap | undefined,
     ...classes: Array<string | undefined>
 ) => string;


### PR DESCRIPTION
for projects using the new noUncheckedIndexedAccess typescript flag, `classes.root` gets a type of `string | undefined`, forcing the user to use `!` in many cases.

this change relaxes the type-check of the first parameter, at least until we have .d.ts generation with watch mode.