### PR TITLE
test: enable parallel testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,6 @@ jobs:
       - run: npm i -g yarn@1
       - run: yarn config set network-timeout 300000
       - run: yarn --frozen-lockfile
+      - run: yarn lint
+      - run: yarn build
       - run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,6 @@ jobs:
       - run: npm i -g yarn@1
       - run: yarn config set network-timeout 300000
       - run: yarn --frozen-lockfile
-      - run: yarn lint
       - run: yarn build
+      - run: yarn lint
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "yarn build -w",
     "lint": "eslint . -f codeframe",
     "pretest": "yarn build && yarn lint",
-    "test": "lerna run test --stream",
+    "test": "mocha \"./packages/*/dist/test/**/*.spec.js\" --parallel --timeout 10000",
     "prettify": "npx prettier . --write"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . -f codeframe",
     "pretest": "yarn build && yarn lint",
     "test": "mocha \"./packages/*/dist/test/**/*.spec.js\" --parallel --timeout 10000",
+    "test2": "mocha \"./packages/*/dist/test/**/*.spec.js\" --parallel --timeout 10000",
     "prettify": "npx prettier . --write"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "build": "tsc --build",
     "watch": "yarn build -w",
     "lint": "eslint . -f codeframe",
-    "pretest": "yarn build && yarn lint",
     "test": "mocha \"./packages/*/dist/test/**/*.spec.js\" --parallel --timeout 10000",
-    "test2": "mocha \"./packages/*/dist/test/**/*.spec.js\" --parallel --timeout 10000",
     "prettify": "npx prettier . --write"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --build",
     "watch": "yarn build -w",
     "lint": "eslint . -f codeframe",
+    "pretest": "yarn build",
     "test": "mocha \"./packages/*/dist/test/**/*.spec.js\" --parallel --timeout 10000",
     "prettify": "npx prettier . --write"
   },

