### PR TITLE
refactor(cli): move cli entry to bin folder

### DIFF
--- a/packages/cli/bin/stc.js
+++ b/packages/cli/bin/stc.js
@@ -3,10 +3,10 @@
 const { normalize } = require('path');
 
 // Use ts-tools to run typescript from source when running in the context of this mono-repo
-if (__filename.endsWith(normalize('/packages/cli/cli.js'))) {
+if (__filename.endsWith(normalize('/packages/cli/bin/stc.js'))) {
     require('@ts-tools/node/r');
     require('tsconfig-paths/register');
-    require('./src/cli');
+    require('../src/cli');
 } else {
-    require('./cjs/cli');
+    require('../cjs/cli');
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "cjs/index.js",
   "types": "cjs/index.d.ts",
   "bin": {
-    "stc": "./cli.js"
+    "stc": "bin/stc.js"
   },
   "scripts": {
     "clean": "rimraf ./cjs",
@@ -22,9 +22,9 @@
     "yargs": "^16.2.0"
   },
   "files": [
+    "bin",
     "cjs",
-    "src",
-    "cli.js"
+    "src"
   ],
   "engines": {
     "node": ">=10"

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -7,7 +7,7 @@ import { evalStylableModule } from '@stylable/module-utils/test/test-kit';
 import { resolveNamespace } from '@stylable/node';
 
 function runCli(cliArgs: string[] = []) {
-    const cliPath = require.resolve('@stylable/cli/cli.js');
+    const cliPath = require.resolve('@stylable/cli/bin/stc.js');
     return spawnSync('node', [cliPath, ...cliArgs], { encoding: 'utf8' });
 }
 


### PR DESCRIPTION
- for a more common package structure.
- named entrypoint `stc.js`, per cli name.