### PR TITLE
Test inline expectation

### DIFF
--- a/packages/core-test-kit/package.json
+++ b/packages/core-test-kit/package.json
@@ -3,6 +3,9 @@
   "version": "4.2.1",
   "description": "Stylable core test-kit",
   "main": "dist/index.js",
+  "scripts": {
+    "test": "mocha \"./dist/test/**/*.spec.js\""
+  },
   "dependencies": {
     "@stylable/core": "^4.2.1",
     "chai": "^4.3.4",

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -4,3 +4,4 @@ export * from './matchers/flat-match';
 export * from './matchers/match-css';
 export * from './matchers/results';
 export * from './match-rules';
+export * from './inline-expectation';

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -60,7 +60,6 @@ export function testInlineExpects(
                     }
                 }
             }
-            // const m = p.text.match(/@check(.*)/s);
         }
     });
     // check

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -1,5 +1,33 @@
 import type * as postcss from 'postcss';
 
+type RuleCheck = {
+    rule: postcss.Rule;
+    msg?: string;
+    expectedSelector: string;
+    expectedDeclarations: [string, string][];
+    declarationCheck: 'full' | 'none';
+};
+
+
+/**
+ * Test transformed stylesheets inline expectation comments
+ * rule checking (place just before rule)
+ * 
+ * full options:
+ * @check(label)[5] .selector {decl: value}
+ * 
+ * basic:
+ * @check .selector
+ * 
+ * with declarations (will check full match and order):
+ * @check .selector {decl1: value; decl2: value}
+ * 
+ * Label for check:
+ * @check(label for test) .selector
+ * 
+ * target generated rules (mixin):
+ * @check[4] selector
+ */
 export function testInlineExpects(
     result: postcss.Root,
     expectedTestsCount = result.toString().match(/@check/gm)!.length
@@ -7,29 +35,97 @@ export function testInlineExpects(
     if (expectedTestsCount === 0) {
         throw new Error('no tests found try to add @check comments before any selector');
     }
-    const checks: Array<[string, string]> = [];
+    const checks: RuleCheck[] = [];
+    const errors: string[] = [];
 
+    // collect checks
     result.walkRules((rule) => {
         const p = rule.prev();
         if (p && p.type === 'comment') {
-            const m = p.text.match(/@check\s+(.*)/);
-            if (m) {
-                checks.push([rule.selector, m[1]]);
+            const checksInput = p.text.split(`@check`);
+            for (const checkInput of checksInput) {
+                if (checkInput.trim()) {
+                    const check = createRuleCheck(rule, checkInput, errors);
+                    if (check) {
+                        checks.push(check);
+                    }
+                }
+            }
+            // const m = p.text.match(/@check(.*)/s);
+        }
+    });
+    // check
+    checks.forEach(({ msg, rule, expectedSelector, expectedDeclarations, declarationCheck }) => {
+        const prefix = msg ? msg + `: ` : ``;
+        if (rule.selector !== expectedSelector) {
+            errors.push(`${prefix}expected ${rule.selector} to transform to ${expectedSelector}`);
+        }
+        if (declarationCheck === `full`) {
+            const actualDecl = rule.nodes.map((x) => x.toString()).join(`;`);
+            const expectedDecl = expectedDeclarations
+                .map(([prop, value]) => `${prop}: ${value}`)
+                .join(`;`);
+            if (actualDecl !== expectedDecl) {
+                errors.push(
+                    `${prefix}expected ${rule.selector} to have declaration {${expectedDecl}}, but got {${actualDecl}}`
+                );
             }
         }
     });
-    const errors: string[] = [];
-    checks.forEach(([a, b]) => {
-        if (a !== b) {
-            errors.push(`expected ${a} to transform to ${b}`);
-        }
-    });
+    // report errors
     if (errors.length) {
-        throw new Error(errors.join('\n'));
+        throw new Error('\n' + errors.join('\n'));
     }
     if (expectedTestsCount !== checks.length) {
         throw new Error(
             `Expected ${expectedTestsCount} checks to run but there was ${checks.length}`
         );
     }
+}
+
+function createRuleCheck(rule: postcss.Rule, expectInput: string, errors: string[]): RuleCheck | undefined {
+    const { msg, ruleIndex, expectedSelector, expectedBody } = expectInput.match(
+        /(?<msg>\(.*\))*(\[(?<ruleIndex>\d+)\])*(?<expectedSelector>[^{}]*)\s*(?<expectedBody>.*)/s
+    )!.groups!;
+    const targetRule = ruleIndex ? getNextMixinRule(rule, Number(ruleIndex)) : rule;
+    if (!targetRule) {
+        errors.push(`cannot locate mixed-in rule for "${expectInput}"`);
+        return;
+    }
+    const expectedDeclarations: RuleCheck[`expectedDeclarations`] = [];
+    const declsInput = expectedBody.trim().match(/^{(.*)}$/s);
+    const declarationCheck: RuleCheck[`declarationCheck`] = declsInput ? `full` : `none`;
+    if (declsInput && declsInput[1]?.includes(`:`)) {
+        for (const decl of declsInput[1].split(`;`)) {
+            if (decl.trim() !== ``) {
+                const [prop, value] = decl.split(':');
+                if (prop && value) {
+                    expectedDeclarations.push([prop.trim(), value.trim()]);
+                } else {
+                    errors.push(`error in expectation "${decl}" of "${expectInput}"`);
+                }
+            }
+        }
+    }
+    return {
+        msg,
+        rule: targetRule,
+        expectedSelector: expectedSelector.trim(),
+        expectedDeclarations,
+        declarationCheck,
+    };
+}
+
+function getNextMixinRule(currentRule: postcss.Rule, count: number): postcss.Rule | undefined {
+    while (currentRule && count > 0) {
+        const next: postcss.ChildNode | undefined = currentRule.next();
+        // next must be a rule sense mixin can only add rules
+        if (next?.type === `rule`) {
+            currentRule = next;
+            count--;
+        } else {
+            return;
+        }
+    }
+    return currentRule && count === 0 ? currentRule : undefined;
 }

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -1,12 +1,12 @@
 import type * as postcss from 'postcss';
 
-type RuleCheck = {
+interface RuleCheck {
     rule: postcss.Rule;
     msg?: string;
     expectedSelector: string;
     expectedDeclarations: [string, string][];
     declarationCheck: 'full' | 'none';
-};
+}
 
 /**
  * Test transformed stylesheets inline expectation comments

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -8,25 +8,34 @@ type RuleCheck = {
     declarationCheck: 'full' | 'none';
 };
 
-
 /**
  * Test transformed stylesheets inline expectation comments
  * rule checking (place just before rule)
- * 
+ *
  * full options:
  * @check(label)[5] .selector {decl: value}
- * 
+ *
  * basic:
  * @check .selector
- * 
+ *
  * with declarations (will check full match and order):
  * @check .selector {decl1: value; decl2: value}
- * 
- * Label for check:
+ *
+ * label for check:
  * @check(label for test) .selector
- * 
+ *
  * target generated rules (mixin):
- * @check[4] selector
+ * @check[4] .selector
+ *
+ * support multi line declarations:
+ * @check .selector {
+ *     decl1: value;
+ *     decl2: value;
+ * }
+ *
+ * support multi checks:
+ * @check .selector
+ * @check[1] .selector:hover
  */
 export function testInlineExpects(
     result: postcss.Root,
@@ -83,7 +92,11 @@ export function testInlineExpects(
     }
 }
 
-function createRuleCheck(rule: postcss.Rule, expectInput: string, errors: string[]): RuleCheck | undefined {
+function createRuleCheck(
+    rule: postcss.Rule,
+    expectInput: string,
+    errors: string[]
+): RuleCheck | undefined {
     const { msg, ruleIndex, expectedSelector, expectedBody } = expectInput.match(
         /(?<msg>\(.*\))*(\[(?<ruleIndex>\d+)\])*(?<expectedSelector>[^{}]*)\s*(?<expectedBody>.*)/s
     )!.groups!;

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -1,0 +1,35 @@
+import type * as postcss from 'postcss';
+
+export function testInlineExpects(
+    result: postcss.Root,
+    expectedTestsCount = result.toString().match(/@check/gm)!.length
+) {
+    if (expectedTestsCount === 0) {
+        throw new Error('no tests found try to add @check comments before any selector');
+    }
+    const checks: Array<[string, string]> = [];
+
+    result.walkRules((rule) => {
+        const p = rule.prev();
+        if (p && p.type === 'comment') {
+            const m = p.text.match(/@check\s+(.*)/);
+            if (m) {
+                checks.push([rule.selector, m[1]]);
+            }
+        }
+    });
+    const errors: string[] = [];
+    checks.forEach(([a, b]) => {
+        if (a !== b) {
+            errors.push(`expected ${a} to transform to ${b}`);
+        }
+    });
+    if (errors.length) {
+        throw new Error(errors.join('\n'));
+    }
+    if (expectedTestsCount !== checks.length) {
+        throw new Error(
+            `Expected ${expectedTestsCount} checks to run but there was ${checks.length}`
+        );
+    }
+}

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -1,0 +1,241 @@
+import {
+    generateStylableRoot,
+    testInlineExpects,
+    testInlineExpectsErrors,
+} from '@stylable/core-test-kit';
+import { expect } from 'chai';
+
+describe('inline-expectations', () => {
+    it('should throw when expected @match amount is not found (manual)', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check .entry__root*/
+                        .root {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result, 5)).to.throw(
+            testInlineExpectsErrors.matchAmount(5, 1)
+        );
+    });
+    it('should throw when expected @match amount is not found (auto)', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check */
+                        .root {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(testInlineExpectsErrors.matchAmount(1, 0));
+    });
+    it('should throw for unexpected selector', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check .otherNamespace__root*/
+                        .root {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.selector(`.otherNamespace__root`, `.entry__root`)
+        );
+    });
+    it('should throw for unexpected declarations', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check .entry__root {color: green;}*/
+                        .root {
+                            color: red;
+                        }
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.declarations(`color: green`, `color: red`, `.entry__root`)
+        );
+    });
+    it('should throw for unexpected declarations (multiple variations)', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check .entry__multi {color: green; width: 1px}*/
+                        .multi {
+                            color: green;
+                            width: 2px;
+                        }
+                        /* @check .entry__order {width: 2px; color: green;}*/
+                        .order {
+                            color: green;
+                            width: 2px;
+                        }
+                        /* @check .entry__multiline {
+                            color: red;
+                            width: 2px;
+                        }*/
+                        .multiline {
+                            color: green;
+                            width: 1px;
+                        }
+                        /* @check(only prop) .entry__malformed {color:}*/
+                        .malformed {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.combine([
+                testInlineExpectsErrors.malformedDecl(
+                    `color:`,
+                    `(only prop) .entry__malformed {color:}`
+                ),
+                testInlineExpectsErrors.declarations(
+                    `color: green; width: 1px`,
+                    `color: green; width: 2px`,
+                    `.entry__multi`
+                ),
+                testInlineExpectsErrors.declarations(
+                    `width: 2px; color: green`,
+                    `color: green; width: 2px`,
+                    `.entry__order`
+                ),
+                testInlineExpectsErrors.declarations(
+                    `color: red; width: 2px`,
+                    `color: green; width: 1px`,
+                    `.entry__multiline`
+                ),
+            ])
+        );
+    });
+    it('should throw when for keyframes nested rules', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        @keyframes anim {
+                            /* @check 50%*/
+                            100% {}
+                        }
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.selector(`50%`, `100%`)
+        );
+    });
+    it('should throw for mixed in rules', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* 
+                            @check .entry__root 
+                            @check[1] .entry__root:focus
+                        */
+                        .root {
+                            -st-mixin: mix;
+                        }
+
+                        .mix {}
+                        .mix:hover {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.selector(`.entry__root:focus`, `.entry__root:hover`)
+        );
+    });
+    it('should throw for unfound mixin rules', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* 
+                            @check .entry__root 
+                            @check[10] .entry__root:focus
+                        */
+                        .root {
+                            -st-mixin: mix;
+                        }
+                        /*comment to break search after index over 1*/
+
+                        .mix {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.unfoundMixin(`[10] .entry__root:focus`)
+        );
+    });
+    it('should add label to thrown miss matches', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check(only selector) .entry__onlySelector*/
+                        .onlySelectorXXX {}
+                        /* @check(declarations) .entry__decls {color: green;}*/
+                        .decls {color: red;}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.combine([
+                testInlineExpectsErrors.selector(
+                    `.entry__onlySelector`,
+                    `.entry__onlySelectorXXX`,
+                    `(only selector): `
+                ),
+                testInlineExpectsErrors.declarations(
+                    `color: green`,
+                    `color: red`,
+                    `.entry__decls`,
+                    `(declarations): `
+                ),
+            ])
+        );
+    });
+});

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -134,7 +134,61 @@ describe('inline-expectations', () => {
             ])
         );
     });
