### PR TITLE
fix(language-service): limit api break to type fix

### DIFF
--- a/packages/language-service/src/lib/feature/formatting.ts
+++ b/packages/language-service/src/lib/feature/formatting.ts
@@ -1,7 +1,7 @@
 import { getDocumentFormatting } from '@stylable/code-formatter';
 import type { CSSBeautifyOptions } from 'js-beautify';
 import type { FormattingOptions, TextEdit } from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function lspFormattingOptionsToJsBeautifyOptions(
     options: FormattingOptions
@@ -15,18 +15,14 @@ export function lspFormattingOptionsToJsBeautifyOptions(
 }
 
 export function format(
-    srcText: string,
+    doc: TextDocument,
     offset: { start: number; end: number },
-    options: FormattingOptions
+    options: CSSBeautifyOptions
 ): TextEdit[] {
-    const doc = TextDocument.create('', 'stylable', 1, srcText);
+    const srcText = doc.getText();
     const range = { start: doc.positionAt(offset.start), end: doc.positionAt(offset.end) };
 
-    const newText = getDocumentFormatting(
-        srcText,
-        offset,
-        lspFormattingOptionsToJsBeautifyOptions(options)
-    );
+    const newText = getDocumentFormatting(srcText, offset, options);
 
     return srcText === newText
         ? []

--- a/packages/language-service/test/test-kit/asserters.ts
+++ b/packages/language-service/test/test-kit/asserters.ts
@@ -13,7 +13,7 @@ import {
 import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
 import { Range, TextDocumentIdentifier } from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
-import { format } from '@stylable/language-service';
+import { format, lspFormattingOptionsToJsBeautifyOptions } from '@stylable/language-service';
 import { ProviderPosition } from '@stylable/language-service/dist/lib/completion-providers';
 import { createMeta, ProviderLocation } from '@stylable/language-service/dist/lib/provider';
 import { pathFromPosition } from '@stylable/language-service/dist/lib/utils/postcss-ast-utils';
@@ -81,7 +81,11 @@ export function getFormattingEdits(
         tabSize: 4,
     }
 ): TextEdit[] {
-    return format(content, offsetRange || { start: 0, end: content.length }, options);
+    return format(
+        TextDocument.create('test.st.css', 'stylable', 1, content),
+        offsetRange || { start: 0, end: content.length },
+        lspFormattingOptionsToJsBeautifyOptions(options)
+    );
 }
 
 export function getDocColorPresentation(


### PR DESCRIPTION
API change due to the code formatter extraction was a bit harsh, restoring `getDocumentFormatting` on the main LSP service.