### PR TITLE
fix(core): use correct context when resolving js mixins

### DIFF
--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -58,7 +58,7 @@ export class StylableResolver {
         } else {
             let _module;
             try {
-                _module = this.requireModule(this.fileProcessor.resolvePath(from));
+                _module = this.requireModule(this.fileProcessor.resolvePath(from, context));
             } catch {
                 return null;
             }

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/index.js
@@ -1,0 +1,3 @@
+import { classes } from './index.st.css';
+
+document.documentElement.classList.add(classes.root);

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/index.st.css
@@ -1,0 +1,8 @@
+:import {
+    -st-from: "test1/comp.st.css";
+    -st-named: x;
+}
+
+.root {
+    -st-mixin: x;
+}

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/comp.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/comp.st.css
@@ -1,0 +1,9 @@
+:import {
+    -st-from: "test-inner";
+    -st-named: redColor;
+}
+
+
+.x {
+    color: redColor();
+}

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/node_modules/test-inner/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/node_modules/test-inner/index.js
@@ -1,1 +1,1 @@
-module.exports.redColor = ()=>{return 'red'}
+module.exports.redColor = () => 'red';

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/node_modules/test-inner/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/node_modules/test-inner/index.js
@@ -1,0 +1,1 @@
+module.exports.redColor = ()=>{return 'red'}

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/node_modules/test-inner/package.json
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/node_modules/test-inner/package.json
@@ -1,0 +1,1 @@
+{"name": "test-inner", "version": "0.0.0-test", "main": "./index.js"}

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/package.json
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/node_modules/test1/package.json
@@ -1,0 +1,1 @@
+{"name": "test1", "version": "0.0.0-test"}

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/webpack.config.js
@@ -1,0 +1,9 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [new StylableWebpackPlugin(), new HtmlWebpackPlugin()],
+};

--- a/packages/webpack-plugin/test/e2e/resolve-js-with-context.spec.ts
+++ b/packages/webpack-plugin/test/e2e/resolve-js-with-context.spec.ts
@@ -1,0 +1,30 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { join } from 'path';
+
+const project = 'resolve-js-with-context';
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir: join(__dirname, 'projects', project),
+            puppeteerOptions: {
+                headless: false
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    
+
+    it('css is working', async () => {
+        const { page } = await projectRunner.openInBrowser();
+        const color = await page.evaluate(() => {
+            return getComputedStyle(document.documentElement).color;
+        });
+
+        expect(color).to.eql('rgb(255, 0, 0)');
+    });
+});

--- a/packages/webpack-plugin/test/e2e/resolve-js-with-context.spec.ts
+++ b/packages/webpack-plugin/test/e2e/resolve-js-with-context.spec.ts
@@ -17,8 +17,6 @@ describe(`(${project})`, () => {
         after
     );
 
-    
-
     it('css is working', async () => {
         const { page } = await projectRunner.openInBrowser();
         const color = await page.evaluate(() => {

--- a/packages/webpack-plugin/test/e2e/resolve-js-with-context.spec.ts
+++ b/packages/webpack-plugin/test/e2e/resolve-js-with-context.spec.ts
@@ -9,7 +9,7 @@ describe(`(${project})`, () => {
         {
             projectDir: join(__dirname, 'projects', project),
             puppeteerOptions: {
-                headless: false
+                // headless: false
             },
         },
         before,


### PR DESCRIPTION
Bugfix - JavaScript imports from st.css file are now resolved correctly with context