### PR TITLE
fix(webpack-plugin): modules inside concatenated module were ignored

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -458,46 +458,61 @@ export class StylableWebpackPlugin {
                     compilation.dependencyTemplates
                 );
 
-                compilation.hooks.processAssets.tap(
-                    {
-                        name: StylableWebpackPlugin.name,
-                        stage: webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED,
-                    },
-                    () => {
-                        if (this.options.extractMode === 'entries') {
-                            for (const entryPoint of compilation.entrypoints.values()) {
-                                if (isDependencyOf(entryPoint, compilation.entrypoints.values())) {
-                                    continue;
-                                }
-                                const entryChunk = entryPoint.getEntrypointChunk();
-                                const modules = new Map<NormalModule, BuildData | null>();
-                                getEntryPointModules(
-                                    entryPoint,
-                                    compilation.chunkGraph,
-                                    (module) => {
-                                        const m = module as NormalModule;
-                                        if (stylableModules.has(m)) {
-                                            modules.set(
-                                                m,
-                                                getStylableBuildData(stylableModules, m)
-                                            );
-                                        }
-                                    }
-                                );
-                                const cssBundleFilename = emitCSSFile(
-                                    compilation,
-                                    createStaticCSS(modules).join('\n'),
-                                    this.options.filename,
-                                    webpack.util.createHash,
-                                    entryChunk
-                                );
-                                entryPoint.getEntrypointChunk().files.add(cssBundleFilename);
+                if (this.options.extractMode === 'entries') {
+                    let modulesPerChunks: Array<{
+                        entryPoint: EntryPoint;
+                        modules: Map<NormalModule, BuildData | null>;
+                    }>;
+                    compilation.hooks.afterOptimizeTree.tap(StylableWebpackPlugin.name, () => {
+                        modulesPerChunks = [];
+                        for (const entryPoint of compilation.entrypoints.values()) {
+                            if (isDependencyOf(entryPoint, compilation.entrypoints.values())) {
+                                continue;
                             }
-                        } else if (this.options.extractMode === 'single') {
+                            const modules = new Map<NormalModule, BuildData | null>();
+                            getEntryPointModules(entryPoint, compilation.chunkGraph, (module) => {
+                                const m = module as NormalModule;
+                                if (stylableModules.has(m)) {
+                                    modules.set(m, getStylableBuildData(stylableModules, m));
+                                }
+                            });
+                            if (modules.size) {
+                                modulesPerChunks.push({ entryPoint, modules });
+                            }
+                        }
+                    });
+                    compilation.hooks.processAssets.tap(
+                        {
+                            name: StylableWebpackPlugin.name,
+                            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED,
+                        },
+                        () => {
+                            for (const { entryPoint, modules } of modulesPerChunks) {
+                                const entryChunk = entryPoint.getEntrypointChunk();
+                                entryChunk.files.add(
+                                    emitCSSFile(
+                                        compilation,
+                                        createStaticCSS(modules).join('\n'),
+                                        this.options.filename,
+                                        webpack.util.createHash,
+                                        entryChunk
+                                    )
+                                );
+                            }
+                        }
+                    );
+                } else if (this.options.extractMode === 'single') {
+                    compilation.hooks.processAssets.tap(
+                        {
+                            name: StylableWebpackPlugin.name,
+                            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED,
+                        },
+                        () => {
+                            if (!stylableModules.size) {
+                                return;
+                            }
                             const chunk = getOnlyChunk(compilation);
-
                             const cssSource = createStaticCSS(stylableModules).join('\n');
-
                             const cssBundleFilename = emitCSSFile(
                                 compilation,
                                 cssSource,
@@ -505,13 +520,12 @@ export class StylableWebpackPlugin {
                                 webpack.util.createHash,
                                 chunk
                             );
-
                             for (const entryPoint of compilation.entrypoints.values()) {
                                 entryPoint.getEntrypointChunk().files.add(cssBundleFilename);
                             }
                         }
-                    }
-                );
+                    );
+                }
             } else if (this.options.cssInjection === 'mini-css') {
                 injectCssModules(
                     webpack,

--- a/packages/webpack-plugin/test/e2e/multiple-chunks-split.spec.ts
+++ b/packages/webpack-plugin/test/e2e/multiple-chunks-split.spec.ts
@@ -27,6 +27,8 @@ describe(`(${project})`, () => {
 
         const a = projectRunner.getBuildAsset('a.css');
         const b = projectRunner.getBuildAsset('b.css');
+        expect(a).to.not.be.empty;
+        expect(b).to.not.be.empty;
         expect(a).to.not.equal(b);
 
         expect(await getComputedColor(page, 'Hello From Common')).to.eql(`rgb(210, 105, 30)`);

--- a/packages/webpack-plugin/test/e2e/projects/multiple-chunks-split/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/multiple-chunks-split/webpack.config.js
@@ -3,7 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
-    mode: 'development',
+    mode: 'production',
     entry: {
         a: './src/a',
         b: './src/b',


### PR DESCRIPTION
Modules inside concatenated module were ignored in split by entry 
Moved the logic of getting the modules inside an entry to `afterOptimizeTree` 