### PR TITLE
fix(core): fix parse of :is and :where as nested-pseudo-class

### DIFF
--- a/packages/core/test/stylable-transformer/nested-pseudo-classes.spec.ts
+++ b/packages/core/test/stylable-transformer/nested-pseudo-classes.spec.ts
@@ -1,0 +1,22 @@
+import { generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
+
+describe('native nested pseudo classes', () => {
+    for (const name of ['is', 'has', 'where']) {
+        it(`should transform inside :${name}`, () => {
+            const result = generateStylableRoot({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'ns',
+                        content: `
+                            /* @check :${name}(.ns__x, .ns__y) */
+                            :${name}(.x, .y) {}
+                        `,
+                    },
+                },
+            });
+
+            testInlineExpects(result);
+        });
+    }
+});


### PR DESCRIPTION
We should wait before merge this PR and instead prefer https://github.com/css-modules/css-selector-tokenizer/pull/25 