### PR TITLE
refactor: use native assets in create-stylable-app

### DIFF
--- a/packages/create-stylable-app/template/ts-react-webpack/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/template.js
@@ -1,3 +1,4 @@
+/** @type {import('create-stylable-app').TemplateDefinition} */
 module.exports = {
     dependencies: ['@stylable/runtime', 'react', 'react-dom'],
     devDependencies: [
@@ -12,7 +13,6 @@ module.exports = {
         'eslint-plugin-react-hooks',
         'eslint-plugin-stylable',
         'eslint',
-        'file-loader',
         'html-webpack-plugin',
         'rimraf',
         'serve',

--- a/packages/create-stylable-app/template/ts-react-webpack/webpack.config.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
             },
             {
                 test: /\.(png|jpg|jpeg|gif|svg)$/,
-                loader: 'file-loader',
+                type: 'asset/resource',
             },
         ],
     },


### PR DESCRIPTION
- one less dependency to worry about
- added `@type` comment in template definition for auto completions and hover info.