### PR TITLE
fix(language-service): improve definition support for both :import and @st-import

### DIFF
--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -204,7 +204,7 @@ export class Provider {
                         /**/
                     }
 
-                    let filePath;
+                    let filePath: string | undefined;
 
                     if (resolved && resolved._kind !== 'js') {
                         filePath = resolved.meta.source;

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -155,10 +155,25 @@ export class Provider {
         const defs: ProviderLocation[] = [];
         let temp: ClassSymbol | null = null;
         let stateMeta: StylableMeta;
+        let maybeRequestPath;
 
-        if (Object.keys(meta.mappedSymbols).find((sym) => sym === word.replace('.', ''))) {
-            const symb = meta.mappedSymbols[word.replace('.', '')];
-            switch (symb._kind) {
+        try {
+            maybeRequestPath = this.stylable.resolver.resolvePath(word, fs.dirname(meta.source));
+        } catch {
+            // todo: figure out proper logging
+        }
+        if (maybeRequestPath) {
+            if (fs.statSync(maybeRequestPath)) {
+                defs.push(
+                    new ProviderLocation(maybeRequestPath, {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 0 },
+                    })
+                );
+            }
+        } else if (Object.keys(meta.mappedSymbols).find((sym) => sym === word.replace('.', ''))) {
+            const symbol = meta.mappedSymbols[word.replace('.', '')];
+            switch (symbol._kind) {
                 case 'class': {
                     defs.push(
                         new ProviderLocation(
@@ -182,26 +197,33 @@ export class Provider {
                     break;
                 }
                 case 'import': {
-                    let rslvd: CSSResolve | JSResolve | null = null;
+                    let resolved: CSSResolve | JSResolve | null = null;
                     try {
-                        rslvd = this.stylable.resolver.resolve(symb);
+                        resolved = this.stylable.resolver.resolve(symbol);
                     } catch {
                         /**/
                     }
 
-                    let filePath: string;
+                    let filePath;
 
-                    if (rslvd && rslvd._kind !== 'js') {
-                        filePath = rslvd.meta.source;
+                    if (resolved && resolved._kind !== 'js') {
+                        filePath = resolved.meta.source;
                     } else {
-                        filePath = this.stylable.resolvePath(undefined, symb.import.from);
+                        try {
+                            filePath = this.stylable.resolvePath(undefined, symbol.import.from);
+                        } catch {
+                            // todo: figure out proper logging
+                        }
                     }
-                    const doc = fs.readFileSync(filePath, 'utf8');
 
-                    if (doc !== '') {
-                        defs.push(
-                            new ProviderLocation(filePath, this.findWord(word, doc, position))
-                        );
+                    if (filePath) {
+                        const doc = fs.readFileSync(filePath, 'utf8');
+
+                        if (doc !== '') {
+                            defs.push(
+                                new ProviderLocation(filePath, this.findWord(word, doc, position))
+                            );
+                        }
                     }
                     break;
                 }
@@ -1738,7 +1760,15 @@ export function getDefSymbol(
         }
     }
 
-    const word: string = val.value;
+    let word: string = val.value;
+
+    // sanitize @st-import named imports
+    if (word.startsWith('[')) {
+        word = word.slice(1, word.length);
+    }
+    if (word.endsWith(']')) {
+        word = word.slice(0, word.length - 1);
+    }
 
     const { lineChunkAtCursor } = getChunkAtCursor(
         res.currentLine.slice(0, val.sourceIndex + val.value.length),
@@ -1762,8 +1792,11 @@ export function getDefSymbol(
     if (match && localSymbol) {
         // We're in an -st directive
         let imp;
-        if (localSymbol._kind === 'import') {
+        if (localSymbol._kind === 'import' && localSymbol.type !== 'default') {
             imp = stylable.resolver.resolveImport(localSymbol);
+        } else if (localSymbol._kind === 'import' && localSymbol.type === 'default') {
+            imp = stylable.resolver.resolveImport(localSymbol);
+            return { word: imp?.meta?.root || '', meta: imp?.meta || null };
         } else if (localSymbol._kind === 'element' && localSymbol.alias) {
             imp = stylable.resolver.resolveImport(localSymbol.alias);
         } else if (localSymbol._kind === 'class') {
@@ -1822,7 +1855,7 @@ export function getDefSymbol(
         reso = resolvedElements[0][resolvedElements[0].length - 1].resolved.find(
             (res) => !!(res.symbol as ClassSymbol)['-st-root']
         );
-    } else {
+    } else if (resolvedElements.length && resolvedElements[0].length) {
         reso = resolvedElements[0][resolvedElements[0].length - 1].resolved.find((res) => {
             let symbolStates;
             if (res.symbol._kind === 'class') {

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-default.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-default.st.css
@@ -1,0 +1,4 @@
+:import {
+    -st-from: "./import.st.css";
+    -st-default: Co|mp;
+}

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-path.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-path.st.css
@@ -1,0 +1,4 @@
+:import {
+    -st-from: "./impo|rt.st.css";
+    -st-default: Comp;
+}

--- a/packages/language-service/test/fixtures/server-cases/definitions/st-imported-default.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/st-imported-default.st.css
@@ -1,0 +1,1 @@
+@st-import Co|mp from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/definitions/st-imported-named-end.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/st-imported-named-end.st.css
@@ -1,0 +1,1 @@
+@st-import [momo, shl|omo] from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/definitions/st-imported-named-start.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/st-imported-named-start.st.css
@@ -1,0 +1,1 @@
+@st-import [mo|mo, shlomo] from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/definitions/st-imported-path.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/st-imported-path.st.css
@@ -1,0 +1,1 @@
+@st-import "./impo|rt.st.css";

--- a/packages/language-service/test/lib/definitions.spec.ts
+++ b/packages/language-service/test/lib/definitions.spec.ts
@@ -46,8 +46,56 @@ describe('Definitions', () => {
         });
     });
 
-    describe('Imported elements', () => {
-        describe('Classes', () => {
+    describe('Imported', () => {
+        describe('Classes and Elements', () => {
+            it('should return definition of the path in an @st-import', () => {
+                const defs = asserters.getDefinition('definitions/st-imported-path.st.css');
+                expect(defs.length).to.equal(1);
+                const def = defs[0];
+                expect(def.uri).to.equal(getCasePath('definitions/import.st.css'));
+                expect(def.range).to.eql(createRange(0, 0, 0, 0));
+            });
+
+            it('should return definition of the default part in an @st-import', () => {
+                const defs = asserters.getDefinition('definitions/st-imported-default.st.css');
+                expect(defs.length).to.equal(1);
+                const def = defs[0];
+                expect(def.uri).to.equal(getCasePath('definitions/import.st.css'));
+                expect(def.range).to.eql(createRange(0, 0, 0, 0));
+            });
+
+            it('should return definition of the named in an @st-import (start)', () => {
+                const defs = asserters.getDefinition('definitions/st-imported-named-start.st.css');
+                expect(defs.length).to.equal(1);
+                const def = defs[0];
+                expect(def.uri).to.equal(getCasePath('definitions/import.st.css'));
+                expect(def.range).to.eql(createRange(4, 1, 4, 5));
+            });
+
+            it('should return definition of the named in an @st-import (end)', () => {
+                const defs = asserters.getDefinition('definitions/st-imported-named-end.st.css');
+                expect(defs.length).to.equal(1);
+                const def = defs[0];
+                expect(def.uri).to.equal(getCasePath('definitions/import.st.css'));
+                expect(def.range).to.eql(createRange(0, 1, 0, 7));
+            });
+
+            it('should return definition of the path in an -st-import', () => {
+                const defs = asserters.getDefinition('definitions/imported-path.st.css');
+                expect(defs.length).to.equal(1);
+                const def = defs[0];
+                expect(def.uri).to.equal(getCasePath('definitions/import.st.css'));
+                expect(def.range).to.eql(createRange(0, 0, 0, 0));
+            });
+
+            it('should return definition of the default part in an -st-import', () => {
+                const defs = asserters.getDefinition('definitions/imported-default.st.css');
+                expect(defs.length).to.equal(1);
+                const def = defs[0];
+                expect(def.uri).to.equal(getCasePath('definitions/import.st.css'));
+                expect(def.range).to.eql(createRange(8, 1, 8, 5));
+            });
+
             it('should return definition of imported class in -st-named', () => {
                 const defs = asserters.getDefinition('definitions/imported-class-named.st.css');
                 expect(defs.length).to.equal(1);


### PR DESCRIPTION
Go-to-definition with imports behavior should be much better:
- `from` paths are now clickable
- `default` imports work more consistently 
- `named` imports work more consistently
- prevent exceptions from being thrown in certain cases 

This is just an improvement, there are still plenty of quirks.

Fixes: 
- #1148