### PR TITLE
fix(core): bug import order can override a mapped symbol

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -172,6 +172,14 @@ export class StylableProcessor {
 
         const stubs = this.insertCustomSelectorsStubs();
 
+        for (const node of root.nodes) {
+            if (node.type === 'rule' && node.selector === rootValueMapping.import) {
+                const imported = this.handleImport(node);
+                this.meta.imports.push(imported);
+                this.addImportSymbols(imported);
+            }
+        }
+
         root.walkRules((rule) => {
             if (!isChildOfAtRule(rule, 'keyframes')) {
                 this.handleCustomSelectors(rule);
@@ -272,9 +280,9 @@ export class StylableProcessor {
                         );
                         atRule.remove();
                     } else {
-                        const _import = this.handleStImport(atRule);
-                        this.meta.imports.push(_import);
-                        this.addImportSymbols(_import);
+                        const stImport = this.handleStImport(atRule);
+                        this.meta.imports.push(stImport);
+                        this.addImportSymbols(stImport);
                     }
 
                     break;
@@ -380,10 +388,7 @@ export class StylableProcessor {
                             rule.remove();
                             return false;
                         }
-
-                        const imported = this.handleImport(rule);
-                        this.meta.imports.push(imported);
-                        this.addImportSymbols(imported);
+                        rule.remove();
                         return false;
                     } else {
                         this.diagnostics.warn(
@@ -906,8 +911,6 @@ export class StylableProcessor {
         if (!importObj.from) {
             this.diagnostics.error(rule, processorWarnings.FROM_PROP_MISSING_IN_IMPORT());
         }
-
-        rule.remove();
 
         return importObj;
     }

--- a/packages/core/test/stylable-transformer/general.spec.ts
+++ b/packages/core/test/stylable-transformer/general.spec.ts
@@ -16,6 +16,103 @@ describe('Stylable postcss transform (General)', () => {
         expect(result.toString()).to.equal('');
     });
 
+    it('should hoist :imports', () => {
+        const result = generateStylableRoot({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    content: `
+                        
+                        :import {
+                            -st-from:"./index.st.css";
+                            -st-named: Comp;
+                        }
+                        
+                        Comp{}
+
+                    `,
+                },
+                '/index.st.css': {
+                    namespace: 'index',
+                    content: `
+                        
+                        :import {
+                            -st-from:"./comp.st.css";
+                            -st-default: Comp;
+                        }
+                        
+                        Comp{}
+                        
+                        :import {
+                            -st-from:"./comp.st.css";
+                            -st-default: Comp;
+                        }
+                        
+                        Comp{}
+                    `,
+                },
+                '/comp.st.css': {
+                    namespace: 'comp',
+                    content: `
+                        .root{}                        
+                    `,
+                },
+            },
+        });
+
+        expect(result.nodes[0].toString()).to.equal('.comp__root{}');
+    });
+
+    it('should hoist :imports and support different import symbols', () => {
+        const result = generateStylableRoot({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    content: `
+                        
+                        :import {
+                            -st-from:"./index.st.css";
+                            -st-named: Comp, part;
+                        }
+                        
+                        Comp{}
+                        .part{}
+
+                    `,
+                },
+                '/index.st.css': {
+                    namespace: 'index',
+                    content: `
+                        
+                        :import {
+                            -st-from:"./comp.st.css";
+                            -st-default: Comp;
+                        }
+                        
+                        Comp{}
+                        
+                        :import {
+                            -st-from:"./comp.st.css";
+                            -st-named: part;
+                        }
+                        
+                        .part{}
+                    `,
+                },
+                '/comp.st.css': {
+                    namespace: 'comp',
+                    content: `
+                        .root{}                        
+                        .part{}                        
+                    `,
+                },
+            },
+        });
+
+        expect(result.nodes[0].toString()).to.equal('.comp__root{}');
+        expect(result.nodes[1].toString()).to.equal('.comp__part{}');
+    });
+
     it('should not output :import', () => {
         const result = generateStylableRoot({
             entry: `/a/b/style.st.css`,


### PR DESCRIPTION
This fixes issue where `:import` is not hoisted and overrides a mapped symbol (alias) 

This will cause X to not be transpiled correctly 
```css
:import{ -st-from: '...'; -st-default: X }
X{}
:import{ -st-from: '...'; -st-default: X }
X{}
```

This is working as intended
```css
:import{ -st-from: '...'; -st-default: X }
:import{ -st-from: '...'; -st-default: X }
X{}
X{}
```

`@st-imports` does not suffer from this behavior because they are processed before all other rules 