### PR TITLE
fix(webpack-plugin): fix crash in optimization step when css is broken

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -369,26 +369,30 @@ export class StylableWebpackPlugin {
             }
 
             for (const module of sortedModules) {
-                const buildMeta = getStylableBuildMeta(module);
-                const { css, exports, globals } = buildMeta;
+                try {
+                    const buildMeta = getStylableBuildMeta(module);
+                    const { css, exports, globals } = buildMeta;
 
-                const ast = parse(css);
+                    const ast = parse(css);
 
-                optimizer.optimizeAst(
-                    optimizeOptions,
-                    ast,
-                    usageMapping,
-                    this.stylable.delimiter,
-                    exports,
-                    globals
-                );
+                    optimizer.optimizeAst(
+                        optimizeOptions,
+                        ast,
+                        usageMapping,
+                        this.stylable.delimiter,
+                        exports,
+                        globals
+                    );
 
-                buildMeta.css = optimizeOptions.minify
-                    ? optimizer.minifyCSS(ast.toString())
-                    : ast.toString();
+                    buildMeta.css = optimizeOptions.minify
+                        ? optimizer.minifyCSS(ast.toString())
+                        : ast.toString();
 
-                if (optimizeOptions.shortNamespaces) {
-                    buildMeta.namespace = namespaceMapping[buildMeta.namespace];
+                    if (optimizeOptions.shortNamespaces) {
+                        buildMeta.namespace = namespaceMapping[buildMeta.namespace];
+                    }
+                } catch (e) {
+                    compilation.errors.push(e);
                 }
             }
         });

--- a/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/package.json
+++ b/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "watched-project"
+}

--- a/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/src/index.js
@@ -1,0 +1,4 @@
+import { classes } from './index.st.css';
+
+document.body.textContent = 'Watching!';
+document.body.classList.add(classes.root);

--- a/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/src/index.st.css
@@ -1,0 +1,3 @@
+.root {
+    color: red;
+}

--- a/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/watched-project-error-recovery/webpack.config.js
@@ -1,0 +1,10 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [new StylableWebpackPlugin({ cssInjection: 'css', filename: 'stylable.[contenthash].css' }), new HtmlWebpackPlugin()],
+};

--- a/packages/webpack-plugin/test/e2e/watched-project-error-recovery.spec.ts
+++ b/packages/webpack-plugin/test/e2e/watched-project-error-recovery.spec.ts
@@ -36,7 +36,7 @@ describe(`(${project})`, () => {
                 );
             },
             async () => {
-                await page.reload({ waitUntil: 'networkidle' });
+                const { page } = await projectRunner.openInBrowser();
                 const color = await page.evaluate(() => getComputedStyle(document.body).color);
                 expect(color).to.equal('rgb(0, 128, 0)');
             }
@@ -51,7 +51,8 @@ describe(`(${project})`, () => {
                 );
             },
             async () => {
-                await page.reload({ waitUntil: 'networkidle' });
+                const { page } = await projectRunner.openInBrowser();
+
                 const e = projectRunner.getBuildErrorMessages();
 
                 expect(e.length, 'one error').to.equal(1);
@@ -72,7 +73,7 @@ describe(`(${project})`, () => {
                 );
             },
             async () => {
-                await page.reload({ waitUntil: 'networkidle' });
+                const { page } = await projectRunner.openInBrowser();
 
                 const color = await page.evaluate(() => getComputedStyle(document.body).color);
                 // Broken css never loaded to the browser

--- a/packages/webpack-plugin/test/e2e/watched-project-error-recovery.spec.ts
+++ b/packages/webpack-plugin/test/e2e/watched-project-error-recovery.spec.ts
@@ -1,0 +1,83 @@
+import { writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { expect } from 'chai';
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+
+const project = 'watched-project-error-recovery';
+const projectDir = dirname(
+    require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
+);
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir,
+            launchOptions: {
+                headless: false,
+            },
+        },
+        before,
+        afterEach,
+        after,
+        true
+    );
+    it('renders css', async () => {
+        const { page } = await projectRunner.openInBrowser();
+
+        const color = await page.evaluate(() => getComputedStyle(document.body).color);
+        expect(color).to.equal('rgb(255, 0, 0)');
+
+        await projectRunner.actAndWaitForRecompile(
+            'make a change',
+            () => {
+                writeFileSync(
+                    join(projectRunner.projectDir, 'src', 'index.st.css'),
+                    '.root{ color: green; }'
+                );
+            },
+            async () => {
+                await page.reload({ waitUntil: 'networkidle' });
+                const color = await page.evaluate(() => getComputedStyle(document.body).color);
+                expect(color).to.equal('rgb(0, 128, 0)');
+            }
+        );
+
+        await projectRunner.actAndWaitForRecompile(
+            'break the output',
+            () => {
+                writeFileSync(
+                    join(projectRunner.projectDir, 'src', 'index.st.css'),
+                    '.root{ color:: blue; }'
+                );
+            },
+            async () => {
+                await page.reload({ waitUntil: 'networkidle' });
+                const e = projectRunner.getBuildErrorMessages();
+
+                expect(e.length, 'one error').to.equal(1);
+                expect(e[0].constructor.name, 'one error').to.equal('CssSyntaxError');
+                expect(e[0].message).to.match(/Double colon/);
+
+                const color = await page.evaluate(() => getComputedStyle(document.body).color);
+                expect(color).to.equal('rgb(0, 0, 0)');
+            }
+        );
+
+        await projectRunner.actAndWaitForRecompile(
+            'fix the output',
+            () => {
+                writeFileSync(
+                    join(projectRunner.projectDir, 'src', 'index.st.css'),
+                    '.root{ color: blue; }'
+                );
+            },
+            async () => {
+                await page.reload({ waitUntil: 'networkidle' });
+
+                const color = await page.evaluate(() => getComputedStyle(document.body).color);
+                // Broken css never loaded to the browser
+                expect(color).to.equal('rgb(0, 0, 255)');
+            }
+        );
+    });
+});

--- a/packages/webpack-plugin/test/e2e/watched-project-error-recovery.spec.ts
+++ b/packages/webpack-plugin/test/e2e/watched-project-error-recovery.spec.ts
@@ -13,7 +13,7 @@ describe(`(${project})`, () => {
         {
             projectDir,
             launchOptions: {
-                headless: false,
+                // headless: false,
             },
         },
         before,


### PR DESCRIPTION
When using `cssInjection: 'css'` if the css is invalid we break webpack. this PR fixes that. 