-    it('should throw when for keyframes nested rules', () => {
+    it('should throw for at rules params', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check entry__anim */
+                        @keyframes animX {}
+
+                        /* @check(no body) "no-body" */
+                        @charset "utf-8";
+
+                        /* @check(complex) screen and (min-width: 8px) */
+                        @media screen and (min-width: 900px) {
+                            article {
+                              padding: 1rem 3rem;
+                            }
+                        }
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.combine([
+                testInlineExpectsErrors.atruleParams(`entry__anim`, `entry__animX`),
+                testInlineExpectsErrors.atruleParams(`"no-body"`, `"utf-8"`, `(no body): `),
+                testInlineExpectsErrors.atruleParams(
+                    `screen and (min-width: 8px)`,
+                    `screen and (min-width: 900px)`,
+                    `(complex): `
+                ),
+            ])
+        );
+    });
+    it('should throw for multi check on at rules', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    namespace: 'entry',
+                    content: `
+                        /* @check entry__anim @check[1] entry__anim */
+                        @keyframes animX {}
+                    `,
+                },
+            },
+        });
+
+        expect(() => testInlineExpects(result)).to.throw(
+            testInlineExpectsErrors.atRuleMultiTest(`@check entry__anim @check[1] entry__anim`)
+        );
+    });
+    it('should throw for keyframes nested rules', () => {
         const result = generateStylableRoot({
             entry: `/style.st.css`,
             files: {

--- a/packages/core-test-kit/test/tsconfig.json
+++ b/packages/core-test-kit/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["node", "externals", "mocha"]
+  },
+  "references": [{ "path": "../src" }]
+}

--- a/packages/core/test/stylable-transformer/scope-selector-v2.spec.ts
+++ b/packages/core/test/stylable-transformer/scope-selector-v2.spec.ts
@@ -90,8 +90,7 @@ describe('Stylable scope-selector v2', () => {
                         }
 
                         /* 
-                            ALIAS CHECK
-                            @check .style__root .base__base
+                            @check(ALIAS CHECK) .style__root .base__base
                         */
                         .root::base{}
 

--- a/packages/core/test/stylable-transformer/scope-selector-v2.spec.ts
+++ b/packages/core/test/stylable-transformer/scope-selector-v2.spec.ts
@@ -1,39 +1,4 @@
-import type * as postcss from 'postcss';
-import { generateStylableRoot } from '@stylable/core-test-kit';
-
-function selfTest(
-    result: postcss.Root,
-    expectedTestsCount = result.toString().match(/@check/gm)!.length
-) {
-    if (expectedTestsCount === 0) {
-        throw new Error('no tests found try to add @check comments before any selector');
-    }
-    const checks: Array<[string, string]> = [];
-
-    result.walkRules((rule) => {
-        const p = rule.prev();
-        if (p && p.type === 'comment') {
-            const m = p.text.match(/@check\s+(.*)/);
-            if (m) {
-                checks.push([rule.selector, m[1]]);
-            }
-        }
-    });
-    const errors: string[] = [];
-    checks.forEach(([a, b]) => {
-        if (a !== b) {
-            errors.push(`expected ${a} to transform to ${b}`);
-        }
-    });
-    if (errors.length) {
-        throw new Error(errors.join('\n'));
-    }
-    if (expectedTestsCount !== checks.length) {
-        throw new Error(
-            `Expected ${expectedTestsCount} checks to run but there was ${checks.length}`
-        );
-    }
-}
+import { generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
 
 describe('Stylable scope-selector v2', () => {
     it('should handle basic transform', () => {
@@ -160,7 +125,7 @@ describe('Stylable scope-selector v2', () => {
             },
         });
 
-        selfTest(result);
+        testInlineExpects(result);
     });
 
     it('should properly scope states in nested-pseudo-classes', () => {
@@ -219,7 +184,7 @@ describe('Stylable scope-selector v2', () => {
             },
         });
 
-        selfTest(result);
+        testInlineExpects(result);
     });
 
     it('should properly scope states in nested-pseudo-classes (more exmaples)', () => {
@@ -304,7 +269,7 @@ describe('Stylable scope-selector v2', () => {
             },
         });
 
-        selfTest(result);
+        testInlineExpects(result);
     });
 
     it('should properly scope states in nested-pseudo-classes with aliase state override', () => {
@@ -368,7 +333,7 @@ describe('Stylable scope-selector v2', () => {
             },
         });
 
-        selfTest(result);
+        testInlineExpects(result);
     });
 
     it('should properly scope states in nested-pseudo-classes222231241241242', () => {
@@ -401,6 +366,6 @@ describe('Stylable scope-selector v2', () => {
             },
         });
 
-        selfTest(result);
+        testInlineExpects(result);
     });
 });

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1180,16 +1180,22 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/entry.st.css': {
                         namespace: 'entry',
                         content: `
+                            /* @check entry__name */
                             @keyframes name {
                                 from {}
                                 to {}
                             }
-
+                            
+                            /* @check entry__name2 */
                             @keyframes name2 {
                                 from {}
                                 to {}
                             }
 
+                            /* @check .entry__selector {
+                                animation: 2s entry__name infinite, 1s entry__name2 infinite;
+                                animation-name: entry__name;
+                            }*/
                             .selector {
                                 animation: 2s name infinite, 1s name2 infinite;
                                 animation-name: name;
@@ -1199,14 +1205,8 @@ describe('Stylable postcss transform (Scoping)', () => {
                     },
                 },
             });
-            expect((result.nodes[0] as postcss.AtRule).params).to.equal('entry__name');
-            expect((result.nodes[1] as postcss.AtRule).params).to.equal('entry__name2');
-            expect((result.nodes[2] as postcss.Rule).nodes[0].toString()).to.equal(
-                'animation: 2s entry__name infinite, 1s entry__name2 infinite'
-            );
-            expect((result.nodes[2] as postcss.Rule).nodes[1].toString()).to.equal(
-                'animation-name: entry__name'
-            );
+
+            testInlineExpects(result);
         });
 
         it('scope imported animation and animation name', () => {

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
-import { generateStylableRoot } from '@stylable/core-test-kit';
+import { generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
 import { createWarningRule } from '@stylable/core';
 
 describe('Stylable postcss transform (Scoping)', () => {
@@ -12,17 +12,18 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/style.st.css': {
                         namespace: 'ns',
                         content: `
