### PR TITLE
fix(core): always resolve non-absolute requests

### DIFF
--- a/packages/core/src/create-infra-structure.ts
+++ b/packages/core/src/create-infra-structure.ts
@@ -23,10 +23,7 @@ export function createInfrastructure(
     createDiagnostics?: (from: string) => Diagnostics
 ): StylableInfrastructure {
     let resolvePath = (context: string | undefined = projectRoot, moduleId: string) => {
-        if (!path.isAbsolute(moduleId) && !moduleId.startsWith('.')) {
-            moduleId = resolveModule(context, moduleId);
-        }
-        return moduleId;
+        return path.isAbsolute(moduleId) ? moduleId : resolveModule(context, moduleId);
     };
 
     if (timedCacheOptions) {


### PR DESCRIPTION
mid-solution that ensures all non-absolute requests are resolved using the resolver, while absolute ones are returned untouched.

this allows flows calling the resolvePath with absolute paths to stay fast, while providing full/correct resolution for any non-absolute requests.

this change also has the potential to improve caching/correctness in locations that used the returned result as cache key.