### PR TITLE
infra: ensure only tests can access test globals

### DIFF
--- a/packages/cli/test/tsconfig.json
+++ b/packages/cli/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [
     { "path": "../../core/src" },

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../src" }, { "path": "../../core-test-kit/src" }]
 }

--- a/packages/custom-value/test/tsconfig.json
+++ b/packages/custom-value/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../../webpack-plugin/src" }, { "path": "../../e2e-test-kit/src" }]
 }

--- a/packages/dom-test-kit/test/tsconfig.json
+++ b/packages/dom-test-kit/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../../runtime/src" }, { "path": "../src" }]
 }

--- a/packages/eslint-plugin-stylable/test/tsconfig.json
+++ b/packages/eslint-plugin-stylable/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../src" }]
 }

--- a/packages/experimental-loader/test/tsconfig.json
+++ b/packages/experimental-loader/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [
     { "path": "../../e2e-test-kit/src" },

--- a/packages/jest/test/tsconfig.json
+++ b/packages/jest/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../../runtime/src" }, { "path": "../src" }]
 }

--- a/packages/language-service/test/tsconfig.json
+++ b/packages/language-service/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../src" }, { "path": "../../core/src" }]
 }

--- a/packages/module-utils/test/tsconfig.json
+++ b/packages/module-utils/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [
     { "path": "../../e2e-test-kit/src" },

--- a/packages/node/test/tsconfig.json
+++ b/packages/node/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../../core/src" }, { "path": "../src" }]
 }

--- a/packages/optimizer/test/tsconfig.json
+++ b/packages/optimizer/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../src" }, { "path": "../../core-test-kit/src" }]
 }

--- a/packages/runtime/test/tsconfig.json
+++ b/packages/runtime/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [
     { "path": "../../webpack-plugin/src" },

--- a/packages/schema-extract/test/tsconfig.json
+++ b/packages/schema-extract/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../src" }, { "path": "../../core-test-kit/src" }]
 }

--- a/packages/uni-driver/test/tsconfig.json
+++ b/packages/uni-driver/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [{ "path": "../../dom-test-kit/src" }, { "path": "../src" }]
 }

--- a/packages/webpack-extensions/test/tsconfig.json
+++ b/packages/webpack-extensions/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [
     { "path": "../../e2e-test-kit/src" },

--- a/packages/webpack-plugin/test/tsconfig.json
+++ b/packages/webpack-plugin/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../dist/test"
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
   },
   "references": [
     { "path": "../../e2e-test-kit/src" },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -51,11 +51,7 @@
       "node_modules/@types",
       "typings"
     ],                                        /* List of folders to include type definitions from. */
-    "types": [
-      "node",
-      "mocha",
-      "externals",
-    ],                                        /* Type declaration files to be included in compilation. */
+    "types": ["node", "externals"],           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
build time is roughly the same on my machine, so I don't expect this improve build speed as much as I hoped it would.