### PR TITLE
fix(webpack-plugin): enable mini-css-extract-plugin feature

### DIFF
--- a/packages/webpack-plugin/src/mini-css-support.ts
+++ b/packages/webpack-plugin/src/mini-css-support.ts
@@ -5,16 +5,18 @@ const memoize = require('webpack/lib/util/memoize');
 
 import { StylableWebpackPlugin } from './plugin';
 
-const getCssModule = memoize(() => {
-    return require('mini-css-extract-plugin/dist/CssModule').default;
+const getMiniCssExtractPlugin = memoize(() => {
+    return require('mini-css-extract-plugin');
 });
 export function injectCssModules(
+    webpack: Compiler['webpack'],
     compilation: Compilation,
     staticPublicPath: string,
     stylableModules: Set<NormalModule>,
     assetsModules: Map<string, NormalModule>
 ) {
-    const CssModule = getCssModule();
+    const MiniCssExtractPlugin = getMiniCssExtractPlugin();
+    const CssModule = MiniCssExtractPlugin.getCssModule(webpack);
 
     compilation.hooks.afterChunks.tap(StylableWebpackPlugin.name, () => {
         const { moduleGraph, dependencyTemplates, runtimeTemplate } = compilation;
@@ -53,7 +55,7 @@ export function injectCssModules(
 }
 
 export function injectCSSOptimizationRules(compiler: Compiler) {
-    const CssModule = getCssModule();
+    const CssModule = getMiniCssExtractPlugin().getCssModule(compiler.webpack);
     if (!compiler.options.optimization) {
         compiler.options.optimization = {};
     }

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -181,6 +181,7 @@ export class StylableWebpackPlugin {
                  * Handle things that related to chunking and bundling
                  */
                 this.chunksIntegration(
+                    compiler.webpack,
                     compilation,
                     staticPublicPath,
                     stylableModules,
@@ -398,6 +399,7 @@ export class StylableWebpackPlugin {
         });
     }
     private chunksIntegration(
+        webpack: Compiler['webpack'],
         compilation: Compilation,
         staticPublicPath: string,
         stylableModules: Set<NormalModule>,
@@ -451,10 +453,7 @@ export class StylableWebpackPlugin {
                     }
                 );
             } else if (this.options.cssInjection === 'mini-css') {
-                throw new Error(
-                    'Support for mini-css is temporarily disabled. see https://github.com/webpack-contrib/mini-css-extract-plugin/pull/703'
-                );
-                injectCssModules(compilation, staticPublicPath, stylableModules, assetsModules);
+                injectCssModules(webpack, compilation, staticPublicPath, stylableModules, assetsModules);
             }
         }
     }

--- a/packages/webpack-plugin/test/e2e/mini-css-extract.spec.ts
+++ b/packages/webpack-plugin/test/e2e/mini-css-extract.spec.ts
@@ -7,7 +7,7 @@ const projectDir = dirname(
     require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
 );
 
-describe.skip(`(${project})`, () => {
+describe(`(${project})`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,
@@ -19,7 +19,7 @@ describe.skip(`(${project})`, () => {
         afterEach,
         after
     );
-
+    
     it('renders css', async () => {
         const { page } = await projectRunner.openInBrowser();
         const links = await page.evaluate(browserFunctions.getCSSLinks);

--- a/packages/webpack-plugin/test/e2e/mini-css-extract.spec.ts
+++ b/packages/webpack-plugin/test/e2e/mini-css-extract.spec.ts
@@ -19,7 +19,7 @@ describe(`(${project})`, () => {
         afterEach,
         after
     );
-    
+
     it('renders css', async () => {
         const { page } = await projectRunner.openInBrowser();
         const links = await page.evaluate(browserFunctions.getCSSLinks);


### PR DESCRIPTION
This PR enables the mini-css support in the webpack plugin.