### PR TITLE
feat(core): basic transform support for @property

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -190,19 +190,24 @@ export class StylableTransformer {
             rule.selector = this.scopeRule(meta, rule);
         });
 
-        ast.walkAtRules(/media$/, (atRule) => {
-            atRule.params = evalDeclarationValue(
-                this.resolver,
-                atRule.params,
-                meta,
-                atRule,
-                variableOverride,
-                this.replaceValueHook,
-                this.diagnostics,
-                path.slice(),
-                undefined,
-                undefined
-            );
+        ast.walkAtRules((atRule) => {
+            const { name } = atRule;
+            if (name === 'media') {
+                atRule.params = evalDeclarationValue(
+                    this.resolver,
+                    atRule.params,
+                    meta,
+                    atRule,
+                    variableOverride,
+                    this.replaceValueHook,
+                    this.diagnostics,
+                    path.slice(),
+                    undefined,
+                    undefined
+                );
+            } else if (name === 'property') {
+                atRule.params = cssVarsMapping[atRule.params] ?? atRule.params;
+            }
         });
 
         ast.walkDecls((decl) => {

--- a/packages/core/test/stylable-transformer/at-property.spec.ts
+++ b/packages/core/test/stylable-transformer/at-property.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import type * as postcss from 'postcss';
+import { generateStylableRoot } from '@stylable/core-test-kit';
+
+describe('@property support', () => {
+    it('should transform @property var definition', () => {
+        const result = generateStylableRoot({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        @st-global-custom-property --global;
+                        
+                        @property --global {
+                            syntax: "<length>";
+                            inherits: false;
+                            initial-value: 0px;
+                        }
+
+                        @property --radius {
+                            syntax: "<length>";
+                            inherits: false;
+                            initial-value: 0px;
+                        }
+                        
+                        .root {
+                            --radius: 10px;
+                            --global: 20px;
+                        }
+                        
+                        `,
+                },
+            },
+        });
+
+        const prop1 = result.nodes[0] as postcss.AtRule;
+        const prop2 = result.nodes[1] as postcss.AtRule;
+
+        expect(prop1.params).to.equal('--global');
+        expect(prop2.params).to.equal('--entry-radius');
+    });
+});


### PR DESCRIPTION
Stylable will now transform `@property`

```css
//entry.st.css
@property --radius {
  syntax: "<length>";
  inherits: false;
  initial-value: 0px;
}
```
Outputs
```css
//entry.css
@property --entry-radius {
  syntax: "<length>";
  inherits: false;
  initial-value: 0px;
}
```