### PR TITLE
add error when nesting rules

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -155,7 +155,7 @@ export const processorWarnings = {
         return 'st-namespace-reference dose not have any value';
     },
     INVALID_NESTING(child: string, parent: string) {
-        return `invalid nesting of ${child} inside ${parent}`;
+        return `Stylable does not support nesting of rules within rules, found: "${child}" inside "${parent}"`;
     },
 };
 

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -155,7 +155,7 @@ export const processorWarnings = {
         return 'st-namespace-reference dose not have any value';
     },
     INVALID_NESTING(child: string, parent: string) {
-        return `Stylable does not support nesting of rules within rules, found: "${child}" inside "${parent}"`;
+        return `nesting of rules within rules is not supported, found: "${child}" inside "${parent}"`;
     },
 };
 

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -154,6 +154,9 @@ export const processorWarnings = {
     INVALID_NAMESPACE_REFERENCE() {
         return 'st-namespace-reference dose not have any value';
     },
+    INVALID_NESTING(child: string, parent: string) {
+        return `invalid nesting of ${child} inside ${parent}`;
+    },
 };
 
 export class StylableProcessor {
@@ -184,6 +187,16 @@ export class StylableProcessor {
             if (!isChildOfAtRule(rule, 'keyframes')) {
                 this.handleCustomSelectors(rule);
                 this.handleRule(rule as SRule, isChildOfAtRule(rule, rootValueMapping.stScope));
+            }
+            const parent = rule.parent;
+            if (parent?.type === 'rule') {
+                this.diagnostics.error(
+                    rule,
+                    processorWarnings.INVALID_NESTING(
+                        rule.selector,
+                        (parent as postcss.Rule).selector
+                    )
+                );
             }
         });
 

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -33,6 +33,23 @@ describe('Stylable postcss process', () => {
         });
     });
 
+    it('error on invalid rule nesting', () => {
+        const { diagnostics } = processSource(
+            `
+            .x{
+                .y{}
+            }
+        
+        `,
+            { from: '/path/to/source' }
+        );
+
+        expect(diagnostics.reports[0]).to.include({
+            type: 'error',
+            message: processorWarnings.INVALID_NESTING('.y', '.x'),
+        });
+    });
+
     it('collect namespace', () => {
         const from = resolve('/path/to/style.css');
         const result = processSource(


### PR DESCRIPTION
```css

.x {
  .y{}
}
```
should emit error
