### PR TITLE
fix(core): emit validation diagnostics on @st-imports

### DIFF
--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -350,7 +350,7 @@ export class StylableResolver {
                         (decl) => decl.type === 'decl' && decl.prop === valueMapping.from
                     );
 
-                diagnostics.error(
+                diagnostics.warn(
                     fromDecl || importObj.rule,
                     resolverWarnings.UNKNOWN_IMPORTED_FILE(importObj.request),
                     { word: importObj.request }

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -350,27 +350,26 @@ export class StylableResolver {
                         (decl) => decl.type === 'decl' && decl.prop === valueMapping.from
                     );
 
-                if (fromDecl) {
-                    diagnostics.warn(
-                        fromDecl,
-                        resolverWarnings.UNKNOWN_IMPORTED_FILE(importObj.request),
-                        { word: importObj.request }
-                    );
-                }
+                diagnostics.error(
+                    fromDecl || importObj.rule,
+                    resolverWarnings.UNKNOWN_IMPORTED_FILE(importObj.request),
+                    { word: importObj.request }
+                );
             } else if (resolvedImport._kind === 'css') {
                 // warn about unknown named imported symbols
                 for (const name in importObj.named) {
                     const origName = importObj.named[name];
                     const resolvedSymbol = this.resolveImported(importObj, origName);
-                    const namedDecl =
-                        importObj.rule.nodes &&
-                        importObj.rule.nodes.find(
-                            (decl) => decl.type === 'decl' && decl.prop === valueMapping.named
-                        );
 
-                    if (!resolvedSymbol!.symbol && namedDecl) {
+                    if (resolvedSymbol === null || !resolvedSymbol.symbol) {
+                        const namedDecl =
+                            importObj.rule.nodes &&
+                            importObj.rule.nodes.find(
+                                (decl) => decl.type === 'decl' && decl.prop === valueMapping.named
+                            );
+
                         diagnostics.warn(
-                            namedDecl,
+                            namedDecl || importObj.rule,
                             resolverWarnings.UNKNOWN_IMPORTED_SYMBOL(origName, importObj.request),
                             { word: origName }
                         );

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -1345,5 +1345,113 @@ describe('diagnostics: warnings and errors', () => {
                 );
             });
         });
+
+        describe('@st-import', () => {
+            it('should error on unresolved file', () => {
+                const config = {
+                    entry: '/main.st.css',
+                    files: {
+                        '/main.st.css': {
+                            namespace: 'entry',
+                            content: `
+                                |@st-import "$./missing.st.css$";|
+                            `,
+                        },
+                    },
+                };
+                expectWarningsFromTransform(config, [
+                    {
+                        message: resolverWarnings.UNKNOWN_IMPORTED_FILE('./missing.st.css'),
+                        file: '/main.st.css',
+                    }
+                ]);
+            });
+
+            it('should error on unresolved file from third party', () => {
+                const config = {
+                    entry: '/main.st.css',
+                    files: {
+                        '/main.st.css': {
+                            namespace: 'entry',
+                            content: `
+                                |@st-import "$missing-package/index.st.css$";|
+                            `,
+                        },
+                    },
+                };
+                expectWarningsFromTransform(
+                    config,
+
+                    [
+                        {
+                            message: resolverWarnings.UNKNOWN_IMPORTED_FILE(
+                                'missing-package/index.st.css'
+                            ),
+                            file: '/main.st.css',
+                        },
+                    ]
+                );
+            });
+
+            it('should error on unresolved named symbol', () => {
+                const config = {
+                    entry: '/main.st.css',
+                    files: {
+                        '/main.st.css': {
+                            namespace: 'entry',
+                            content: `
+                                |@st-import [$Missing$] from "./imported.st.css";|
+                            `,
+                        },
+                        '/imported.st.css': {
+                            content: `.root{}`,
+                        },
+                    },
+                };
+                expectWarningsFromTransform(
+                    config,
+
+                    [
+                        {
+                            message: resolverWarnings.UNKNOWN_IMPORTED_SYMBOL(
+                                'Missing',
+                                './imported.st.css'
+                            ),
+                            file: '/main.st.css',
+                        },
+                    ]
+                );
+            });
+
+            it('should error on unresolved named symbol with alias', () => {
+                const config = {
+                    entry: '/main.st.css',
+                    files: {
+                        '/main.st.css': {
+                            namespace: 'entry',
+                            content: `
+                                |@st-import [$Missing$ as LocalMissing] from "./imported.st.css"|;
+                            `,
+                        },
+                        '/imported.st.css': {
+                            content: `.root{}`,
+                        },
+                    },
+                };
+                expectWarningsFromTransform(
+                    config,
+
+                    [
+                        {
+                            message: resolverWarnings.UNKNOWN_IMPORTED_SYMBOL(
+                                'Missing',
+                                './imported.st.css'
+                            ),
+                            file: '/main.st.css',
+                        },
+                    ]
+                );
+            });
+        });
     });
 });

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -9,6 +9,7 @@ import {
     cachedProcessFile,
     MinimalFS,
     StylableMeta,
+    createDefaultResolver,
 } from '@stylable/core';
 
 function createResolveExtendsResults(
@@ -17,12 +18,13 @@ function createResolveExtendsResults(
     classNameToLookup: string,
     isElement = false
 ) {
+    const moduleResolver = createDefaultResolver(fs, {});
     const processFile = cachedProcessFile<StylableMeta>(
         (fullpath, content) => {
             return process(cssParse(content, { from: fullpath }));
         },
         fs,
-        (x) => x
+        (request, context = '/') => moduleResolver(context, request)
     );
 
     const resolver = new StylableResolver(processFile, (module: string) => module && '');


### PR DESCRIPTION
This PR fixes `@st-import` resolution validation errors. 
We did not emitted warnings on them because we couldn't find the "correct declaration".  
