### PR TITLE
fix(core): use request for js imports in the resolver

### DIFF
--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -13,7 +13,7 @@ export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any
         useSyncFileSystemCalls: true,
         cache: false,
         fileSystem,
-        extensions: ['.js', '.mjs', '.ts'],
+        extensions: Array.from(new Set(['.js', ...resolveOptions.extensions])),
     });
 
     return (directoryPath, request): string => {

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -13,6 +13,7 @@ export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any
         useSyncFileSystemCalls: true,
         cache: false,
         fileSystem,
+        extensions: ['.js', '.mjs', '.ts'],
     });
 
     return (directoryPath, request): string => {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -27,6 +27,13 @@ export interface CSSResolve<T extends StylableSymbol = StylableSymbol> {
     meta: StylableMeta;
 }
 
+export interface ResolverOptions {
+    alias?: Record<string, string | false | string[]> | Record<string, string | false | string[]>[];
+    symlinks?: boolean;
+    extensions?: string[];
+    [key: string]: any;
+}
+
 export interface JSResolve {
     _kind: 'js';
     symbol: any;

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -51,7 +51,7 @@ export class StylableResolver {
         protected requireModule: (modulePath: string) => any,
         protected cache?: StylableResolverCache
     ) {}
-    private getModule({ context, from }: Imported): CachedModule {
+    private getModule({ context, from, request }: Imported): CachedModule {
         const key = `${context}${safePathDelimiter}${from}`;
         if (this.cache?.has(key)) {
             return this.cache.get(key)!;
@@ -65,7 +65,7 @@ export class StylableResolver {
             }
         } else {
             try {
-                res = this.requireModule(this.fileProcessor.resolvePath(from, context));
+                res = this.requireModule(this.fileProcessor.resolvePath(request, context));
             } catch {
                 res = null;
             }

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -3,7 +3,7 @@ import { createInfrastructure } from './create-infra-structure';
 import { Diagnostics } from './diagnostics';
 import { CssParser, safeParse } from './parser';
 import { processNamespace, StylableMeta, StylableProcessor } from './stylable-processor';
-import { StylableResolverCache, StylableResolver } from './stylable-resolver';
+import { StylableResolverCache, StylableResolver, ResolverOptions } from './stylable-resolver';
 import {
     StylableResults,
     StylableTransformer,
@@ -21,11 +21,7 @@ export interface StylableConfig {
     onProcess?: (meta: StylableMeta, path: string) => StylableMeta;
     diagnostics?: Diagnostics;
     hooks?: TransformHooks;
-    resolveOptions?: {
-        alias: any;
-        symlinks: boolean;
-        [key: string]: any;
-    };
+    resolveOptions?: ResolverOptions;
     optimizer?: IStylableOptimizer;
     mode?: 'production' | 'development';
     resolveNamespace?: typeof processNamespace;


### PR DESCRIPTION
Our resolve module for JS import was receiving the "from" field from the import symbol. This created a case where absolute path without extension was provided to the resolver and was ignored. it was affecting the requireModule function provided to Stylable and required it to resolve extensions. this PR fixes that by providing the request instead.  