### PR TITLE
security(core): drop postcss-selector-matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@file-services/node": "^5.3.1",
     "@rollup/plugin-html": "^0.2.3",
     "@rollup/plugin-node-resolve": "^13.0.0",
+    "@types/balanced-match": "^1.0.1",
     "@types/chai": "^4.2.18",
     "@types/chai-subset": "^1.3.3",
     "@types/css-selector-tokenizer": "^0.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "start": "webpack serve"
   },
   "dependencies": {
+    "balanced-match": "^2.0.0",
     "css-selector-tokenizer": "^0.7.3",
     "deindent": "^0.1.0",
     "enhanced-resolve": "^5.8.2",
@@ -19,7 +20,6 @@
     "postcss-js": "^3.0.3",
     "postcss-nested": "^5.0.5",
     "postcss-safe-parser": "^5.0.2",
-    "postcss-selector-matches": "^4.0.0",
     "postcss-value-parser": "^4.1.0",
     "toky": "^0.1.0"
   },

--- a/packages/core/src/replace-rule-selector.ts
+++ b/packages/core/src/replace-rule-selector.ts
@@ -1,0 +1,77 @@
+// sourced from https://github.com/postcss/postcss-selector-matches
+
+import { list, Rule } from 'postcss';
+import balancedMatch from 'balanced-match';
+
+const pseudoClass = ':matches';
+const selectorElementRE = /^[a-zA-Z]/;
+
+function isElementSelector(selector: string) {
+    const matches = selectorElementRE.exec(selector);
+    return matches;
+}
+
+function normalizeSelector(selector: string, preWhitespace: string, pre: string) {
+    if (isElementSelector(selector) && !isElementSelector(pre)) {
+        return `${preWhitespace}${selector}${pre}`;
+    }
+
+    return `${preWhitespace}${pre}${selector}`;
+}
+
+function explodeSelector(selector: string, options: { lineBreak: boolean }) {
+    if (selector && selector.indexOf(pseudoClass) > -1) {
+        let newSelectors: string[] = [];
+        const preWhitespaceMatches = selector.match(/^\s+/);
+        const preWhitespace = preWhitespaceMatches ? preWhitespaceMatches[0] : '';
+        const selectorPart = list.comma(selector);
+        selectorPart.forEach((part) => {
+            const position = part.indexOf(pseudoClass);
+            const pre = part.slice(0, position);
+            const body = part.slice(position);
+            const matches = balancedMatch('(', ')', body);
+
+            const bodySelectors =
+                matches && matches.body
+                    ? list
+                          .comma(matches.body)
+                          .reduce<string[]>(
+                              (acc, s) => [...acc, ...explodeSelector(s, options)],
+                              []
+                          )
+                    : [body];
+
+            const postSelectors =
+                matches && matches.post ? explodeSelector(matches.post, options) : [];
+
+            let newParts: string[];
+            if (postSelectors.length === 0) {
+                // the test below is a poor way to try we are facing a piece of a
+                // selector...
+                if (position === -1 || pre.indexOf(' ') > -1) {
+                    newParts = bodySelectors.map((s) => preWhitespace + pre + s);
+                } else {
+                    newParts = bodySelectors.map((s) => normalizeSelector(s, preWhitespace, pre));
+                }
+            } else {
+                newParts = [];
+                postSelectors.forEach((postS) => {
+                    bodySelectors.forEach((s) => {
+                        newParts.push(preWhitespace + pre + s + postS);
+                    });
+                });
+            }
+            newSelectors = [...newSelectors, ...newParts];
+        });
+
+        return newSelectors;
+    }
+    return [selector];
+}
+
+export function replaceRuleSelector(rule: Rule, options: { lineBreak: boolean }) {
+    const indentation = rule.raws && rule.raws.before ? rule.raws.before.split('\n').pop() : '';
+    return explodeSelector(rule.selector, options).join(
+        ',' + (options.lineBreak ? '\n' + indentation : ' ')
+    );
+}

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import { isAbsolute } from 'path';
 import * as postcss from 'postcss';
-import replaceRuleSelector from 'postcss-selector-matches/dist/replaceRuleSelector';
+import { replaceRuleSelector } from './replace-rule-selector';
 import type { Diagnostics } from './diagnostics';
 import type {
     DeclStylableProps,

--- a/typings/externals/index.d.ts
+++ b/typings/externals/index.d.ts
@@ -32,14 +32,6 @@ declare module 'postcss-js' {
     export = postcssJs;
 }
 
-declare module 'postcss-selector-matches/dist/replaceRuleSelector' {
-    // library is esm transpiled to cjs! has an actual default export.
-    export default function replaceRuleSelector(
-        rule: import('postcss').Rule,
-        options: { lineBreak: boolean }
-    ): string;
-}
-
 declare module 'node-eval' {
     function nodeEval(content: string, filename: string, context?: object): any;
     export = nodeEval;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,6 +1015,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/balanced-match@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/balanced-match/-/balanced-match-1.0.1.tgz#056a4793ae82b33308b39bd9a3e114a3438d2590"
+  integrity sha512-flYjxKu45rRRd//gE2Y3zfVb1rCa4aNHW8fZ68c4Yt++iCBjij7YmraB9DGjsue1RC5pj4+yU50sI5cADCKZRA==
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -1941,6 +1946,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -2195,7 +2205,7 @@ chai@^4.3.4:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
-chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -6452,14 +6462,6 @@ postcss-safe-parser@^5.0.2:
   dependencies:
     postcss "^8.1.0"
 
-postcss-selector-matches@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz#71c8248f917ba2cc93037c9637ee09c64436fcff"
-  integrity sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==
-  dependencies:
-    balanced-match "^1.0.0"
-    postcss "^7.0.2"
-
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
@@ -6472,15 +6474,6 @@ postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
-
-postcss@^7.0.2:
-  version "7.0.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 postcss@^8.1.0, postcss@^8.1.6, postcss@^8.2.10, postcss@^8.2.15:
   version "8.2.15"
@@ -7708,13 +7701,6 @@ supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
fixes #1799 

this change drops the last runtime dependency bringing postcss@7 with it.

instead, code was ported to typescript and inlined.