--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -93,7 +93,7 @@ export class ProjectRunner {
         log = false,
     }: Options) {
         this.projectDir = projectDir;
-        this.outputDir = join(this.projectDir, 'dist');
+        this.outputDir = join(this.projectDir, webpackOptions?.output?.path || 'dist');
         this.webpackConfig = this.loadTestConfig(configName, webpackOptions);
         this.port = port;
         this.serverUrl = `http://localhost:${this.port}`;
@@ -338,14 +338,10 @@ export class ProjectRunner {
 
     private getWebpackConfig() {
         const webpackConfig = this.webpackConfig;
-        if (webpackConfig.output && webpackConfig.output.path) {
-            throw new Error('Test project should not specify output.path option');
-        } else {
-            webpackConfig.output = {
-                ...webpackConfig.output,
-                path: this.outputDir,
-            };
-        }
+        webpackConfig.output = {
+            ...webpackConfig.output,
+            path: this.outputDir,
+        };
         return webpackConfig;
     }
 }

--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -93,7 +93,7 @@ export class ProjectRunner {
         log = false,
     }: Options) {
         this.projectDir = projectDir;
-        this.outputDir = join(this.projectDir, webpackOptions?.output?.path || 'dist');
+        this.outputDir = webpackOptions?.output?.path ?? join(this.projectDir, 'dist');
         this.webpackConfig = this.loadTestConfig(configName, webpackOptions);
         this.port = port;
         this.serverUrl = `http://localhost:${this.port}`;

--- a/packages/experimental-loader/test/two-components-dynamic-order-prod.spec.ts
+++ b/packages/experimental-loader/test/two-components-dynamic-order-prod.spec.ts
@@ -16,7 +16,7 @@ describe(`(${project}) (production)`, () => {
             },
             webpackOptions: {
                 mode: 'production',
-                output: { path: join(projectDir, 'dist-prod', project) },
+                output: { path: join(projectDir, 'dist-prod') },
             },
         },
         before,

--- a/packages/experimental-loader/test/two-components-dynamic-order-prod.spec.ts
+++ b/packages/experimental-loader/test/two-components-dynamic-order-prod.spec.ts
@@ -7,7 +7,8 @@ const projectDir = dirname(
     require.resolve(`@stylable/experimental-loader/test/projects/${project}/webpack.config`)
 );
 
-describe(`(${project}) (production)`, () => {
+// -== PARALLEL TESTS ==-
+xdescribe(`(${project}) (production)`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,

--- a/packages/experimental-loader/test/two-components-dynamic-order-prod.spec.ts
+++ b/packages/experimental-loader/test/two-components-dynamic-order-prod.spec.ts
@@ -1,14 +1,13 @@
 import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { expect } from 'chai';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 
 const project = 'two-components-dynamic-order';
 const projectDir = dirname(
     require.resolve(`@stylable/experimental-loader/test/projects/${project}/webpack.config`)
 );
 
-// -== PARALLEL TESTS ==-
-xdescribe(`(${project}) (production)`, () => {
+describe(`(${project}) (production)`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,
@@ -17,6 +16,7 @@ xdescribe(`(${project}) (production)`, () => {
             },
             webpackOptions: {
                 mode: 'production',
+                output: { path: join(projectDir, 'dist-prod', project) },
             },
         },
         before,

--- a/packages/experimental-loader/test/two-components-dynamic-order.spec.ts
+++ b/packages/experimental-loader/test/two-components-dynamic-order.spec.ts
@@ -15,7 +15,7 @@ describe(`(${project})`, () => {
                 // headless: false,
             },
             webpackOptions: {
-                output: { path: join(projectDir, 'dist-', project) },
+                output: { path: join(projectDir, 'dist2') },
             },
         },
         before,

--- a/packages/experimental-loader/test/two-components-dynamic-order.spec.ts
+++ b/packages/experimental-loader/test/two-components-dynamic-order.spec.ts
@@ -7,7 +7,8 @@ const projectDir = dirname(
     require.resolve(`@stylable/experimental-loader/test/projects/${project}/webpack.config`)
 );
 
-describe(`(${project})`, () => {
+// -== PARALLEL TESTS ==-
+xdescribe(`(${project})`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,

--- a/packages/experimental-loader/test/two-components-dynamic-order.spec.ts
+++ b/packages/experimental-loader/test/two-components-dynamic-order.spec.ts
@@ -1,19 +1,21 @@
 import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { expect } from 'chai';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 
 const project = 'two-components-dynamic-order';
 const projectDir = dirname(
     require.resolve(`@stylable/experimental-loader/test/projects/${project}/webpack.config`)
 );
 
-// -== PARALLEL TESTS ==-
-xdescribe(`(${project})`, () => {
+describe(`(${project})`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,
             launchOptions: {
                 // headless: false,
+            },
+            webpackOptions: {
+                output: { path: join(projectDir, 'dist-', project) },
             },
         },
         before,

--- a/packages/webpack-extensions/test/e2e/manifest.spec.ts
+++ b/packages/webpack-extensions/test/e2e/manifest.spec.ts
@@ -17,6 +17,9 @@ describe(`${project} - manifest`, () => {
             launchOptions: {
                 // headless: false
             },
+            webpackOptions: {
+                output: { path: join(projectDir, 'dist-', project) },
+            },
         },
         before,
         afterEach,

--- a/packages/webpack-extensions/test/e2e/manifest.spec.ts
+++ b/packages/webpack-extensions/test/e2e/manifest.spec.ts
@@ -18,7 +18,7 @@ describe(`${project} - manifest`, () => {
                 // headless: false
             },
             webpackOptions: {
-                output: { path: join(projectDir, 'dist-', project) },
+                output: { path: join(projectDir, 'dist2') },
             },
         },
         before,

--- a/packages/webpack-plugin/test/e2e/simplest-project.spec.ts
+++ b/packages/webpack-plugin/test/e2e/simplest-project.spec.ts
@@ -7,7 +7,8 @@ const projectDir = dirname(
     require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
 );
 
-describe(`(${project})`, () => {
+// -== PARALLEL TESTS ==-
+xdescribe(`(${project})`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,

--- a/packages/webpack-plugin/test/e2e/simplest-project.spec.ts
+++ b/packages/webpack-plugin/test/e2e/simplest-project.spec.ts
@@ -1,19 +1,21 @@
 import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { expect } from 'chai';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 
 const project = 'simplest-project';
 const projectDir = dirname(
     require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
 );
 
-// -== PARALLEL TESTS ==-
-xdescribe(`(${project})`, () => {
+describe(`(${project})`, () => {
     const projectRunner = StylableProjectRunner.mochaSetup(
         {
             projectDir,
             launchOptions: {
                 // headless: false
+            },
+            webpackOptions: {
+                output: { path: join(projectDir, 'dist-', project) },
             },
         },
         before,

--- a/packages/webpack-plugin/test/e2e/simplest-project.spec.ts
+++ b/packages/webpack-plugin/test/e2e/simplest-project.spec.ts
@@ -15,7 +15,7 @@ describe(`(${project})`, () => {
                 // headless: false
             },
             webpackOptions: {
-                output: { path: join(projectDir, 'dist-', project) },
+                output: { path: join(projectDir, 'dist2') },
             },
         },
         before,


### PR DESCRIPTION
reduces test run itself (just `mocha`) from 65s to 18s locally.