### PR TITLE
refactor(core-test-kit): reduce semi-duplicate APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ cjs
 .vcode/settings.json
 **/test/**/temp-dist
 
+# alternative test project dists
+**/test/**/dist2
+**/test/**/dist-prod
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/packages/core-test-kit/README.md
+++ b/packages/core-test-kit/README.md
@@ -15,61 +15,80 @@ An assortment of `Chai` matchers used by Stylable.
 
 ### Diagnostics tooling
 
-A collection of tools aimed at testing Stylable diagnostics messages (warnings and errors).
+A collection of tools used for testing Stylable diagnostics messages (warnings and errors).
+
+- `expectWarnings` - processes a Stylable input and checks for diagnostics during processing
+- `expectWarningsFromTransform` - checks for diagnostics after a full transformation
+- `shouldReportNoDiagnostics` - helper to check no diagnostics were reported
 
 ### Testing infrastructure
 
-Used for easily setting up Stylable instances (processor/transformer) and its infrastructure.
+Used for setting up Stylable instances (`processor`/`transformer`) and their infrastructure:
 
-`generateInfra` - create Stylable basic in memory infrastructure (resolver, requireModule, fileProcessor)
+- `generateInfra` - create Stylable basic in memory infrastructure (`resolver`, `requireModule`, `fileProcessor`)
+- `generateStylableResult` - genetare transformation results from in memory configuration
+- `generateStylableRoot` - helper over `generateStylableResult` that returns the `outputAst`
+- `generateStylableExports` - helper over `generateStylableResult` that returns the `exports` mapping
 
-`generateStylableResult` - genetare transform result from in memory configuration
+### `testInlineExpects` utility
 
-`generateStylableRoot` - helper over `generateStylableResult` that returns the outputAst
+Exposes `testInlineExpects` for testing transformed stylesheets that include inline expectation comments. These are the most common type of core tests and the recommended way of testing the core functionality.
 
-`generateStylableExports` - helper over `generateStylableResult` that returns the exports mapping
+#### Supported checks:
 
-### testInlineExpects
-
-Exposes `testInlineExpects` for Test transformed stylesheets with inline expectation comments. These are the most common core tests and the recommended way to test the core transform functionality. 
-
-#### `Supported checks:` 
-
-Rule checking (place just before rule) support multi line declarations and multiple @checks
+Rule checking (place just before rule) supporting multi-line declarations and multiple `@checks` statements
 
 ##### Terminilogy
-LABEL <string> - label for the test expectation 
-OFFEST <number> - offest for the tested rule after the @check   
-SELECTOR <string> - the output selector
-DECL <string> - name of the declaration
-VALUE <string> - value of the declaration 
+- `LABEL: <string>` - label for the test expectation 
+- `OFFEST: <number>` - offest for the tested rule after the `@check`   
+- `SELECTOR: <string>` - output selector
+- `DECL: <string>` - declaration name
+- `VALUE: <string>` - declaration value 
 
-full options:
+Full options:
 ```css
 /* @check(LABEL)[OFFEST] SELECTOR {DECL: VALUE} */
 ```
 
-basic:
+Basic - `@check SELECTOR`
 ```css 
-/* @check SELECTOR */
+/* @check header::before */
+header::before {}
 ```
 
-with declarations (will check full match and order):
+With declarations - ` @check SELECTOR {DECL1: VALUE1; DECL2: VALUE2;}`
+
+This will check full match and order.
+```css 
+.my-mixin {
+    color: red;
+}
+
+/* @check .entry__container {color: red;} */
+.container {
+    -st-mixin: my-mixin;
+}
+```
+
+Target generated rules (mixin) - ` @check[OFFEST] SELECTOR`
 ```css
-/* @check SELECTOR {DECL1: VALUE1; DECL2: VALUE2} */
+/* 
+    @check[1] .entry__container:hover {color: blue;} 
+*/
+.container {
+    -st-mixin: my-mixin;
+}
 ```
 
-target generated rules (mixin):
-```css
-/* @check[OFFEST] SELECTOR */
-```
-
-support atrule params (anything between the @atrule and body or semicolon):
+Support atrule params (anything between the @atrule and body or semicolon):
 ```css
 /* @check screen and (min-width: 900px) */
+@media value(smallScreen) {}
 ```
 #### Example 
