### PR TITLE
feat(webpack-plugin): add utility to internalize projects from node target build in NextJS

### DIFF
--- a/packages/webpack-plugin/src/webpack-config-stylable-excludes.ts
+++ b/packages/webpack-plugin/src/webpack-config-stylable-excludes.ts
@@ -4,6 +4,48 @@ export function applyWebpackConfigStylableExcludes(webpackConfig: Configuration)
     safelyWalkJSON(webpackConfig.module ?? {}, insertStCssExclude(/\.st\.css$/));
 }
 
+export function applyExcludeNextJSExternslLibInNodeTarget(
+    config: Configuration,
+    packages: Iterable<string>
+) {
+    if (!isTargetNode(config)) {
+        return;
+    }
+    const nextExternals = getNextJSExternalHandler(config);
+    config.externals = [
+        async (ctx: { request?: string }) => {
+            for (const pkg of packages) {
+                if (ctx?.request?.startsWith(pkg)) {
+                    return false;
+                }
+            }
+            return nextExternals(ctx);
+        },
+    ];
+}
+
+function isTargetNode(config: Configuration) {
+    return (
+        (Array.isArray(config.target) && config.target.includes('node')) || config.target === 'node'
+    );
+}
+
+function getNextJSExternalHandler(config: Configuration) {
+    if (
+        !(
+            Array.isArray(config.externals) &&
+            config.externals.length === 1 &&
+            typeof config.externals[0] === 'function'
+        )
+    ) {
+        throw new Error(
+            'Invalid configuration: expected config.externals to be an Array with a single function. got ' +
+                JSON.stringify(config.externals)
+        );
+    }
+    return config.externals[0] as (data: ExternalItemFunctionData) => Promise<any>;
+}
+
 function insertStCssExclude(stRegex: RegExp) {
     return (_: string, value: RuleSetRule) => {
         if (typeof value !== 'string' && value && (value.test || value.issuer)) {
@@ -53,4 +95,11 @@ function safelyWalkJSON(
             safelyWalkJSON(obj[key], visitor, currentPath, visited);
         }
     }
+}
+
+/* extracted from webpack */
+declare interface ExternalItemFunctionData {
+    context?: string;
+    getResolve?: (options?: {}) => (context: string, request: string) => Promise<string>;
+    request?: string;
 }


### PR DESCRIPTION
Not sure if we want to adopt this code, it only works in specific case.
The idea behind the code is good. but I didn't find a way to make the exclude not specific. (help needed) 
If I had a way to tell webpack from the external callback to handle the request with the default behavior it would make more sense.