### PR TITLE
fix(jest): compatibility with jest@27

### DIFF
--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,1 +1,3 @@
+import * as transformer from './jest';
+export default transformer;
 export * from './jest';

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -32,12 +32,12 @@ export function getCacheKey(
     fileData: string,
     filename: string,
     configString: string,
-    { instrument }: { instrument: boolean }
+    options?: { instrument: boolean }
 ) {
     return (
         fileData +
         configString +
-        (instrument ? 'instrument' : '') +
+        (options && options.instrument ? 'instrument' : '') +
         filename +
         stylableRuntimePath +
         runtimeVersion +


### PR DESCRIPTION
- new major imports transformer as default if `__esModule`.
- also, 4th parameter is not passed to `getCacheKey` anymore, so verify it exists before checking for `'instrument'`.