### PR TITLE
fix: remove non es5 code from runtime stylesheet

### DIFF
--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-var */
 import type { Host, StateMap, StateValue } from './types';
 
-export function stylesheet(host: Host = {}) {
+export function stylesheet(host?: Host) {
+    host = host || {};
     var stateMiddleDelimiter = '-';
     var booleanStateDelimiter = '--';
     var stateWithParamDelimiter = '---';


### PR DESCRIPTION
We might need to consider again to validate es5 compatibility of the runtime so we don't add these kind of mistakes.
  