### PR TITLE
fix(webpack-plugin): exclude stylable from issuers

### DIFF
--- a/packages/webpack-plugin/src/webpack-config-stylable-excludes.ts
+++ b/packages/webpack-plugin/src/webpack-config-stylable-excludes.ts
@@ -6,8 +6,11 @@ export function applyWebpackConfigStylableExcludes(webpackConfig: Configuration)
 
 function insertStCssExclude(stRegex: RegExp) {
     return (_: string, value: RuleSetRule) => {
-        if (typeof value !== 'string' && value && value.test) {
-            if (value.test.toString().includes('css')) {
+        if (typeof value !== 'string' && value && (value.test || value.issuer)) {
+            if (
+                value.test?.toString().includes('css') ||
+                value.issuer?.toString().includes('css')
+            ) {
                 if (value.exclude && Array.isArray(value.exclude)) {
                     value.exclude.push(stRegex);
                     return false;


### PR DESCRIPTION
Exclude handling of Stylable files targeted by loader issuer option. 
fix #1781