+                            /* @check header::before */
                             header::before {}
+                            /* @check div::after */
                             div::after {}
+                            /* @check form::focused */
                             form::focused {}
                         `,
                     },
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('header::before');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('div::after');
-            expect((result.nodes[2] as postcss.Rule).selector).to.equal('form::focused');
+            testInlineExpects(result);
         });
 
         it('component/tag selector that extends root with inner class targeting', () => {
@@ -36,7 +37,9 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./inner.st.css";
                                 -st-default: Container;
                             }
+                            /* @check .ns1__root .ns1__inner */
                             Container::inner {}
+                            /* @check .ns1__root .ns1__inner .ns2__deep */
                             Container::inner::deep {}
                         `,
                     },
@@ -61,10 +64,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns1__root .ns1__inner');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.ns1__root .ns1__inner .ns2__deep'
-            );
+            testInlineExpects(result);
         });
 
         it('component/tag selector with -st-global', () => {
@@ -78,8 +78,8 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./inner.st.css";
                                 -st-default: Container;
                             }
+                            /* @check .x */
                             Container {}
-
                         `,
                     },
                     '/inner.st.css': {
@@ -93,7 +93,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.x');
+            testInlineExpects(result);
         });
 
         it('class selector that extends root with inner class targeting (deep)', () => {
@@ -110,7 +110,9 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .app {
                                 -st-extends: Container;
                             }
+                            /* @check .ns__app .ns1__inner */
                             .app::inner {}
+                            /* @check .ns__app .ns1__inner .ns2__deep */
                             .app::inner::deep {}
                         `,
                     },
