### PR TITLE
fix(webpack-plugin): inject all exports only when usedExports enabled in dev

### DIFF
--- a/packages/webpack-plugin/src/loader-utils.ts
+++ b/packages/webpack-plugin/src/loader-utils.ts
@@ -9,6 +9,10 @@ import {
 } from '@stylable/core';
 import { dirname } from 'path';
 
+export function getReplacementToken(token: string) {
+    return '/* INJECT */' + JSON.stringify({ [`__${token}__`]: true });
+}
+
 export function getImports(
     stylable: Stylable,
     meta: StylableMeta,

--- a/packages/webpack-plugin/src/loader-utils.ts
+++ b/packages/webpack-plugin/src/loader-utils.ts
@@ -10,7 +10,7 @@ import {
 import { dirname } from 'path';
 
 export function getReplacementToken(token: string) {
-    return '/* INJECT */' + JSON.stringify({ [`__${token}__`]: true });
+    return `/* INJECT */ {__${token}__:true}`;
 }
 
 export function getImports(

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -1,4 +1,4 @@
-import { addBuildDependencies, getImports } from './loader-utils';
+import { addBuildDependencies, getImports, getReplacementToken } from './loader-utils';
 import type { StylableLoaderContext } from './types';
 import { emitDiagnostics } from '@stylable/core';
 
@@ -27,16 +27,15 @@ export default function StylableWebpackLoader(this: StylableLoaderContext, sourc
 
     return `
 ${imports.join('\n')}
-export ${varType} namespace = {__namespace__:true};
-export ${varType} classes = {__classes__:true};
-export ${varType} keyframes = ${JSON.stringify(exports.keyframes)}; 
-export ${varType} stVars = ${JSON.stringify(exports.stVars)}; 
-export ${varType} vars = ${JSON.stringify(exports.vars)}; 
-export ${varType} cssStates = /*#__PURE__*/ __webpack_require__.stc.bind(null, namespace);
-export ${varType} style = /*#__PURE__*/ __webpack_require__.sts.bind(null, namespace);
-export ${varType} st = style;
-if(import.meta.webpackHot /* HMR */) {
-  import.meta.webpackHot.accept();
-}
+export ${varType} namespace = ${getReplacementToken('namespace')};
+export ${varType} classes = ${getReplacementToken('classes')};
+export ${varType} keyframes = ${getReplacementToken('keyframes')}; 
+export ${varType} stVars = ${getReplacementToken('stVars')}; 
+export ${varType} vars = ${getReplacementToken('vars')}; 
+export ${varType} cssStates = ${getReplacementToken('stc')};
+export ${varType} style = ${getReplacementToken('sts')};
+export ${varType} st = ${getReplacementToken('st')};
+/* JS_INJECT */
+if(import.meta.webpackHot /* HMR */) { import.meta.webpackHot.accept();}
 `;
 }

--- a/packages/webpack-plugin/test/e2e/simplest-project-used-exports.spec.ts
+++ b/packages/webpack-plugin/test/e2e/simplest-project-used-exports.spec.ts
@@ -1,0 +1,33 @@
+import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { dirname } from 'path';
+
+const project = 'simplest-project';
+const projectDir = dirname(
+    require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
+);
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir,
+            launchOptions: {
+                // headless: false
+            },
+            webpackOptions: {
+                optimization: { usedExports: true },
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('renders css', async () => {
+        const { page } = await projectRunner.openInBrowser();
+        const styleElements = await page.evaluate(browserFunctions.getStyleElementsMetadata);
+
+        expect(styleElements).to.eql([{ id: './src/index.st.css', depth: '1' }]);
+    });
+
+});


### PR DESCRIPTION
Sine webpack can opt out of removing pure exports (like we use in the loader) in certain configurations, this PR moves all injection points in the JavaScript module to the `StylableRuntimeDependency` apply phase.

This allows better decision point for when to inject the shared runtime and also prepare the ground for optimizing `keyframes` and `vars` exports.

fix #1698 