### PR TITLE
feat(core-test-kit): Test helper for matching target selector inline

### DIFF
--- a/packages/core-test-kit/README.md
+++ b/packages/core-test-kit/README.md
@@ -21,6 +21,35 @@ A collection of tools aimed at testing Stylable diagnostics messages (warnings a
 
 Used for easily setting up Stylable instances (processor/transformer) and its infrastructure.
 
+Exposes `expectTransformOutput` utility for creating a transform tests. these are the most common core tests and the recommended way to test the core transform functionality.
+
+Currently only supports testing target selector but when needed the functionality can be expended here to support: 
+
+* JavaScript exports output
+* Declaration values
+* Mixins output  
+
+Example using the /* @expect selector */ magic comment to test the root selector target 
+
+```js
+expectTransformOutput(
+    {
+        entry: `/style.st.css`,
+        files: {
+            '/style.st.css': {
+                namespace: 'ns',
+                content: `
+                /* @expect .ns__root */
+                .root {}
+            `
+        },
+    },
+    1
+);
+```
+
+
+
 #### Match rules
 
 Exposes two utility functions (`matchRuleAndDeclaration` and `matchAllRulesAndDeclarations`) used for testing Stylable generated AST representing CSS rules and declarations.

--- a/packages/core-test-kit/README.md
+++ b/packages/core-test-kit/README.md
@@ -21,7 +21,7 @@ A collection of tools aimed at testing Stylable diagnostics messages (warnings a
 
 Used for easily setting up Stylable instances (processor/transformer) and its infrastructure.
 
-Exposes `expectTransformOutput` utility for creating a transform tests. these are the most common core tests and the recommended way to test the core transform functionality.
+Exposes `expectTransformOutput` utility for creating a transform tests. These are the most common core tests and the recommended way to test the core transform functionality.
 
 Currently only supports testing target selector but when needed the functionality can be expended here to support: 
 

--- a/packages/core-test-kit/README.md
+++ b/packages/core-test-kit/README.md
@@ -4,24 +4,24 @@
 
 `@stylable/core-test-kit` is a collection of utilities aimed at making testing Stylable core behavior and functionality easier.
 
-### What's in this test-kit?
+## What's in this test-kit?
 
-#### Matchers
+### Matchers
 
 An assortment of `Chai` matchers used by Stylable.
 
 - `flat-match` - flattens and matches passed arguments
 - `results` - test Stylable transpiled style rules output
 
-#### Diagnostics tooling
+### Diagnostics tooling
 
 A collection of tools aimed at testing Stylable diagnostics messages (warnings and errors).
 
-#### Testing infrastructure
+### Testing infrastructure
 
 Used for easily setting up Stylable instances (processor/transformer) and its infrastructure.
 
-Exposes `expectTransformOutput` utility for creating a transform tests. These are the most common core tests and the recommended way to test the core transform functionality.
+Exposes `expectTransformOutput` utility for creating transformation tests. These are the most common core tests and the recommended way to test the core transform functionality.
 
 Currently only supports testing target selector but when needed the functionality can be expended here to support: 
 
@@ -29,7 +29,8 @@ Currently only supports testing target selector but when needed the functionalit
 * Declaration values
 * Mixins output  
 
-Example using the /* @expect selector */ magic comment to test the root selector target 
+#### Example 
+Using the `/* @expect selector */` comment to test the root class selector target 
 
 ```js
 expectTransformOutput(
@@ -48,9 +49,7 @@ expectTransformOutput(
 );
 ```
 
-
-
-#### Match rules
+### Match rules
 
 Exposes two utility functions (`matchRuleAndDeclaration` and `matchAllRulesAndDeclarations`) used for testing Stylable generated AST representing CSS rules and declarations.
 

--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -15,6 +15,7 @@ import {
 } from '@stylable/core';
 import { isAbsolute } from 'path';
 import * as postcss from 'postcss';
+import { matchFromSource } from './match-rules';
 
 export interface File {
     content: string;
@@ -129,6 +130,12 @@ export function createTransform(
             keepValues: false,
         }).transform(meta).meta;
     };
+}
+
+export function expectTransformOutput(config: Config, numOfAssertions: number) {
+    const res = generateFromMock(config);
+    matchFromSource(res, numOfAssertions);
+    return res;
 }
 
 export function generateStylableResult(config: Config) {

--- a/packages/core-test-kit/src/match-rules.ts
+++ b/packages/core-test-kit/src/match-rules.ts
@@ -1,3 +1,4 @@
+import { StylableResults } from '@stylable/core';
 import * as postcss from 'postcss';
 
 export function matchRuleAndDeclaration(
@@ -33,4 +34,33 @@ export function matchAllRulesAndDeclarations(
     offset = 0
 ) {
     all.forEach((_, i) => matchRuleAndDeclaration(parent, i + offset, _[0], _[1], msg));
+}
+
+export function matchFromSource(results: StylableResults, numOfAssertions = 0) {
+    let foundAssertions = 0;
+    const errors: string[] = [];
+    const root = results.meta.outputAst;
+    if (!root) {
+        throw new Error('expectCSS missing root ast');
+    }
+    root.walkRules((rule) => {
+        const prev = rule.prev();
+
+        if (prev?.type === 'comment') {
+            const match = prev.text.trim().match(/@expect (.*)/);
+            if (match) {
+                foundAssertions++;
+                const selector = match[1];
+                if (selector !== rule.selector) {
+                    errors.push(`\nactual: ${rule.selector}\nexpect: ${selector}`);
+                }
+            }
+        }
+    });
+    if (foundAssertions !== numOfAssertions) {
+        errors.push(`expected ${numOfAssertions} @expect assertions found ${foundAssertions}`);
+    }
+    if (errors.length) {
+        throw new Error(errors.join('\n'));
+    }
 }

--- a/packages/core/test/stylable-transformer/elements.spec.ts
+++ b/packages/core/test/stylable-transformer/elements.spec.ts
@@ -1,134 +1,137 @@
-import { generateStylableRoot } from '@stylable/core-test-kit';
-import { expect } from 'chai';
-import * as postcss from 'postcss';
+import { expectTransformOutput } from '@stylable/core-test-kit';
 
 describe('Stylable transform elements', () => {
     describe('scoped elements', () => {
         it('component/tag selector with first Capital letter automatically extends reference with identical name', () => {
-            const result = generateStylableRoot({
-                entry: `/style.st.css`,
-                files: {
-                    '/style.st.css': {
-                        namespace: 'ns',
-                        content: `
+            expectTransformOutput(
+                {
+                    entry: `/style.st.css`,
+                    files: {
+                        '/style.st.css': {
+                            namespace: 'ns',
+                            content: `
                             :import {
                                 -st-from: "./imported.st.css";
                                 -st-default: Element;
                             }
+                            /* @expect .ns1__root */
                             Element {}
+                            /* @expect .ns__root .ns1__root */
                             .root Element {}
                         `,
-                    },
-                    '/imported.st.css': {
-                        namespace: 'ns1',
-                        content: ``,
+                        },
+                        '/imported.st.css': {
+                            namespace: 'ns1',
+                            content: ``,
+                        },
                     },
                 },
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns1__root');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.ns__root .ns1__root');
+                2
+            );
         });
 
         it('component/tag selector with first Capital letter automatically extend reference with identical name (inner parts)', () => {
-            const result = generateStylableRoot({
-                entry: `/entry.st.css`,
-                files: {
-                    '/entry.st.css': {
-                        namespace: 'entry',
-                        content: `
+            expectTransformOutput(
+                {
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
                             :import {
                                 -st-from: "./inner.st.css";
                                 -st-default: Element;
                             }
+                            /* @expect .inner__root .inner__part */
                             Element::part {}
                         `,
-                    },
-                    '/inner.st.css': {
-                        namespace: 'inner',
-                        content: `
+                        },
+                        '/inner.st.css': {
+                            namespace: 'inner',
+                            content: `
                             .part {}
                         `,
+                        },
                     },
                 },
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal(
-                '.inner__root .inner__part'
+                1
             );
         });
 
         it('resolve imported element that is also root', () => {
-            const result = generateStylableRoot({
-                entry: `/style.st.css`,
-                files: {
-                    '/style.st.css': {
-                        namespace: 'ns',
-                        content: `
+            expectTransformOutput(
+                {
+                    entry: `/style.st.css`,
+                    files: {
+                        '/style.st.css': {
+                            namespace: 'ns',
+                            content: `
                             :import {
                                 -st-from: "./imported.st.css";
                                 -st-named: ButtonX;
                             }
+                            /* @expect .ns__x */
                             .x {
                                 -st-extends: ButtonX;
                             }
                         `,
-                    },
-                    '/imported.st.css': {
-                        namespace: 'ns1',
-                        content: `
+                        },
+                        '/imported.st.css': {
+                            namespace: 'ns1',
+                            content: `
                             :import {
                                 -st-from: "./button-x.st.css";
                                 -st-default: ButtonX;
                             }
                             ButtonX{}
                         `,
-                    },
-                    '/button-x.st.css': {
-                        namespace: 'button-x',
-                        content: ``,
+                        },
+                        '/button-x.st.css': {
+                            namespace: 'button-x',
+                            content: ``,
+                        },
                     },
                 },
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns__x');
+                1
+            );
         });
 
         it('should resolve imported named element type when used as element', () => {
-            const res = generateStylableRoot({
-                entry: `/entry.st.css`,
-                files: {
-                    '/entry.st.css': {
-                        namespace: 'entry',
-                        content: `
+            expectTransformOutput(
+                {
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
                             :import {
                                 -st-from: "./inner.st.css";
                                 -st-named: Element;
                             }
-
+                            /* @expect .base__root */
                             Element {}
                         `,
-                    },
-                    '/inner.st.css': {
-                        namespace: 'inner',
-                        content: `
+                        },
+                        '/inner.st.css': {
+                            namespace: 'inner',
+                            content: `
                             :import {
                                 -st-from: "./base.st.css";
                                 -st-default: Element;
                             }
                             Element {}
                         `,
-                    },
-                    '/base.st.css': {
-                        namespace: 'base',
-                        content: `
+                        },
+                        '/base.st.css': {
+                            namespace: 'base',
+                            content: `
                             .root {}
                         `,
+                        },
                     },
                 },
-            });
-
-            expect((res.nodes[0] as postcss.Rule).selector).to.equal('.base__root');
+                1
+            );
         });
     });
 });


### PR DESCRIPTION
When creating Stylable transform tests usually the ugly part was to find the right selector in the AST and match it.

`expect((results.outputAst!.nodes[0] as postcss.Rule).selector).to.equal('...')`

Now we can write the matching selector inside the css as "magic comment" before the tested selector and we must specify the number of assertions.

```js

expectTransformOutput(
    {
        entry: `/style.st.css`,
        files: {
            '/style.st.css': {
                namespace: 'ns',
                content: `
                /* @expect .ns__root */
                .root {}
            `
        },
    },
    1
);

```