### PR TITLE
Change .st.css module declaration to disallow stylesheet default exports

### DIFF
--- a/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
@@ -1,7 +1,7 @@
 declare module '*.st.css' {
-    export const defaultExport: never;
-
     export * from '@stylable/runtime/stylesheet';
+
+    const defaultExport: never;
     export default defaultExport;
 }
 

--- a/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
@@ -1,6 +1,8 @@
 declare module '*.st.css' {
-    const stylesheet: import('@stylable/runtime').RuntimeStylesheet;
-    export = stylesheet;
+    export const defaultExport: never;
+
+    export * from '@stylable/runtime/stylesheet';
+    export default defaultExport;
 }
 
 declare module '*.png' {

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -87,8 +87,10 @@ Add the following file to your `/src` directory.
 ```ts
 // globals.d.ts
 declare module '*.st.css' {
-    const stylesheet: import('@stylable/runtime').RuntimeStylesheet;
-    export = stylesheet;
+    export const defaultExport: never;
+
+    export * from '@stylable/runtime/stylesheet';
+    export default defaultExport;
 }
 ```
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -87,9 +87,9 @@ Add the following file to your `/src` directory.
 ```ts
 // globals.d.ts
 declare module '*.st.css' {
-    export const defaultExport: never;
-
     export * from '@stylable/runtime/stylesheet';
+
+    const defaultExport: never;
     export default defaultExport;
 }
 ```

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,6 +12,7 @@
     "dist",
     "!dist/test",
     "src",
+    "stylesheet.d.ts",
     "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "engines": {

--- a/packages/runtime/stylesheet.d.ts
+++ b/packages/runtime/stylesheet.d.ts
@@ -1,4 +1,4 @@
-type RuntimeStylesheet = import('@stylable/runtime').RuntimeStylesheet;
+import type { RuntimeStylesheet } from './dist';
 
 export const classes: RuntimeStylesheet['classes'];
 export const keyframes: RuntimeStylesheet['keyframes'];

--- a/packages/runtime/stylesheet.d.ts
+++ b/packages/runtime/stylesheet.d.ts
@@ -1,0 +1,10 @@
+type RuntimeStylesheet = import('@stylable/runtime').RuntimeStylesheet;
+
+export const classes: RuntimeStylesheet['classes'];
+export const keyframes: RuntimeStylesheet['keyframes'];
+export const vars: RuntimeStylesheet['vars'];
+export const stVars: RuntimeStylesheet['stVars'];
+export const namespace: RuntimeStylesheet['namespace'];
+export const cssStates: RuntimeStylesheet['cssStates'];
+export const style: RuntimeStylesheet['style'];
+export const st: RuntimeStylesheet['st'];


### PR DESCRIPTION
The new TS snippet: 
```ts
// globals.d.ts
declare module '*.st.css' {
    export const defaultExport: never;

    export * from '@stylable/runtime/stylesheet';
    export default defaultExport;
}
```