### PR TITLE
infra(ci): enable cache in setup-node

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org/'
+          cache: 'yarn'
       - run: npm i -g yarn@1
       - run: yarn config set network-timeout 300000
       - run: yarn --frozen-lockfile

--- a/.github/workflows/release3.yml
+++ b/.github/workflows/release3.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org/'
+          cache: 'yarn'
       - run: npm i -g yarn@1
       - run: yarn config set network-timeout 300000
       - run: yarn --frozen-lockfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - run: npm i -g yarn@1
       - run: yarn config set network-timeout 300000
       - run: yarn --frozen-lockfile


### PR DESCRIPTION
it uses the cache action under the hood, but actually caches npm/yarn's cache directory per platform.
hoping that this done right will cause ci to install faster.