### PR TITLE
Add resolver cache for symbol resolution.

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -167,6 +167,7 @@ const stylable = Stylable.create({
     requireModule: require,
     projectRoot: rootDir,
     resolveNamespace: require(namespaceResolver).resolveNamespace,
+    resolverCache: new Map()
 });
 
 build({

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -70,7 +70,7 @@ export class StylableResolver {
                 res = null;
             }
         }
-        this.cache?.set(key, null);
+        this.cache?.set(key, res);
         return res;
     }
 

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -74,7 +74,11 @@ export class StylableResolver {
         return res;
     }
 
-    public resolveImported(imported: Imported, name: string): CSSResolve | JSResolve | null {
+    public resolveImported(
+        imported: Imported,
+        name: string,
+        subtype: 'mappedSymbols' | 'mappedKeyframes' = 'mappedSymbols'
+    ): CSSResolve | JSResolve | null {
         const res = this.getModule(imported);
         if (res === null) {
             return null;
@@ -84,9 +88,7 @@ export class StylableResolver {
             const meta = res as StylableMeta;
             return {
                 _kind: 'css',
-                symbol: !name
-                    ? meta.mappedSymbols[meta.root]
-                    : meta.mappedSymbols[name] || meta.mappedKeyframes[name],
+                symbol: !name ? meta.mappedSymbols[meta.root] : meta[subtype][name],
                 meta,
             };
         } else {
@@ -134,7 +136,11 @@ export class StylableResolver {
         };
 
         while (current.symbol?.import) {
-            const res = this.resolveImported(current.symbol.import, current.symbol.name);
+            const res = this.resolveImported(
+                current.symbol.import,
+                current.symbol.name,
+                'mappedKeyframes'
+            );
             if (res?._kind === 'css' && res.symbol?._kind === 'keyframes') {
                 const { meta, symbol } = res;
                 current = {

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -40,7 +40,7 @@ import {
     StylableMeta,
     StylableSymbol,
 } from './stylable-processor';
-import { CSSResolve, JSResolve, StylableResolver } from './stylable-resolver';
+import { CSSResolve, JSResolve, ResolverCache, StylableResolver } from './stylable-resolver';
 import { findRule, generateScopedCSSVar, getDeclStylable, isCSSVarProp } from './stylable-utils';
 import { valueMapping } from './stylable-value-parsers';
 
@@ -106,6 +106,7 @@ export interface TransformerOptions {
     replaceValueHook?: replaceValueHook;
     postProcessor?: postProcessor;
     mode?: EnvMode;
+    resolveCache?: ResolverCache;
 }
 
 export interface AdditionalSelector {
@@ -153,7 +154,11 @@ export class StylableTransformer {
         this.fileProcessor = options.fileProcessor;
         this.replaceValueHook = options.replaceValueHook;
         this.postProcessor = options.postProcessor;
-        this.resolver = new StylableResolver(options.fileProcessor, options.requireModule);
+        this.resolver = new StylableResolver(
+            options.fileProcessor,
+            options.requireModule,
+            options.resolveCache
+        );
         this.mode = options.mode || 'production';
     }
     public transform(meta: StylableMeta): StylableResults {

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -40,7 +40,7 @@ import {
     StylableMeta,
     StylableSymbol,
 } from './stylable-processor';
-import { CSSResolve, JSResolve, ResolverCache, StylableResolver } from './stylable-resolver';
+import { CSSResolve, JSResolve, StylableResolverCache, StylableResolver } from './stylable-resolver';
 import { findRule, generateScopedCSSVar, getDeclStylable, isCSSVarProp } from './stylable-utils';
 import { valueMapping } from './stylable-value-parsers';
 
@@ -106,7 +106,7 @@ export interface TransformerOptions {
     replaceValueHook?: replaceValueHook;
     postProcessor?: postProcessor;
     mode?: EnvMode;
-    resolveCache?: ResolverCache;
+    resolveCache?: StylableResolverCache;
 }
 
 export interface AdditionalSelector {

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -106,7 +106,7 @@ export interface TransformerOptions {
     replaceValueHook?: replaceValueHook;
     postProcessor?: postProcessor;
     mode?: EnvMode;
-    resolveCache?: StylableResolverCache;
+    resolverCache?: StylableResolverCache;
 }
 
 export interface AdditionalSelector {
@@ -157,7 +157,7 @@ export class StylableTransformer {
         this.resolver = new StylableResolver(
             options.fileProcessor,
             options.requireModule,
-            options.resolveCache
+            options.resolverCache
         );
         this.mode = options.mode || 'production';
     }

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -29,6 +29,7 @@ export interface StylableConfig {
     optimizer?: IStylableOptimizer;
     mode?: 'production' | 'development';
     resolveNamespace?: typeof processNamespace;
+    /** @deprecated use resolverCache instead */
     timedCacheOptions?: Omit<TimedCacheOptions, 'createKey'>;
     resolveModule?: ModuleResolver;
     cssParser?: CssParser;

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -35,6 +35,8 @@ export interface StylableConfig {
     resolverCache?: StylableResolverCache;
 }
 
+export type CreateProcessorOptions = Pick<StylableConfig, 'resolveNamespace'>;
+
 export class Stylable {
     public static create(config: StylableConfig) {
         return new this(
@@ -110,7 +112,7 @@ export class Stylable {
             resolverCache || this.resolverCache
         );
     }
-    public createProcessor({ resolveNamespace }: Pick<StylableConfig, 'resolveNamespace'> = {}) {
+    public createProcessor({ resolveNamespace }: CreateProcessorOptions = {}) {
         return new StylableProcessor(new Diagnostics(), resolveNamespace || this.resolveNamespace);
     }
     public createTransformer(options: Partial<TransformerOptions> = {}) {
@@ -131,18 +133,16 @@ export class Stylable {
     public transform(
         meta: string | StylableMeta,
         resourcePath?: string,
-        options: Partial<TransformerOptions> = {}
+        options: Partial<TransformerOptions> = {},
+        processorOptions: CreateProcessorOptions = {}
     ): StylableResults {
         if (typeof meta === 'string') {
-            // TODO: refactor to use fileProcessor
-            // meta = this.fileProcessor.processContent(meta, resourcePath + '');
-            const root = this.cssParser(meta, { from: resourcePath });
-            meta = this.createProcessor().process(root);
+            meta = this.createProcessor(processorOptions).process(
+                this.cssParser(meta, { from: resourcePath })
+            );
         }
         const transformer = this.createTransformer(options);
-
         this.fileProcessor.add(meta.source, meta);
-
         return transformer.transform(meta);
     }
     public process(fullpath: string, context?: string, ignoreCache?: boolean): StylableMeta {

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -3,7 +3,7 @@ import { createInfrastructure } from './create-infra-structure';
 import { Diagnostics } from './diagnostics';
 import { CssParser, safeParse } from './parser';
 import { processNamespace, StylableMeta, StylableProcessor } from './stylable-processor';
-import { StylableResolver } from './stylable-resolver';
+import { ResolverCache, StylableResolver } from './stylable-resolver';
 import {
     StylableResults,
     StylableTransformer,
@@ -61,6 +61,7 @@ export class Stylable {
     public fileProcessor: FileProcessor<StylableMeta>;
     public resolver: StylableResolver;
     public resolvePath: (ctx: string | undefined, path: string) => string;
+    public resolverCache?: ResolverCache;
     constructor(
         public projectRoot: string,
         protected fileSystem: MinimalFS,
@@ -93,6 +94,15 @@ export class Stylable {
         this.resolvePath = resolvePath;
         this.fileProcessor = fileProcessor;
         this.resolver = new StylableResolver(this.fileProcessor, this.requireModule);
+    }
+    public initCache() {
+        this.resolverCache = new Map();
+    }
+    public createResolver() {
+        return new StylableResolver(this.fileProcessor, this.requireModule, this.resolverCache);
+    }
+    public createProcessor() {
+        return new StylableProcessor(undefined, this.resolveNamespace);
     }
     public createTransformer(options: Partial<TransformerOptions> = {}) {
         return new StylableTransformer({

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -121,6 +121,7 @@ export class Stylable {
             requireModule: this.requireModule,
             postProcessor: this.hooks.postProcessor,
             replaceValueHook: this.hooks.replaceValueHook,
+            resolverCache: this.resolverCache,
             mode: this.mode,
             ...options,
         });

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1199,6 +1199,52 @@ describe('Stylable postcss transform (Scoping)', () => {
             );
         });
 
+        it('scope imported animation and animation name with part name collision', () => {
+            const result = generateStylableRoot({
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            :import {
+                                -st-from: './imported.st.css';
+                                -st-named: anim1, keyframes(anim1);
+                            }
+
+                            .selector {
+                                animation: 2s anim1 infinite;
+                                animation-name: anim1;
+                            }
+
+                            .anim1{}
+
+                        `,
+                    },
+                    '/imported.st.css': {
+                        namespace: 'imported',
+                        content: `
+                            @keyframes anim1 {
+                                from {}
+                                to {}
+                            }
+                            .anim1 {}
+
+                        `,
+                    },
+                },
+            });
+
+            expect((result.nodes[0] as postcss.Rule).nodes[0].toString()).to.equal(
+                'animation: 2s imported__anim1 infinite'
+            );
+            expect((result.nodes[0] as postcss.Rule).nodes[1].toString()).to.equal(
+                'animation-name: imported__anim1'
+            );
+            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
+                '.imported__anim1'
+            );
+        });
+
         it('not scope rules that are child of keyframe atRule', () => {
             const result = generateStylableRoot({
                 entry: `/entry.st.css`,

--- a/packages/experimental-loader/src/cached-stylable-factory.ts
+++ b/packages/experimental-loader/src/cached-stylable-factory.ts
@@ -1,4 +1,5 @@
 import { Stylable, StylableConfig } from '@stylable/core';
+import decache from 'decache';
 import { Compiler } from 'webpack';
 
 const stylableInstancesCache = new WeakMap<Compiler, Map<Stylable, StylableConfig>>();
@@ -13,7 +14,20 @@ export function getStylable(compiler: Compiler, initialConfig: StylableConfig): 
 
     let stylable = findMatchingStylableInstance(initialConfig, cache);
     if (!stylable) {
-        stylable = Stylable.create(initialConfig);
+        const requireModuleCache = new Set<string>();
+        const requireModule = (id: string) => {
+            requireModuleCache.add(id);
+            return require(id);
+        };
+
+        stylable = Stylable.create({ ...initialConfig, requireModule });
+        stylable.initCache();
+        compiler.hooks.done.tap('StylableLoader stylable.initCache', () => {
+            stylable!.initCache();
+            for (const id of requireModuleCache) {
+                decache(id);
+            }
+        });
         cache.set(stylable, initialConfig);
     }
     return stylable;

--- a/packages/experimental-loader/src/cached-stylable-factory.ts
+++ b/packages/experimental-loader/src/cached-stylable-factory.ts
@@ -20,8 +20,7 @@ export function getStylable(compiler: Compiler, initialConfig: StylableConfig): 
             return require(id);
         };
 
-        stylable = Stylable.create({ ...initialConfig, requireModule });
-        stylable.initCache();
+        stylable = Stylable.create({ ...initialConfig, requireModule, resolverCache: new Map() });
         compiler.hooks.done.tap('StylableLoader stylable.initCache', () => {
             stylable!.initCache();
             for (const id of requireModuleCache) {

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -1,6 +1,5 @@
 import { loader } from 'webpack';
 import postcss from 'postcss';
-import decache from 'decache';
 import { Stylable, processNamespace, StylableResults } from '@stylable/core';
 import { StylableOptimizer } from '@stylable/optimizer';
 import { getOptions, isUrlRequest, stringifyRequest } from 'loader-utils';
@@ -43,11 +42,6 @@ interface LoaderImport {
     index: number;
 }
 
-const timedCacheOptions = { useTimer: true, timeout: 1000 };
-const requireModule = (id: string) => {
-    decache(id);
-    return require(id);
-};
 const optimizer = new StylableOptimizer();
 
 const stylableLoader: loader.Loader = function (content) {
@@ -72,9 +66,7 @@ const stylableLoader: loader.Loader = function (content) {
         fileSystem: this.fs,
         mode,
         resolveOptions: this._compiler.options.resolve as any /* make stylable types better */,
-        timedCacheOptions,
         resolveNamespace,
-        requireModule,
     });
 
     const res = stylable.transform(content, this.resourcePath);

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -57,9 +57,11 @@ export class StylableManifestPlugin {
             },
             mode: compiler.options.mode === 'development' ? 'development' : 'production',
             resolveOptions: compiler.options.resolve as any /* make stylable types better */,
-            timedCacheOptions: { useTimer: true, timeout: 1000 },
+            resolverCache: new Map(),
             resolveNamespace: this.options.resolveNamespace,
         });
+
+        compiler.hooks.done.tap(this.constructor.name + ' stylable.initCache', () => stylable.initCache());
 
         let metadata: Array<{ compId: string; metadata: Metadata }>;
         compiler.hooks.compilation.tap(this.constructor.name, (compilation) => {

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -130,7 +130,7 @@ export class StylableWebpackPlugin {
             new Map()
         );
         this.stylable = stylable;
-        compiler.hooks.done.tap('decache require', () => {
+        compiler.hooks.done.tap(StylableWebpackPlugin.name + ' stylable.initCache', () => {
             this.stylable.initCache();
         });
     }

--- a/packages/webpack-plugin/src/stylable-webpack-plugin.ts
+++ b/packages/webpack-plugin/src/stylable-webpack-plugin.ts
@@ -125,9 +125,14 @@ export class StylableWebpackPlugin {
             compiler.options.mode as any,
             this.options.resolveNamespace || resolveNamespace,
             undefined,
-            resolveModule
+            resolveModule,
+            undefined,
+            new Map()
         );
         this.stylable = stylable;
+        compiler.hooks.done.tap('decache require', () => {
+            this.stylable.initCache();
+        });
     }
     public injectPlugins(compiler: webpack.Compiler) {
         if (this.options.plugins) {


### PR DESCRIPTION
Add resolver cache for all imports. this is an opt in so there is no breaking change. 
The ability improve dramatically the performance of stylable transform