### PR TITLE
fix(core): assure that pseudo-classes warn when no arguments are given

### DIFF
--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -22,7 +22,7 @@ export const stateErrors = {
     TOO_MANY_STATE_TYPES: (name: string, types: string[]) =>
         `pseudo-state "${name}(${types.join(', ')})" definition must be of a single type`,
     NO_STATE_ARGUMENT_GIVEN: (name: string, type: string) =>
-        `pseudo-state "${name}" expected argument of type ${type} but got none`,
+        `pseudo-state "${name}" expected argument of type "${type}" but got none`,
     NO_STATE_TYPE_GIVEN: (name: string) =>
         `pseudo-state "${name}" expected a definition of a single type, but received none`,
     TOO_MANY_ARGS_IN_VALIDATOR: (name: string, validator: string, args: string[]) =>
@@ -298,11 +298,9 @@ function resolveStateValue(
     );
 
     if (rule && !node.content && !stateDef.defaultValue) {
-        diagnostics.warn(
-            rule,
-            stateErrors.NO_STATE_ARGUMENT_GIVEN(name, stateDef.type),
-            { word: actualParam }
-        );
+        diagnostics.warn(rule, stateErrors.NO_STATE_ARGUMENT_GIVEN(name, stateDef.type), {
+            word: actualParam,
+        });
     }
 
     const validator = systemValidators[stateDef.type];

--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -295,6 +295,14 @@ function resolveStateValue(
         node.content || stateDef.defaultValue
     );
 
+    if (!actualParam && rule) {
+        diagnostics.warn(
+            rule,
+            `pseudo-state "${name}" expects a parameter of type ${stateDef.type} but none was given`,
+            { word: actualParam }
+        );
+    }
+
     const validator = systemValidators[stateDef.type];
 
     let stateParamOutput;

--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -21,6 +21,8 @@ export const stateErrors = {
         `pseudo-state "${name}" defined with unknown type: "${type}"`,
     TOO_MANY_STATE_TYPES: (name: string, types: string[]) =>
         `pseudo-state "${name}(${types.join(', ')})" definition must be of a single type`,
+    NO_STATE_ARGUMENT_GIVEN: (name: string, type: string) =>
+        `pseudo-state "${name}" expected argument of type ${type} but got none`,
     NO_STATE_TYPE_GIVEN: (name: string) =>
         `pseudo-state "${name}" expected a definition of a single type, but received none`,
     TOO_MANY_ARGS_IN_VALIDATOR: (name: string, validator: string, args: string[]) =>
@@ -295,10 +297,10 @@ function resolveStateValue(
         node.content || stateDef.defaultValue
     );
 
-    if (!actualParam && rule) {
-        diagnostics.error(
+    if (rule && !node.content && !stateDef.defaultValue) {
+        diagnostics.warn(
             rule,
-            stateErrors.UNKNOWN_STATE_TYPE(name, stateDef.type),
+            stateErrors.NO_STATE_ARGUMENT_GIVEN(name, stateDef.type),
             { word: actualParam }
         );
     }

--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -299,7 +299,7 @@ function resolveStateValue(
 
     if (rule && !node.content && !stateDef.defaultValue) {
         diagnostics.warn(rule, stateErrors.NO_STATE_ARGUMENT_GIVEN(name, stateDef.type), {
-            word: actualParam,
+            word: name,
         });
     }
 

--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -296,9 +296,9 @@ function resolveStateValue(
     );
 
     if (!actualParam && rule) {
-        diagnostics.warn(
+        diagnostics.error(
             rule,
-            `pseudo-state "${name}" expects a parameter of type ${stateDef.type} but none was given`,
+            stateErrors.UNKNOWN_STATE_TYPE(name, stateDef.type),
             { word: actualParam }
         );
     }

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -649,64 +649,6 @@ describe('pseudo-states', () => {
                 });
             });
 
-            it('should warn when pseudo-class expects params but none was given (no default)', () => {
-                const config = {
-                    entry: `/entry.st.css`,
-                    files: {
-                        '/entry.st.css': {
-                            namespace: 'entry',
-                            content: `
-                            .my-class {
-                                -st-states: state1(string);
-                            }
-                            |.my-class:state1 {}
-                            `,
-                        },
-                    },
-                }
-
-                const res = expectWarningsFromTransform(config, [
-                    {
-                        message: 'pseudo-state "state1" expected argument of type string but got none',
-                        file: '/entry.st.css',
-                        severity: 'warning',
-                    }
-                ])
-
-                expect(res).to.have.styleRules({
-                    1: '.entry__my-class.entry---state1-0- {}',
-                });
-            })
-
-            it('should warn when pseudo-class invoked and expects params but none was given', () => {
-                const config = {
-                    entry: `/entry.st.css`,
-                    files: {
-                        '/entry.st.css': {
-                            namespace: 'entry',
-                            content: `
-                            .my-class {
-                                -st-states: state1(string);
-                            }
-                            |.my-class:state1() {}
-                            `,
-                        },
-                    },
-                }
-
-                const res = expectWarningsFromTransform(config, [
-                    {
-                        message: 'pseudo-state "state1" expected argument of type string but got none',
-                        file: '/entry.st.css',
-                        severity: 'warning',
-                    }
-                ])
-
-                expect(res).to.have.styleRules({
-                    1: '.entry__my-class.entry---state1-0- {}',
-                });
-            })
-
             it('should strip quotation marks when transform any state parameter', () => {
                 const res = generateStylableResult({
                     entry: `/entry.st.css`,
@@ -2105,7 +2047,63 @@ describe('pseudo-states', () => {
             );
         });
 
-        
+        it('should warn when pseudo-class expects params but none was given (no default)', () => {
+            const config = {
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                        .my-class {
+                            -st-states: state1(string);
+                        }
+                        |.my-class:state1 {}
+                        `,
+                    },
+                },
+            }
+
+            const res = expectWarningsFromTransform(config, [
+                {
+                    message: 'pseudo-state "state1" expected argument of type string but got none',
+                    file: '/entry.st.css',
+                    severity: 'warning',
+                }
+            ])
+
+            expect(res).to.have.styleRules({
+                1: '.entry__my-class.entry---state1-0- {}',
+            });
+        })
+
+        it('should warn when pseudo-class invoked and expects params but none was given', () => {
+            const config = {
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                        .my-class {
+                            -st-states: state1(string);
+                        }
+                        |.my-class:state1() {}
+                        `,
+                    },
+                },
+            }
+
+            const res = expectWarningsFromTransform(config, [
+                {
+                    message: 'pseudo-state "state1" expected argument of type string but got none',
+                    file: '/entry.st.css',
+                    severity: 'warning',
+                }
+            ])
+
+            expect(res).to.have.styleRules({
+                1: '.entry__my-class.entry---state1-0- {}',
+            });
+        })
 
         it('should trigger a warning when trying to target an unknown state and keep the state', () => {
             const config = {

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -757,6 +757,31 @@ describe('pseudo-states', () => {
                 });
             });
 
+            it('should support default values when invoked', () => {
+                const res = generateStylableResult({
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: stateWithDefault(string) aDefaultValue;
+                            }
+                            .my-class:stateWithDefault() {}
+                            `,
+                        },
+                    },
+                });
+
+                expect(
+                    res.meta.diagnostics.reports,
+                    'no diagnostics reported for native states'
+                ).to.eql([]);
+                expect(res).to.have.styleRules({
+                    1: '.entry__my-class.entry---stateWithDefault-13-aDefaultValue',
+                });
+            });
+
             describe('string', () => {
                 it('should transform string type', () => {
                     const res = generateStylableResult({

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -626,6 +626,58 @@ describe('pseudo-states', () => {
                 });
             });
 
+            it('should warn when pseudo-class expects params but none was given', () => {
+                const config = {
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: state1(string);
+                            }
+                            |.my-class:state1 {}
+                            `,
+                        },
+                    },
+                }
+
+                const res = expectWarningsFromTransform(config, [
+                    {
+                        message: 'pseudo-state "state1" expects a parameter of type string but none was given',
+                        file: '/entry.st.css',
+                        severity: 'warning',
+                    }
+                ])
+
+                expect(res).to.have.styleRules({
+                    1: '.entry__my-class.entry---state1-0- {}',
+                });
+            })
+
+            it('should not warn when pseudo-class does not expect a params', () => {
+                const config = {
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: state1;
+                            }
+                            .my-class:state1 {}
+                            `,
+                        },
+                    },
+                }
+
+                const res = expectWarningsFromTransform(config, [])
+
+                expect(res).to.have.styleRules({
+                    1: '.entry__my-class.entry--state1 {}',
+                });
+            })
+
             it('should strip quotation marks when transform any state parameter', () => {
                 const res = generateStylableResult({
                     entry: `/entry.st.css`,

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -544,6 +544,29 @@ describe('pseudo-states', () => {
         });
 
         describe('boolean', () => {
+            it('should resolve boolean pseudo-state', () => {
+                const config = {
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: state1;
+                            }
+                            .my-class:state1 {}
+                            `,
+                        },
+                    },
+                }
+
+                const res = expectWarningsFromTransform(config, [])
+
+                expect(res).to.have.styleRules({
+                    1: '.entry__my-class.entry--state1 {}',
+                });
+            })
+
             it('should resolve nested pseudo-states', () => {
                 const res = generateStylableResult({
                     entry: '/entry.st.css',
@@ -652,29 +675,6 @@ describe('pseudo-states', () => {
 
                 expect(res).to.have.styleRules({
                     1: '.entry__my-class.entry---state1-0- {}',
-                });
-            })
-
-            it('should not warn when pseudo-class does not expect a params', () => {
-                const config = {
-                    entry: `/entry.st.css`,
-                    files: {
-                        '/entry.st.css': {
-                            namespace: 'entry',
-                            content: `
-                            .my-class {
-                                -st-states: state1;
-                            }
-                            .my-class:state1 {}
-                            `,
-                        },
-                    },
-                }
-
-                const res = expectWarningsFromTransform(config, [])
-
-                expect(res).to.have.styleRules({
-                    1: '.entry__my-class.entry--state1 {}',
                 });
             })
 

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -558,14 +558,14 @@ describe('pseudo-states', () => {
                             `,
                         },
                     },
-                }
+                };
 
-                const res = expectWarningsFromTransform(config, [])
+                const res = expectWarningsFromTransform(config, []);
 
                 expect(res).to.have.styleRules({
                     1: '.entry__my-class.entry--state1 {}',
                 });
-            })
+            });
 
             it('should resolve nested pseudo-states', () => {
                 const res = generateStylableResult({
@@ -2061,20 +2061,20 @@ describe('pseudo-states', () => {
                         `,
                     },
                 },
-            }
+            };
 
             const res = expectWarningsFromTransform(config, [
                 {
-                    message: 'pseudo-state "state1" expected argument of type string but got none',
+                    message: stateErrors.NO_STATE_ARGUMENT_GIVEN('state1', 'string'),
                     file: '/entry.st.css',
                     severity: 'warning',
-                }
-            ])
+                },
+            ]);
 
             expect(res).to.have.styleRules({
                 1: '.entry__my-class.entry---state1-0- {}',
             });
