### PR TITLE
Language-service: add completion for @st-global-custom-property

### DIFF
--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -188,6 +188,7 @@ const topLevelDeclarations: Array<keyof typeof topLevelDirectives> = [
     'customSelector',
     'stScope',
     'stImport',
+    'stGlobalCustomProperty',
 ];
 
 // Providers
@@ -314,7 +315,8 @@ export const TopLevelDirectiveProvider: CompletionProvider = {
                 return topLevelDeclarations
                     .filter(
                         (d) =>
-                            !meta.ast.source!.input.css.includes('@namespace') || d !== 'namespace'
+                            !meta.ast.source!.input.css.includes(topLevelDirectives.namespace) ||
+                            d !== 'namespace'
                     )
                     .filter((d) => topLevelDirectives[d].startsWith(fullLineText.trim()))
                     .map((d) =>
@@ -872,7 +874,14 @@ export const StImportNamedCompletionProvider: CompletionProvider & {
                     if (resolvedImport) {
                         const { lastName } = getExistingNames(fullLineText, position);
 
-                        getNamedCSSImports(stylable, comps, resolvedImport, lastName, namedValues, meta);
+                        getNamedCSSImports(
+                            stylable,
+                            comps,
+                            resolvedImport,
+                            lastName,
+                            namedValues,
+                            meta
+                        );
 
                         return comps
                             .slice(1)

--- a/packages/language-service/src/lib/completion-types.ts
+++ b/packages/language-service/src/lib/completion-types.ts
@@ -37,6 +37,7 @@ export const topLevelDirectives = {
     import: ':import' as const,
     stScope: '@st-scope' as const,
     stImport: '@st-import' as const,
+    stGlobalCustomProperty: '@st-global-custom-property' as const,
 };
 
 // syntactic
@@ -151,6 +152,14 @@ export function topLevelDirective(type: keyof typeof topLevelDirectives, rng: Pr
                 'Define an @st-import',
                 'a',
                 new Snippet('@st-import $2 from "$1";'),
+                rng
+            );
+        case topLevelDirectives.stGlobalCustomProperty:
+            return new Completion(
+                topLevelDirectives.stGlobalCustomProperty,
+                'Define global custom properties using @st-global-custom-property',
+                'a',
+                new Snippet('@st-global-custom-property --$1;'),
                 rng
             );
     }

--- a/packages/language-service/test/lib/completions/completion.spec.ts
+++ b/packages/language-service/test/lib/completions/completion.spec.ts
@@ -3,21 +3,25 @@ import * as asserters from '../../test-kit/completions-asserters';
 
 describe('Completions', () => {
     describe('Stylesheet Top Level', () => {
+        const topLevelExistingRange = createRange(3, 0, 3, 0);
+        const defaultRange = createRange(0, 0, 0, 0);
+
         it('should complete ONLY import and vars directive, root and existing classes at top level', () => {
             const asserter = asserters.getCompletions('general/top-level-existing-classes.st.css');
             asserter.suggested([
-                asserters.importDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.customSelectorDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.stScopeDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.varsDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.rootClassCompletion(createRange(3, 0, 3, 0)),
-                asserters.classCompletion('gaga', createRange(3, 0, 3, 0)),
-                asserters.classCompletion('baga', createRange(3, 0, 3, 0)),
+                asserters.importDirectiveCompletion(topLevelExistingRange),
+                asserters.customSelectorDirectiveCompletion(topLevelExistingRange),
+                asserters.stScopeDirectiveCompletion(topLevelExistingRange),
+                asserters.stGlobalCustomPropertyCompletion(topLevelExistingRange),
+                asserters.varsDirectiveCompletion(topLevelExistingRange),
+                asserters.rootClassCompletion(topLevelExistingRange),
+                asserters.classCompletion('gaga', topLevelExistingRange),
+                asserters.classCompletion('baga', topLevelExistingRange),
             ]);
             asserter.notSuggested([
-                asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
+                asserters.statesDirectiveCompletion(defaultRange),
+                asserters.extendsDirectiveCompletion(defaultRange),
+                asserters.mixinDirectiveCompletion(defaultRange),
             ]);
         });
 
@@ -26,18 +30,19 @@ describe('Completions', () => {
                 'general/top-level-existing-classes-broken.st.css'
             );
             asserter.suggested([
-                asserters.importDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.customSelectorDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.stScopeDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.varsDirectiveCompletion(createRange(3, 0, 3, 0)),
-                asserters.rootClassCompletion(createRange(3, 0, 3, 0)),
-                asserters.classCompletion('gaga', createRange(3, 0, 3, 0)),
+                asserters.importDirectiveCompletion(topLevelExistingRange),
+                asserters.customSelectorDirectiveCompletion(topLevelExistingRange),
+                asserters.stScopeDirectiveCompletion(topLevelExistingRange),
+                asserters.stGlobalCustomPropertyCompletion(topLevelExistingRange),
+                asserters.varsDirectiveCompletion(topLevelExistingRange),
+                asserters.rootClassCompletion(topLevelExistingRange),
+                asserters.classCompletion('gaga', topLevelExistingRange),
             ]);
             asserter.notSuggested([
-                asserters.classCompletion('baga', createRange(0, 0, 0, 0)),
-                asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
+                asserters.classCompletion('baga', defaultRange),
+                asserters.statesDirectiveCompletion(defaultRange),
+                asserters.extendsDirectiveCompletion(defaultRange),
+                asserters.mixinDirectiveCompletion(defaultRange),
             ]);
         });
 
@@ -48,13 +53,13 @@ describe('Completions', () => {
                 asserters.classCompletion('gaga', createRange(0, 0, 0, 1)),
             ]);
             asserter.notSuggested([
-                asserters.importDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.customSelectorDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.stScopeDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.varsDirectiveCompletion(createRange(0, 0, 0, 0)),
+                asserters.importDirectiveCompletion(defaultRange),
+                asserters.statesDirectiveCompletion(defaultRange),
+                asserters.extendsDirectiveCompletion(defaultRange),
+                asserters.mixinDirectiveCompletion(defaultRange),
+                asserters.customSelectorDirectiveCompletion(defaultRange),
+                asserters.stScopeDirectiveCompletion(defaultRange),
+                asserters.varsDirectiveCompletion(defaultRange),
             ]);
         });
 
@@ -70,9 +75,9 @@ describe('Completions', () => {
                 asserters.stScopeDirectiveCompletion(createRange(9, 0, 9, 0)),
             ]);
             asserter.notSuggested([
-                asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
+                asserters.statesDirectiveCompletion(defaultRange),
+                asserters.extendsDirectiveCompletion(defaultRange),
+                asserters.mixinDirectiveCompletion(defaultRange),
             ]);
         });
 
@@ -84,10 +89,10 @@ describe('Completions', () => {
                 asserters.classCompletion('Compo', createRange(6, 6, 6, 6), true),
             ]);
             asserter.notSuggested([
-                asserters.rootClassCompletion(createRange(0, 0, 0, 0)),
-                asserters.customSelectorDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.stScopeDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.varsDirectiveCompletion(createRange(0, 0, 0, 0)),
+                asserters.rootClassCompletion(defaultRange),
+                asserters.customSelectorDirectiveCompletion(defaultRange),
+                asserters.stScopeDirectiveCompletion(defaultRange),
+                asserters.varsDirectiveCompletion(defaultRange),
             ]);
         });
 

