### PR TITLE
fix(langauge-service): ignore diagnostic for "@st-global-custom-propety"

### DIFF
--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -136,7 +136,8 @@ export class CssService {
                     diag.code === 'unknownAtRules' &&
                     (atRuleName === '@custom-selector' ||
                         atRuleName === '@st-scope' ||
-                        atRuleName === '@st-import')
+                        atRuleName === '@st-import' ||
+                        atRuleName === '@st-global-custom-property')
                 ) {
                     return false;
                 }

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -143,6 +143,19 @@ describe('diagnostics', () => {
             expect(diagnostics).to.eql([]);
         });
 
+        it('should not warn about pseudo-states with params', () => {
+            const filePath = '/style.st.css';
+
+            const diagnostics = createDiagnostics(
+                {
+                    [filePath]: `@st-global-custom-property --x;   /* unknownAtRules */`,
+                },
+                filePath
+            );
+
+            expect(diagnostics).to.eql([]);
+        });
+
         it('should ignore errors from stylable vars in a media query', () => {
             const filePath = '/style.st.css';
 


### PR DESCRIPTION
Fixes #1230 