### PR TITLE
feat(cli): allow generateReExports to filter files from index generation

### DIFF
--- a/packages/cli/src/base-generator.ts
+++ b/packages/cli/src/base-generator.ts
@@ -20,7 +20,7 @@ export class Generator {
 
     constructor(public stylable: Stylable, private log: Log) {}
 
-    public generateReExports(filePath: string): ReExports {
+    public generateReExports(filePath: string): ReExports | undefined {
         return {
             root: this.filename2varname(filePath),
             classes: {},
@@ -32,9 +32,11 @@ export class Generator {
 
     public generateFileIndexEntry(filePath: string, fullOutDir: string) {
         const reExports = this.generateReExports(filePath);
-        this.checkForCollisions(reExports, filePath);
-        this.log('[Generator Index]', `Add file: ${filePath}`);
-        this.indexFileOutput.set(normalizeRelative(relative(fullOutDir, filePath)), reExports);
+        if (reExports) {
+            this.checkForCollisions(reExports, filePath);
+            this.log('[Generator Index]', `Add file: ${filePath}`);
+            this.indexFileOutput.set(normalizeRelative(relative(fullOutDir, filePath)), reExports);
+        }
     }
 
     public removeEntryFromIndex(filePath: string, fullOutDir: string) {

--- a/packages/cli/test/fixtures/test-generator.ts
+++ b/packages/cli/test/fixtures/test-generator.ts
@@ -2,7 +2,10 @@ import { Generator as Base, ReExports } from '@stylable/cli';
 
 export class Generator extends Base {
     private count = 0;
-    public generateReExports(): ReExports {
+    public generateReExports(filePath: string): ReExports | undefined {
+        if (filePath.includes('FILTER-ME')) {
+            return undefined;
+        }
         return {
             root: 'Style' + this.count++,
             classes: {},

--- a/packages/cli/test/generate-index.spec.ts
+++ b/packages/cli/test/generate-index.spec.ts
@@ -112,6 +112,37 @@ describe('build index', () => {
         );
     });
 
+    it('custom generator is able to filter files from the index', async () => {
+        const fs = createMemoryFs({
+            '/comp-A.st.css': `
+               .a{}
+            `,
+            '/b/FILTER-ME.st.css': `
+               .b{}
+            `,
+        });
+
+        const stylable = new Stylable('/', fs, () => ({}));
+
+        await build({
+            extension: '.st.css',
+            fs,
+            stylable,
+            outDir: '.',
+            srcDir: '.',
+            indexFile: 'index.st.css',
+            rootDir: '/',
+            log,
+            generatorPath: require.resolve('./fixtures/test-generator'),
+        });
+
+        const res = fs.readFileSync('/index.st.css').toString();
+
+        expect(res.trim()).to.equal(
+            ':import {-st-from: "./comp-A.st.css";-st-default:Style0;}\n.root Style0{}'
+        );
+    });
+
     it('should create index file using a custom generator with named exports generation and @namespace', async () => {
         const fs = createMemoryFs({
             '/comp-A.st.css': `


### PR DESCRIPTION
This prevent overriding `generateFileIndexEntry` which leads to smaller footprint when writing custom generator. 