--- a/packages/language-service/test/test-kit/completions-asserters.ts
+++ b/packages/language-service/test/test-kit/completions-asserters.ts
@@ -3,9 +3,7 @@ import fs from 'fs';
 import { expect } from 'chai';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import {
-    ProviderRange,
-} from '@stylable/language-service/dist/lib/completion-providers';
+import { ProviderRange } from '@stylable/language-service/dist/lib/completion-providers';
 import { Completion, Snippet } from '@stylable/language-service/dist/lib/completion-types';
 import { CASES_PATH, stylableLSP } from './stylable-fixtures-lsp';
 import { getCaretPosition } from './asserters';
@@ -109,6 +107,7 @@ export function getStylableAndCssCompletions(fileName: string) {
 }
 
 // syntactic
+// at-rules
 export const customSelectorDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (
     rng
 ) => {
@@ -129,17 +128,15 @@ export const stScopeDirectiveCompletion: (rng: ProviderRange) => Partial<Complet
         range: rng,
     };
 };
-export const extendsDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+export const namespaceDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
-        label: '-st-extends:',
-        detail: 'Extend an external component',
+        label: '@namespace',
+        detail: 'Declare a namespace for the file',
         sortText: 'a',
-        insertText: '-st-extends: $1;',
-        additionalCompletions: true,
+        insertText: '@namespace "$1";\n',
         range: rng,
     };
 };
