### PR TITLE
False scoping diagnostic on selector with ":not()"

### DIFF
--- a/packages/core/src/selector-utils.ts
+++ b/packages/core/src/selector-utils.ts
@@ -22,7 +22,8 @@ export interface PseudoSelectorAstNode extends SelectorAstNode {
 export type Visitor = (
     node: SelectorAstNode,
     index: number,
-    nodes: SelectorAstNode[]
+    nodes: SelectorAstNode[],
+    parents: SelectorAstNode[]
 ) => boolean | void;
 type nodeWithPseudo = Partial<SelectorAstNode> & { pseudo: Array<Partial<SelectorAstNode>> };
 
@@ -38,13 +39,14 @@ export function traverseNode(
     node: SelectorAstNode,
     visitor: Visitor,
     index = 0,
-    nodes: SelectorAstNode[] = [node]
+    nodes: SelectorAstNode[] = [node],
+    parents: SelectorAstNode[] = []
 ): boolean | void {
     if (!node) {
         return;
     }
     const cNodes = node.nodes;
-    let doNext = visitor(node, index, nodes);
+    let doNext = visitor(node, index, nodes, parents);
     if (doNext === false) {
         return false;
     }
@@ -52,13 +54,24 @@ export function traverseNode(
         return true;
     }
     if (cNodes) {
+        parents = [...parents, node];
         for (let i = 0; i < node.nodes.length; i++) {
-            doNext = traverseNode(node.nodes[i], visitor, i, node.nodes);
+            doNext = traverseNode(node.nodes[i], visitor, i, node.nodes, parents);
             if (doNext === false) {
                 return false;
             }
         }
     }
+}
+
+export function isNested(parentChain: SelectorAstNode[]) {
+    let i = parentChain.length;
+    while (i--) {
+        if (parentChain[i].type === 'nested-pseudo-class') {
+            return true;
+        }
+    }
+    return false;
 }
 
 export function createChecker(types: Array<string | string[]>) {

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -8,6 +8,7 @@ import {
     createSimpleSelectorChecker,
     isChildOfAtRule,
     isCompRoot,
+    isNested,
     isRootValid,
     parseSelector,
     SelectorAstNode,
@@ -351,8 +352,8 @@ export class StylableProcessor {
 
         let locallyScoped = false;
 
-        traverseNode(rule.selectorAst, (node, index, nodes) => {
-            if (node.type === 'selector') {
+        traverseNode(rule.selectorAst, (node, index, nodes, parents) => {
+            if (node.type === 'selector' && !isNested(parents)) {
                 locallyScoped = false;
             }
             if (!checker(node)) {

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -1034,6 +1034,23 @@ describe('diagnostics: warnings and errors', () => {
                 );
             });
 
+            it('should not issue scoping diagnostics for a class scoped by a selector with ":not()" (regression)', () => {
+                expectWarnings(
+                    `
+                    :import {
+                        -st-from: "./blah.st.css";
+                        -st-named: classNeedsScoping;
+                    }
+                    .cls {
+                        -st-states: someState;
+                    }
+
+                    .cls:not(:someState) .classNeedsScoping {}  
+                `,
+                    []
+                );
+            });
+
             it('should not warn when using imported elements (classes) without scoping', () => {
                 expectWarnings(
                     `


### PR DESCRIPTION
This example will trigger a false scoping diagnostic for `.classNeedsScoping`.
```
:import {                  
  -st-from: "./blah.st.css;
  -st-named: classNeedsScoping;
}
.cls {
  -st-states: someState;
}
.cls:not(:someState) .classNeedsScoping {}  
```