-Using the `/* @check SELECTOR */` comment to test the root class selector target 
+Here we are generating a Stylable AST which lncludes the `/* @check SELECTOR */` comment to test the root class selector target.
+
+The `testInlineExpects` function performs that actual assertions to perform the test.
 
 ```ts
 it('...', ()=>{

--- a/packages/core-test-kit/README.md
+++ b/packages/core-test-kit/README.md
@@ -21,32 +21,71 @@ A collection of tools aimed at testing Stylable diagnostics messages (warnings a
 
 Used for easily setting up Stylable instances (processor/transformer) and its infrastructure.
 
-Exposes `expectTransformOutput` utility for creating transformation tests. These are the most common core tests and the recommended way to test the core transform functionality.
+`generateInfra` - create Stylable basic in memory infrastructure (resolver, requireModule, fileProcessor)
 
-Currently only supports testing target selector but when needed the functionality can be expended here to support: 
+`generateStylableResult` - genetare transform result from in memory configuration
 
-* JavaScript exports output
-* Declaration values
-* Mixins output  
+`generateStylableRoot` - helper over `generateStylableResult` that returns the outputAst
 
+`generateStylableExports` - helper over `generateStylableResult` that returns the exports mapping
+
+### testInlineExpects
+
+Exposes `testInlineExpects` for Test transformed stylesheets with inline expectation comments. These are the most common core tests and the recommended way to test the core transform functionality. 
+
+#### `Supported checks:` 
+
+Rule checking (place just before rule) support multi line declarations and multiple @checks
+
+##### Terminilogy
+LABEL <string> - label for the test expectation 
+OFFEST <number> - offest for the tested rule after the @check   
+SELECTOR <string> - the output selector
+DECL <string> - name of the declaration
+VALUE <string> - value of the declaration 
+
+full options:
+```css
+/* @check(LABEL)[OFFEST] SELECTOR {DECL: VALUE} */
+```
+
+basic:
+```css 
+/* @check SELECTOR */
+```
+
+with declarations (will check full match and order):
+```css
+/* @check SELECTOR {DECL1: VALUE1; DECL2: VALUE2} */
+```
+
+target generated rules (mixin):
+```css
+/* @check[OFFEST] SELECTOR */
+```
+
+support atrule params (anything between the @atrule and body or semicolon):
+```css
+/* @check screen and (min-width: 900px) */
+```
 #### Example 
-Using the `/* @expect selector */` comment to test the root class selector target 
+Using the `/* @check SELECTOR */` comment to test the root class selector target 
 
-```js
-expectTransformOutput(
-    {
+```ts
+it('...', ()=>{
+    const root = generateStylableRoot({
         entry: `/style.st.css`,
         files: {
             '/style.st.css': {
                 namespace: 'ns',
                 content: `
-                /* @expect .ns__root */
+                /* @check .ns__root */
                 .root {}
             `
         },
-    },
-    1
-);
+    });
+    testInlineExpects(root, 1);
+})
 ```
 
 ### Match rules

--- a/packages/core-test-kit/src/diagnostics.ts
+++ b/packages/core-test-kit/src/diagnostics.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import deindent from 'deindent';
 import type { Position } from 'postcss';
 import { Diagnostics, process, safeParse, StylableMeta, StylableResults } from '@stylable/core';
-import { Config, generateFromMock } from './generate-test-util';
+import { Config, generateStylableResult } from './generate-test-util';
 
 export interface Diagnostic {
     severity?: 'warning' | 'error';
@@ -93,7 +93,7 @@ export function expectWarningsFromTransform(
         locations[path] = source;
     }
     const diagnostics = new Diagnostics();
-    const result = generateFromMock(config, diagnostics);
+    const result = generateStylableResult(config, diagnostics);
     const warningMessages = diagnostics.reports.map((d) => d.message);
 
     if (expectedWarnings.length === 0 && diagnostics.reports.length !== 0) {

--- a/packages/core-test-kit/src/match-rules.ts
+++ b/packages/core-test-kit/src/match-rules.ts
@@ -1,4 +1,3 @@
-import type { StylableResults } from '@stylable/core';
 import type * as postcss from 'postcss';
 
 export function matchRuleAndDeclaration(
@@ -34,33 +33,4 @@ export function matchAllRulesAndDeclarations(
     offset = 0
 ) {
     all.forEach((_, i) => matchRuleAndDeclaration(parent, i + offset, _[0], _[1], msg));
-}
-
-export function matchFromSource(results: StylableResults, numOfAssertions = 0) {
-    let foundAssertions = 0;
-    const errors: string[] = [];
-    const root = results.meta.outputAst;
-    if (!root) {
-        throw new Error('expectCSS missing root ast');
-    }
-    root.walkRules((rule) => {
-        const prev = rule.prev();
-
-        if (prev?.type === 'comment') {
-            const match = prev.text.trim().match(/@expect (.*)/);
-            if (match) {
-                foundAssertions++;
-                const selector = match[1];
-                if (selector !== rule.selector) {
-                    errors.push(`\nactual: ${rule.selector}\nexpect: ${selector}`);
-                }
-            }
-        }
-    });
-    if (foundAssertions !== numOfAssertions) {
-        errors.push(`expected ${numOfAssertions} @expect assertions found ${foundAssertions}`);
-    }
-    if (errors.length) {
-        throw new Error(errors.join('\n'));
-    }
 }

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
-import { createStylableInstance, generateInfra } from '@stylable/core-test-kit';
+import { generateInfra, generateStylableResult } from '@stylable/core-test-kit';
 import {
     createMinimalFS,
     process,
@@ -453,20 +453,9 @@ describe('stylable-resolver', () => {
     });
 
     it('should resolve 4th party according to context', () => {
-        const stylable = createStylableInstance({
+        const { meta } = generateStylableResult({
+            entry: '/node_modules/a/index.st.css',
             files: {
-                '/entry.st.css': {
-                    namespace: 'entry',
-                    content: `
-                        :import {
-                            -st-from: "a/index.st.css";
-                            -st-default: A;
-                        }
-                        .root {
-                            -st-extends: A;
-                        }
-                    `,
-                },
                 '/node_modules/a/index.st.css': {
                     namespace: 'A',
                     content: `
@@ -485,8 +474,6 @@ describe('stylable-resolver', () => {
                 },
             },
         });
-
-        const { meta } = stylable.transform(stylable.process('/node_modules/a/index.st.css'));
 
         const rule = meta.outputAst!.nodes[0] as postcss.Rule;
         expect(rule.selector).to.equal('.A__root');

--- a/packages/core/test/stylable-transformer/elements.spec.ts
+++ b/packages/core/test/stylable-transformer/elements.spec.ts
@@ -1,137 +1,130 @@
-import { expectTransformOutput } from '@stylable/core-test-kit';
+import { generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
 
 describe('Stylable transform elements', () => {
     describe('scoped elements', () => {
         it('component/tag selector with first Capital letter automatically extends reference with identical name', () => {
-            expectTransformOutput(
-                {
-                    entry: `/style.st.css`,
-                    files: {
-                        '/style.st.css': {
-                            namespace: 'ns',
-                            content: `
+            const root = generateStylableRoot({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'ns',
+                        content: `
                             :import {
                                 -st-from: "./imported.st.css";
                                 -st-default: Element;
                             }
-                            /* @expect .ns1__root */
+                            /* @check .ns1__root */
                             Element {}
-                            /* @expect .ns__root .ns1__root */
+                            /* @check .ns__root .ns1__root */
                             .root Element {}
                         `,
-                        },
-                        '/imported.st.css': {
-                            namespace: 'ns1',
-                            content: ``,
-                        },
+                    },
+                    '/imported.st.css': {
+                        namespace: 'ns1',
+                        content: ``,
                     },
                 },
-                2
-            );
+            });
+
+            testInlineExpects(root);
         });
 
         it('component/tag selector with first Capital letter automatically extend reference with identical name (inner parts)', () => {
-            expectTransformOutput(
-                {
-                    entry: `/entry.st.css`,
-                    files: {
-                        '/entry.st.css': {
-                            namespace: 'entry',
-                            content: `
+            const root = generateStylableRoot({
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
                             :import {
                                 -st-from: "./inner.st.css";
                                 -st-default: Element;
                             }
-                            /* @expect .inner__root .inner__part */
+                            /* @check .inner__root .inner__part */
                             Element::part {}
                         `,
-                        },
-                        '/inner.st.css': {
-                            namespace: 'inner',
-                            content: `
+                    },
+                    '/inner.st.css': {
+                        namespace: 'inner',
+                        content: `
                             .part {}
                         `,
-                        },
                     },
                 },
-                1
-            );
+            });
+            testInlineExpects(root);
         });
 
         it('resolve imported element that is also root', () => {
-            expectTransformOutput(
-                {
-                    entry: `/style.st.css`,
-                    files: {
-                        '/style.st.css': {
-                            namespace: 'ns',
-                            content: `
+            const root = generateStylableRoot({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'ns',
+                        content: `
                             :import {
                                 -st-from: "./imported.st.css";
                                 -st-named: ButtonX;
                             }
-                            /* @expect .ns__x */
+                            /* @check .ns__x */
                             .x {
                                 -st-extends: ButtonX;
                             }
                         `,
-                        },
-                        '/imported.st.css': {
-                            namespace: 'ns1',
-                            content: `
+                    },
+                    '/imported.st.css': {
+                        namespace: 'ns1',
+                        content: `
                             :import {
                                 -st-from: "./button-x.st.css";
                                 -st-default: ButtonX;
                             }
                             ButtonX{}
                         `,
-                        },
-                        '/button-x.st.css': {
-                            namespace: 'button-x',
-                            content: ``,
-                        },
+                    },
+                    '/button-x.st.css': {
+                        namespace: 'button-x',
+                        content: ``,
                     },
                 },
-                1
-            );
+            });
+            testInlineExpects(root);
         });
 
         it('should resolve imported named element type when used as element', () => {
-            expectTransformOutput(
-                {
-                    entry: `/entry.st.css`,
-                    files: {
-                        '/entry.st.css': {
-                            namespace: 'entry',
-                            content: `
+            const root = generateStylableRoot({
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
                             :import {
                                 -st-from: "./inner.st.css";
                                 -st-named: Element;
                             }
-                            /* @expect .base__root */
+                            /* @check .base__root */
                             Element {}
                         `,
-                        },
-                        '/inner.st.css': {
-                            namespace: 'inner',
-                            content: `
+                    },
+                    '/inner.st.css': {
+                        namespace: 'inner',
+                        content: `
                             :import {
                                 -st-from: "./base.st.css";
                                 -st-default: Element;
                             }
                             Element {}
                         `,
-                        },
-                        '/base.st.css': {
-                            namespace: 'base',
-                            content: `
+                    },
+                    '/base.st.css': {
+                        namespace: 'base',
+                        content: `
                             .root {}
                         `,
-                        },
                     },
                 },
-                1
-            );
+            });
+            testInlineExpects(root);
         });
     });
 });

--- a/packages/optimizer/test/stylable-optimizer.spec.ts
+++ b/packages/optimizer/test/stylable-optimizer.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as postcss from 'postcss';
 import deindent from 'deindent';
-import { createStylableInstance } from '@stylable/core-test-kit';
+import { generateStylableResult } from '@stylable/core-test-kit';
 import { removeCommentNodes, StylableOptimizer } from '@stylable/optimizer';
 
 describe('StylableOptimizer', () => {
@@ -55,7 +55,7 @@ describe('StylableOptimizer', () => {
     });
 
     it('removeUnusedComponents', () => {
-        const index = 'index.st.css';
+        const index = '/index.st.css';
         const files = {
             [index]: {
                 content: `
@@ -64,8 +64,7 @@ describe('StylableOptimizer', () => {
             },
         };
 
-        const stylable = createStylableInstance({ files });
-        const result = stylable.transform(files[index].content, index);
+        const result = generateStylableResult({ entry: index, files });
         const usageMapping = {
             [result.meta.namespace]: false,
         };
@@ -74,14 +73,14 @@ describe('StylableOptimizer', () => {
             { removeUnusedComponents: true },
             result,
             usageMapping,
-            stylable.delimiter
+            '__'
         );
 
         expect(result.meta.outputAst!.toString().trim()).to.equal('');
     });
 
     it('minifyCSS', () => {
-        const index = 'index.st.css';
+        const index = '/index.st.css';
         const files = {
             [index]: {
                 content: `
@@ -93,9 +92,7 @@ describe('StylableOptimizer', () => {
                 `,
             },
         };
-
-        const stylable = createStylableInstance({ files });
-        const { meta } = stylable.transform(files[index].content, index);
+        const { meta } = generateStylableResult({ entry: index, files });
         const output = new StylableOptimizer().minifyCSS(meta.outputAst!.toString());
         expect(output).to.equal(`.${meta.namespace}__x{color:red}`);
     }).timeout(25000);


### PR DESCRIPTION
We had too many ways to test. This PR reduce few of them.

I don't know any other package that is using `@stylable/core-test-kit` so I assume we can snick a patch here. (needs double check)