@@ -135,10 +137,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.ns__app .ns1__inner');
-            expect((result.nodes[2] as postcss.Rule).selector).to.equal(
-                '.ns__app .ns1__inner .ns2__deep'
-            );
+            testInlineExpects(result);
         });
 
         it('should add a warning rule while in development mode that targets a broken inheritance structure', () => {
@@ -337,6 +336,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .app {
                                 -st-extends: Container;
                             }
+                            /* @check .ns__app:hover .ns1__inner */
                             .app:hover::inner {}
                         `,
                     },
@@ -369,9 +369,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.ns__app:hover .ns1__inner'
-            );
+            testInlineExpects(result);
         });
 
         it('resolve and transform pseudo-element from deeply extended type', () => {
@@ -388,6 +386,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .app {
                                 -st-extends: Inner;
                             }
+                            /* @check .ns__app .ns2__deep */
                             .app::deep {}
                         `,
                     },
@@ -412,7 +411,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.ns__app .ns2__deep');
+            testInlineExpects(result);
         });
 
         it('resolve and transform pseudo-element from deeply override rather then extended type', () => {
@@ -429,6 +428,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .app {
                                 -st-extends: Container;
                             }
+                            /* @check .ns__app .ns1__deep */
                             .app::deep {}
                         `,
                     },
@@ -454,7 +454,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.ns__app .ns1__deep');
+            testInlineExpects(result);
         });
 
         it('resolve and transform pseudo-element on root - prefer inherited element to override', () => {
@@ -471,6 +471,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .root {
                                 -st-extends: Inner;
                             }
+                            /* @check .entry__root .inner__inner, .entry__inner */
                             .root::inner, .inner { }
                         `,
                     },
@@ -483,9 +484,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.entry__root .inner__inner, .entry__inner'
-            );
+            testInlineExpects(result);
         });
 
         it('resolve and transform pseudo-element with -st-global output', () => {
@@ -499,7 +498,9 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./inner.st.css";
                                 -st-default: Inner;
                             }
+                            /* @check .x */
                             Inner {}
+                            /* @check .x .y */
                             Inner::a {}
                         `,
                     },
@@ -513,8 +514,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.x');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.x .y');
+            testInlineExpects(result);
         });
 
         it('resolve extend on extended alias', () => {
@@ -528,6 +528,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./inner.st.css";
                                 -st-default: Inner;
                             }
+                            /* @check .Inner__root .Inner__deep .Deep__up */
                             Inner::deep::up { }
                         `,
                     },