-        })
+        });
 
         it('should warn when pseudo-class invoked and expects params but none was given', () => {
             const config = {
@@ -2090,20 +2090,20 @@ describe('pseudo-states', () => {
                         `,
                     },
                 },
-            }
+            };
 
             const res = expectWarningsFromTransform(config, [
                 {
-                    message: 'pseudo-state "state1" expected argument of type string but got none',
+                    message: stateErrors.NO_STATE_ARGUMENT_GIVEN('state1', 'string'),
                     file: '/entry.st.css',
                     severity: 'warning',
-                }
-            ])
+                },
+            ]);
 
             expect(res).to.have.styleRules({
                 1: '.entry__my-class.entry---state1-0- {}',
             });
-        })
+        });
 
         it('should trigger a warning when trying to target an unknown state and keep the state', () => {
             const config = {

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -2057,7 +2057,7 @@ describe('pseudo-states', () => {
                         .my-class {
                             -st-states: state1(string);
                         }
-                        |.my-class:state1 {}
+                        |.my-class:$state1$ {}
                         `,
                     },
                 },
@@ -2086,7 +2086,7 @@ describe('pseudo-states', () => {
                         .my-class {
                             -st-states: state1(string);
                         }
-                        |.my-class:state1() {}
+                        |.my-class:$state1$() {}
                         `,
                     },
                 },

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -646,7 +646,7 @@ describe('pseudo-states', () => {
                     {
                         message: 'pseudo-state "state1" expects a parameter of type string but none was given',
                         file: '/entry.st.css',
-                        severity: 'warning',
+                        severity: 'error',
                     }
                 ])
 

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -778,7 +778,7 @@ describe('pseudo-states', () => {
                     'no diagnostics reported for native states'
                 ).to.eql([]);
                 expect(res).to.have.styleRules({
-                    1: '.entry__my-class.entry---stateWithDefault-13-aDefaultValue',
+                    1: '.entry__my-class.entry---stateWithDefault-13-aDefaultValue {}',
                 });
             });
 

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -649,7 +649,7 @@ describe('pseudo-states', () => {
                 });
             });
 
-            it('should warn when pseudo-class expects params but none was given', () => {
+            it('should warn when pseudo-class expects params but none was given (no default)', () => {
                 const config = {
                     entry: `/entry.st.css`,
                     files: {
@@ -2104,6 +2104,8 @@ describe('pseudo-states', () => {
                 ]
             );
         });
+
+        
 
         it('should trigger a warning when trying to target an unknown state and keep the state', () => {
             const config = {

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -644,7 +644,7 @@ describe('pseudo-states', () => {
 
                 const res = expectWarningsFromTransform(config, [
                     {
-                        message: 'pseudo-state "state1" expects a parameter of type string but none was given',
+                        message: 'pseudo-state "state1" defined with unknown type: "string"',
                         file: '/entry.st.css',
                         severity: 'error',
                     }

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -667,9 +667,38 @@ describe('pseudo-states', () => {
 
                 const res = expectWarningsFromTransform(config, [
                     {
-                        message: 'pseudo-state "state1" defined with unknown type: "string"',
+                        message: 'pseudo-state "state1" expected argument of type string but got none',
                         file: '/entry.st.css',
-                        severity: 'error',
+                        severity: 'warning',
+                    }
+                ])
+
+                expect(res).to.have.styleRules({
+                    1: '.entry__my-class.entry---state1-0- {}',
+                });
+            })
+
+            it('should warn when pseudo-class invoked and expects params but none was given', () => {
+                const config = {
+                    entry: `/entry.st.css`,
+                    files: {
+                        '/entry.st.css': {
+                            namespace: 'entry',
+                            content: `
+                            .my-class {
+                                -st-states: state1(string);
+                            }
+                            |.my-class:state1() {}
+                            `,
+                        },
+                    },
+                }
+
+                const res = expectWarningsFromTransform(config, [
+                    {
+                        message: 'pseudo-state "state1" expected argument of type string but got none',
+                        file: '/entry.st.css',
+                        severity: 'warning',
                     }
                 ])
 


### PR DESCRIPTION
should warn when pseudo-class expects params but none was given

Closes #1936