### PR TITLE
feat(runtime): add root property to classes map type

### DIFF
--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,8 +1,8 @@
 export type StateValue = boolean | number | string | undefined;
 
 export interface ClassesMap {
-    root: string,
-    [className: string]: string
+    root: string;
+    [className: string]: string;
 }
 
 export interface StateMap {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,5 +1,10 @@
 export type StateValue = boolean | number | string | undefined;
 
+export interface ClassesMap {
+    root: string,
+    [className: string]: string
+}
+
 export interface StateMap {
     [stateName: string]: StateValue;
 }
@@ -15,7 +20,7 @@ export interface InheritedAttributes {
 }
 
 export interface StylableExports {
-    classes: Record<string, string>;
+    classes: ClassesMap;
     keyframes: Record<string, string>;
     vars: Record<string, string>;
     stVars: Record<string, string>;


### PR DESCRIPTION
Since the `root` class is always there, this PR should give the typescript user a nicer experience if he does not use st declaration files