@@ -553,9 +554,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal(
-                '.Inner__root .Inner__deep .Deep__up'
-            );
+            testInlineExpects(result);
         });
 
         it('resolve aliased pseudo-element', () => {
@@ -572,6 +571,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .x {
                                 -st-extends: Inner;
                             }
+                            /* @check .entry__x .Deep__y */
                             .x::y {}
                         `,
                     },
@@ -594,7 +594,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.entry__x .Deep__y');
+            testInlineExpects(result);
         });
 
         it('resolve aliased pseudo-element (with @custom-selector )', () => {
@@ -611,9 +611,11 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .root {
                                 -st-extends: Inner;
                             }
+                            /* @check .entry__root .Deep__x.Comp--hovered */
                             .root::option:hovered {
                                 z-index: 1;
                             }
+                            /* @check .entry__root .Deep__x .Comp__y.Y--hovered */
                             .root::optionY:hovered {
                                 z-index: 2;
                             }
@@ -671,12 +673,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.entry__root .Deep__x.Comp--hovered'
-            );
-            expect((result.nodes[2] as postcss.Rule).selector).to.equal(
-                '.entry__root .Deep__x .Comp__y.Y--hovered'
-            );
+            testInlineExpects(result);
         });
 
         it('should only lookup in the extedns chain', () => {
@@ -693,9 +690,11 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .gaga {
                                 -st-extends: midClass;
                             }
+                            /* @check .ns4__gaga .ns1__deep */
                             .gaga::deep {
                                 color: gold;
                             }
+                            /* @check .ns4__gaga .ns1__deep .ns0__deepest */
                             .gaga::deep::deepest {
                                 color: gold;
                             }
@@ -755,11 +754,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.ns4__gaga .ns1__deep');
-
-            expect((result.nodes[2] as postcss.Rule).selector).to.equal(
-                '.ns4__gaga .ns1__deep .ns0__deepest'
-            );
+            testInlineExpects(result);
         });
 
         it('should scope multiple selectors with a pseudo element passed through a mixin', () => {
@@ -773,6 +768,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./variant.st.css";
                                 -st-default: Variant;
                             }
+                            /* @check[1] .style__root .comp__partA, .style__root .comp__partB */
                             .root {
                                 -st-mixin: Variant;
                             }
@@ -801,9 +797,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.style__root .comp__partA, .style__root .comp__partB'
-            );
+            testInlineExpects(result);
         });
     });
 
@@ -815,17 +809,18 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/entry.st.css': {
                         namespace: 'entry',
                         content: `
+                            /* @check .entry__a */
                             .a {}
+                            /* @check .entry__b, .entry__c */
                             .b, .c {}
+                            /* @check .entry__d .entry__e*/
                             .d .e {}
                         `,
                     },
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__a');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.entry__b, .entry__c');
-            expect((result.nodes[2] as postcss.Rule).selector).to.equal('.entry__d .entry__e');
+            testInlineExpects(result);
         });
 
         it('scope local root class', () => {
@@ -835,19 +830,18 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/entry.st.css': {
                         namespace: 'entry',
                         content: `
+                            /* @check .entry__root */
                             .root {}
+                            /* @check .entry__root .entry__a */
                             .root .a {}
+                            /* @check .entry__root .entry__b, .entry__c */
                             .root .b, .c{}
                         `,
                     },
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__root');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.entry__root .entry__a');
-            expect((result.nodes[2] as postcss.Rule).selector).to.equal(
-                '.entry__root .entry__b, .entry__c'
-            );
+            testInlineExpects(result);
         });
 
         it('scope according to -st-global', () => {
@@ -857,9 +851,11 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/entry.st.css': {
                         namespace: 'entry',
                         content: `
+                            /* @check .x */
                             .root {
                                 -st-global: ".x";
                             }
+                            /* @check .y*/
                             .a {
                                 -st-global: ".y";
                             }
@@ -868,8 +864,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.x');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.y');
+            testInlineExpects(result);
         });
 
         it('scope according to -st-global complex chunk', () => {
@@ -879,9 +874,11 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/entry.st.css': {
                         namespace: 'entry',
                         content: `
+                            /* @check .x.y */
                             .root {
                                 -st-global: ".x.y";
                             }
+                            /* @check .z */
                             .a {
                                 -st-global: ".z";
                             }
@@ -890,8 +887,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.x.y');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.z');
+            testInlineExpects(result);
         });
 
         it('scope selector that extends local root', () => {
@@ -901,6 +897,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                     '/entry.st.css': {
                         namespace: 'entry',
                         content: `
+                            /* @check .entry__a */
                             .a {
                                 -st-extends: root;
                             }
@@ -909,7 +906,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__a');
+            testInlineExpects(result);
         });
 
         it.skip('TODO: fix it. scope selector that extends local root', () => {
@@ -939,6 +936,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./imported.st.css";
                                 -st-default: Imported;
                             }
+                            /* @check .entry__a */
                             .a {
                                 -st-extends: Imported;
                             }
@@ -951,7 +949,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__a');
+            testInlineExpects(result);
         });
 
         it('scope selector that extends a style with -st-global root', () => {
@@ -965,6 +963,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./imported.st.css";
                                 -st-default: Imported;
                             }
+                            /* @check .entry__a */
                             .a {
                                 -st-extends: Imported;
                             }
@@ -981,7 +980,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__a');
+            testInlineExpects(result);
         });
 
         it('scope class alias', () => {
@@ -996,8 +995,9 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-default: Imported;
                                 -st-named: inner-class;
                             }
-
+                            /* @check(root alias) .imported__root */
                             .Imported{}
+                            /* @check(class alias) .imported__inner-class */
                             .inner-class{}
                         `,
                     },
@@ -1012,12 +1012,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector, 'root alias').to.equal(
-                '.imported__root'
-            );
-            expect((result.nodes[1] as postcss.Rule).selector, 'class alias').to.equal(
-                '.imported__inner-class'
-            );
+            testInlineExpects(result);
         });
 
         it('scope class alias that also extends', () => {
@@ -1032,6 +1027,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-default: Imported;
                                 -st-named: inner-class;
                             }
+                            /* @check(class alias) .entry__inner-class */
                             .inner-class{
                                 -st-extends: inner-class
                             }
@@ -1048,9 +1044,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector, 'class alias').to.equal(
-                '.entry__inner-class'
-            );
+            testInlineExpects(result);
         });
 
         it('scope class alias that extends and have pseudo elements ', () => {
@@ -1065,6 +1059,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-named: inner-class;
                             }
 
+                            /* @check(class alias) .imported__inner-class .base__base */
                             .inner-class::base {
 
                             }
@@ -1093,9 +1088,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector, 'class alias').to.equal(
-                '.imported__inner-class .base__base'
-            );
+            testInlineExpects(result);
         });
 
         it('scope selector that extends local class', () => {
@@ -1108,6 +1101,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                             .a {
 
                             }
+                            /* @check .ns__b */
                             .b {
                                 -st-extends: a;
                             }
@@ -1116,7 +1110,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.ns__b');
+            testInlineExpects(result);
         });
 
         it('extends class form imported sheet', () => {
@@ -1130,6 +1124,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./imported.st.css";
                                 -st-named: b;
                             }
+                            /* @check .ns__a */
                             .a {
                                 -st-extends: b;
                             }
@@ -1146,7 +1141,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns__a');
+            testInlineExpects(result);
         });
 
         it('handle not existing imported class', () => {
@@ -1160,6 +1155,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: "./imported.st.css";
                                 -st-named: b;
                             }
+                            /* @check .ns__b */
                             .b {}
                         `,
                     },
