### PR TITLE
fix(core): fix false report on scoped elements

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -337,7 +337,7 @@ export class StylableProcessor {
 
         let locallyScoped = false;
 
-        traverseNode(rule.selectorAst, (node, _index, _nodes) => {
+        traverseNode(rule.selectorAst, (node, index, nodes) => {
             if (node.type === 'selector') {
                 locallyScoped = false;
             }
@@ -354,9 +354,9 @@ export class StylableProcessor {
                             return false;
                         }
 
-                        const _import = this.handleImport(rule);
-                        this.meta.imports.push(_import);
-                        this.addImportSymbols(_import);
+                        const imported = this.handleImport(rule);
+                        this.meta.imports.push(imported);
+                        this.addImportSymbols(imported);
                         return false;
                     } else {
                         this.diagnostics.warn(
@@ -395,7 +395,7 @@ export class StylableProcessor {
                     if (!this.meta.classes[name].alias) {
                         locallyScoped = true;
                     } else if (locallyScoped === false && !inStScope) {
-                        if (this.checkForScopedNodeAfter(rule, _nodes, _index) === false) {
+                        if (this.checkForScopedNodeAfter(rule, nodes, index) === false) {
                             this.diagnostics.warn(rule, processorWarnings.UNSCOPED_CLASS(name), {
                                 word: name,
                             });
@@ -408,7 +408,7 @@ export class StylableProcessor {
                 this.addElementSymbolOnce(name, rule);
 
                 if (locallyScoped === false && !inStScope) {
-                    if (this.checkForScopedNodeAfter(rule, _nodes, _index) === false) {
+                    if (this.checkForScopedNodeAfter(rule, nodes, index) === false) {
                         this.diagnostics.warn(rule, processorWarnings.UNSCOPED_ELEMENT(name), {
                             word: name,
                         });

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -334,10 +334,13 @@ export class StylableProcessor {
         rule.selectorAst = parseSelector(rule.selector);
 
         const checker = createSimpleSelectorChecker();
-        const validRoot = isRootValid(rule.selectorAst, 'root');
+
         let locallyScoped = false;
 
         traverseNode(rule.selectorAst, (node, _index, _nodes) => {
+            if (node.type === 'selector') {
+                locallyScoped = false;
+            }
             if (!checker(node)) {
                 rule.isSimpleSelector = false;
             }
@@ -392,18 +395,26 @@ export class StylableProcessor {
                     if (!this.meta.classes[name].alias) {
                         locallyScoped = true;
                     } else if (locallyScoped === false && !inStScope) {
-                        this.diagnostics.warn(rule, processorWarnings.UNSCOPED_CLASS(name), {
-                            word: name,
-                        });
+                        if (this.checkForScopedNodeAfter(rule, _nodes, _index) === false) {
+                            this.diagnostics.warn(rule, processorWarnings.UNSCOPED_CLASS(name), {
+                                word: name,
+                            });
+                        } else {
+                            locallyScoped = true;
+                        }
                     }
                 }
             } else if (type === 'element') {
                 this.addElementSymbolOnce(name, rule);
 
                 if (locallyScoped === false && !inStScope) {
-                    this.diagnostics.warn(rule, processorWarnings.UNSCOPED_ELEMENT(name), {
-                        word: name,
-                    });
+                    if (this.checkForScopedNodeAfter(rule, _nodes, _index) === false) {
+                        this.diagnostics.warn(rule, processorWarnings.UNSCOPED_ELEMENT(name), {
+                            word: name,
+                        });
+                    } else {
+                        locallyScoped = true;
+                    }
                 }
             } else if (type === 'nested-pseudo-class' && name === 'global') {
                 return true;
@@ -418,7 +429,7 @@ export class StylableProcessor {
             rule.selectorType = 'complex';
         }
 
-        if (!validRoot) {
+        if (!isRootValid(rule.selectorAst, 'root')) {
             this.diagnostics.warn(rule, processorWarnings.ROOT_AFTER_SPACING());
         }
     }
@@ -440,6 +451,28 @@ export class StylableProcessor {
             });
         }
         return symbol;
+    }
+
+    protected checkForScopedNodeAfter(rule: postcss.Rule, nodes: SelectorAstNode[], index: number) {
+        for (let i = index + 1; i < nodes.length; i++) {
+            const element = nodes[i];
+            if (!element) {
+                break;
+            }
+            if (element.type === 'spacing' || element.type === 'operator') {
+                break;
+            }
+            if (element.type === 'class') {
+                this.addClassSymbolOnce(element.name, rule);
+
+                if (this.meta.classes[element.name]) {
+                    if (!this.meta.classes[element.name].alias) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     protected addElementSymbolOnce(name: string, rule: postcss.Rule) {

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -1057,6 +1057,38 @@ describe('diagnostics: warnings and errors', () => {
                 );
             });
 
+            it('should warn with multiple selector', () => {
+                expectWarnings(
+                    `
+                    |.x, $button$| {}
+                `,
+                    [{ message: processorWarnings.UNSCOPED_ELEMENT('button'), file: 'main.css' }]
+                );
+            });
+
+            it('should not warn if same chunk is scoped', () => {
+                expectWarnings(
+                    `
+                    |$button$.root| {}
+                `,
+                    []
+                );
+            });
+
+            it('should not warn when using imported elements (classes) with scoping in the same chunk', () => {
+                expectWarnings(
+                    `
+                    :import {
+                        -st-from: "./blah.st.css";
+                        -st-named: Blah;
+                    }
+
+                    |.$Blah$.root| {}
+                `,
+                    []
+                );
+            });
+
             it('should warn when using imported element with no root scoping', () => {
                 expectWarnings(
                     `

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -1075,7 +1075,7 @@ describe('diagnostics: warnings and errors', () => {
                 );
             });
 
-            it('should not warn when using imported elements (classes) with scoping in the same chunk', () => {
+            it('should not warn when using imported elements with scoping in the same chunk', () => {
                 expectWarnings(
                     `
                     :import {
@@ -1083,7 +1083,7 @@ describe('diagnostics: warnings and errors', () => {
                         -st-named: Blah;
                     }
 
-                    |.$Blah$.root| {}
+                    |$Blah$.root| {}
                 `,
                     []
                 );


### PR DESCRIPTION
fix a false report on scoped elements when scoping happens after the element node
Example of false report:
`div.root{}`