-
 export const stImportDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
         label: '@st-import',
@@ -149,15 +146,28 @@ export const stImportDirectiveCompletion: (rng: ProviderRange) => Partial<Comple
         range: rng,
     };
 };
-
-export const importDefaultDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (
+export const stGlobalCustomPropertyCompletion: (rng: ProviderRange) => Partial<Completion> = (
     rng
 ) => {
     return {
-        label: '-st-default:',
-        detail: 'Default export name',
+        label: '@st-global-custom-property',
+        detail: 'Define global custom properties using @st-global-custom-property',
         sortText: 'a',
-        insertText: '-st-default: $1;',
+        insertText: '@st-global-custom-property --$1;',
+        range: rng,
+    };
+};
+
+// rules
+export const globalCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+    return new Completion(':global()', 'Target a global selector', 'a', ':global($1)', rng);
+};
+export const varsDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+    return {
+        label: ':vars',
+        detail: 'Declare variables',
+        sortText: 'a',
+        insertText: ':vars {\n\t$1\n}',
         range: rng,
     };
 };
@@ -167,6 +177,28 @@ export const importDirectiveCompletion: (rng: ProviderRange) => Partial<Completi
         detail: 'Import an external library',
         sortText: 'a',
         insertText: ':import {\n\t-st-from: "$1";\n}',
+        range: rng,
+    };
+};
+export const rootClassCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+    return {
+        label: '.root',
+        detail: 'The root class',
+        sortText: 'a',
+        insertText: '.root',
+        range: rng,
+    };
+};
+
+// declarations
+export const importDefaultDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (
+    rng
+) => {
+    return {
+        label: '-st-default:',
+        detail: 'Default export name',
+        sortText: 'a',
+        insertText: '-st-default: $1;',
         range: rng,
     };
 };
@@ -190,30 +222,13 @@ export const importNamedDirectiveCompletion: (rng: ProviderRange) => Partial<Com
         range: rng,
     };
 };
-export const mixinDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+export const extendsDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
-        label: '-st-mixin:',
-        detail: 'Apply mixins on the class',
+        label: '-st-extends:',
+        detail: 'Extend an external component',
         sortText: 'a',
-        insertText: '-st-mixin: $1;',
-        range: rng,
-    };
-};
-export const namespaceDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
-    return {
-        label: '@namespace',
-        detail: 'Declare a namespace for the file',
-        sortText: 'a',
-        insertText: '@namespace "$1";\n',
-        range: rng,
-    };
-};
-export const rootClassCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
-    return {
-        label: '.root',
-        detail: 'The root class',
-        sortText: 'a',
-        insertText: '.root',
+        insertText: '-st-extends: $1;',
+        additionalCompletions: true,
         range: rng,
     };
 };
@@ -226,6 +241,15 @@ export const statesDirectiveCompletion: (rng: ProviderRange) => Partial<Completi
         range: rng,
     };
 };
+export const mixinDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+    return {
+        label: '-st-mixin:',
+        detail: 'Apply mixins on the class',
+        sortText: 'a',
+        insertText: '-st-mixin: $1;',
+        range: rng,
+    };
+};
 export const valueDirective: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
         label: 'value()',
@@ -234,18 +258,6 @@ export const valueDirective: (rng: ProviderRange) => Partial<Completion> = (rng)
         insertText: ' value($1)',
         range: rng,
     };
-};
-export const varsDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
-    return {
-        label: ':vars',
-        detail: 'Declare variables',
-        sortText: 'a',
-        insertText: ':vars {\n\t$1\n}',
-        range: rng,
-    };
-};
-export const globalCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
-    return new Completion(':global()', 'Target a global selector', 'a', ':global($1)', rng);
 };
 
 // semantic


### PR DESCRIPTION
also reorder completion asserters according to at-rule/rule/declaration