@@ -1172,7 +1168,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns__b');
+            testInlineExpects(result);
         });
     });
 
@@ -1224,7 +1220,10 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: './imported.st.css';
                                 -st-named: keyframes(anim1, anim2 as anim3);
                             }
-
+                            /* @check .entry__selector {
+                                animation: 2s imported__anim1 infinite, 1s imported__anim2 infinite;
+                                animation-name: imported__anim1
+                            } */
                             .selector {
                                 animation: 2s anim1 infinite, 1s anim3 infinite;
                                 animation-name: anim1;
@@ -1250,12 +1249,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            expect((result.nodes[0] as postcss.Rule).nodes[0].toString()).to.equal(
-                'animation: 2s imported__anim1 infinite, 1s imported__anim2 infinite'
-            );
-            expect((result.nodes[0] as postcss.Rule).nodes[1].toString()).to.equal(
-                'animation-name: imported__anim1'
-            );
+            testInlineExpects(result);
         });
 
         it('scope imported animation and animation name with part name collision', () => {
@@ -1269,14 +1263,16 @@ describe('Stylable postcss transform (Scoping)', () => {
                                 -st-from: './imported.st.css';
                                 -st-named: anim1, keyframes(anim1);
                             }
-
+                            /* @check .entry__selector {
+                                animation: 2s imported__anim1 infinite;
+                                animation-name: imported__anim1;
+                            } */
                             .selector {
                                 animation: 2s anim1 infinite;
                                 animation-name: anim1;
                             }
-
+                            /* @check .imported__anim1 */
                             .anim1{}
-
                         `,
                     },
                     '/imported.st.css': {
@@ -1292,14 +1288,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                     },
                 },
             });
-
-            expect((result.nodes[0] as postcss.Rule).nodes[0].toString()).to.equal(
-                'animation: 2s imported__anim1 infinite'
-            );
-            expect((result.nodes[0] as postcss.Rule).nodes[1].toString()).to.equal(
-                'animation-name: imported__anim1'
-            );
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal('.imported__anim1');
+            testInlineExpects(result);
         });
 
         it('not scope rules that are child of keyframe atRule', () => {
@@ -1310,11 +1299,15 @@ describe('Stylable postcss transform (Scoping)', () => {
                         namespace: 'entry',
                         content: `
                             @keyframes name {
+                                /* @check from */
                                 from {}
+                                /* @check to */
                                 to {}
                             }
                             @keyframes name2 {
+                                /* @check 0% */
                                 0% {}
+                                /* @check 100% */
                                 100% {}
                             }
                         `,
@@ -1322,13 +1315,7 @@ describe('Stylable postcss transform (Scoping)', () => {
                 },
             });
 
-            const at = result.nodes[0] as postcss.AtRule;
-            expect((at.nodes[0] as postcss.Rule).selector).to.equal('from');
-            expect((at.nodes[1] as postcss.Rule).selector).to.equal('to');
-
-            const at1 = result.nodes[1] as postcss.AtRule;
-            expect((at1.nodes[0] as postcss.Rule).selector).to.equal('0%');
-            expect((at1.nodes[1] as postcss.Rule).selector).to.equal('100%');
+            testInlineExpects(result);
         });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "./packages/core/src" },
     { "path": "./packages/core/test" },
     { "path": "./packages/core-test-kit/src" },
+    { "path": "./packages/core-test-kit/test" },
     { "path": "./packages/create-stylable-app/src" },
     { "path": "./packages/custom-value/src" },
     { "path": "./packages/custom-value/test" },


### PR DESCRIPTION
This PR takes the concept for inline expectation tests from `scope-selector-vs.spec` and add some more features:

- [x] selector check
- [x] optional declarations (all + order)
- [x] optional message for check
- [x] mixin rules - check generated rules that are not part of the source
- [x] @atrule params
- [x] @atrule nested rules

format:
```css
/**
* Test transformed stylesheets inline expectation comments
 * rule checking (place just before rule)
 *
 * full options:
 * @check(label)[5] .selector {decl: value}
 *
 * basic:
 * @check .selector
 *
 * with declarations (will check full match and order):
 * @check .selector {decl1: value; decl2: value}
 *
 * label for check:
 * @check(label for test) .selector
 *
 * target generated rules (mixin):
 * @check[4] .selector
 *
 * support multi line declarations:
 * @check .selector {
 *     decl1: value;
 *     decl2: value;
 * }
 *
 * support multi checks:
 * @check .selector
 * @check[1] .selector:hover
 *
 * support atrule params (anything between the @atrule and body or semicolon)
 * @check screen and (min-width: 900px)
 */
```

I converted a lot of tests to see that everything is working, but not all.