### PR TITLE
fix(wepback-plugin): Remove outdated mini-css error

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -451,9 +451,6 @@ export class StylableWebpackPlugin {
                     }
                 );
             } else if (this.options.cssInjection === 'mini-css') {
-                throw new Error(
-                    'Support for mini-css is temporarily disabled. see https://github.com/webpack-contrib/mini-css-extract-plugin/pull/703'
-                );
                 injectCssModules(compilation, staticPublicPath, stylableModules, assetsModules);
             }
         }


### PR DESCRIPTION
https://github.com/webpack-contrib/mini-css-extract-plugin/pull/703 was merged and released as a part of `1.3.9`.

The PR just removes error which seems like deprecated.

With stop supporting `[name]` for the `filename` option it became problematic to use the plugin for multiple entries, especially with https://github.com/wix-incubator/tpa-style-webpack-plugin.

Using `mini-css` and controlling the output via it resolves our issue.