### PR TITLE
Better handling namespace reference

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -343,7 +343,7 @@ export class StylableProcessor {
                 if (i === -1) {
                     this.diagnostics.error(node, processorWarnings.INVALID_NAMESPACE_REFERENCE());
                 } else {
-                    pathToSource = stripQuotation(node.text.slice(i) + 1);
+                    pathToSource = stripQuotation(node.text.slice(i + 1));
                 }
                 break;
             }

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -151,6 +151,9 @@ export const processorWarnings = {
     INVALID_CUSTOM_PROPERTY_AS_VALUE(name: string, as: string) {
         return `invalid alias for custom property "${name}" as "${as}"; custom properties must be prefixed with "--" (double-dash)`;
     },
+    INVALID_NAMESPACE_REFERENCE() {
+        return 'st-namespace-reference dose not have any value';
+    },
 };
 
 export class StylableProcessor {
@@ -336,10 +339,15 @@ export class StylableProcessor {
         let pathToSource: string | undefined;
         this.meta.ast.walkComments((comment) => {
             if (comment.text.includes('st-namespace-reference')) {
-                const namespaceReferenceParts = comment.text.split('=');
-                pathToSource = stripQuotation(
-                    namespaceReferenceParts[namespaceReferenceParts.length - 1]
-                );
+                const i = comment.text.indexOf('=');
+                if (i === -1) {
+                    this.diagnostics.error(
+                        comment,
+                        processorWarnings.INVALID_NAMESPACE_REFERENCE()
+                    );
+                } else {
+                    pathToSource = stripQuotation(comment.text.slice(i) + 1);
+                }
                 return false;
             }
             return undefined;

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -337,21 +337,17 @@ export class StylableProcessor {
     }
     private handleNamespaceReference(namespace: string): string {
         let pathToSource: string | undefined;
-        this.meta.ast.walkComments((comment) => {
-            if (comment.text.includes('st-namespace-reference')) {
-                const i = comment.text.indexOf('=');
+        for (const node of this.meta.ast.nodes) {
+            if (node.type === 'comment' && node.text.includes('st-namespace-reference')) {
+                const i = node.text.indexOf('=');
                 if (i === -1) {
-                    this.diagnostics.error(
-                        comment,
-                        processorWarnings.INVALID_NAMESPACE_REFERENCE()
-                    );
+                    this.diagnostics.error(node, processorWarnings.INVALID_NAMESPACE_REFERENCE());
                 } else {
-                    pathToSource = stripQuotation(comment.text.slice(i) + 1);
+                    pathToSource = stripQuotation(node.text.slice(i) + 1);
                 }
-                return false;
+                break;
             }
-            return undefined;
-        });
+        }
 
         return this.resolveNamespace(
             namespace,

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -75,7 +75,7 @@ describe('Stylable postcss process', () => {
         expect(result.namespace).to.eql(processNamespace('style', from));
     });
 
-    it('use filename as default namespace prefix', () => {
+    it('use filename as default namespace prefix (empty)', () => {
         const from = resolve('/path/to/style.css');
 
         const result = processSource(

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -70,7 +70,7 @@ describe('Stylable postcss process', () => {
             { from: distFrom }
         );
 
-        // assure namesapce generated with st-namespace-reference
+        // assure namespace generated with st-namespace-reference
         // is identical between source and dist with the relative correction
         expect(result.namespace).to.eql(processNamespace('style', from));
     });


### PR DESCRIPTION
Since file paths can contains `=` the split is not correct.