### PR TITLE
Fix global type definition to set default export as unknown instead of never

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-rollup/typings/globals.d.ts
@@ -1,7 +1,7 @@
 declare module '*.st.css' {
     export * from '@stylable/runtime/stylesheet';
 
-    const defaultExport: never;
+    const defaultExport: unknown;
     export default defaultExport;
 }
 

--- a/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
@@ -1,7 +1,7 @@
 declare module '*.st.css' {
     export * from '@stylable/runtime/stylesheet';
 
-    const defaultExport: never;
+    const defaultExport: unknown;
     export default defaultExport;
 }
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -89,7 +89,7 @@ Add the following file to your `/src` directory.
 declare module '*.st.css' {
     export * from '@stylable/runtime/stylesheet';
 
-    const defaultExport: never;
+    const defaultExport: unknown;
     export default defaultExport;
 }
 ```


### PR DESCRIPTION
Both in `create-stylable-app` templates and `runtime` readme file.

Related doc from `stylable.io` will be fixed in its repo.