### PR TITLE
feat(core): support unscoped rules with st-scope

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -133,9 +133,6 @@ export const processorWarnings = {
     NO_KEYFRAMES_IN_ST_SCOPE() {
         return `cannot use "@keyframes" inside of "@st-scope"`;
     },
-    MISSING_SCOPING_PARAM() {
-        return '"@st-scope" missing scoping selector parameter';
-    },
     ILLEGAL_GLOBAL_CSS_VAR(name: string) {
         return `"@st-global-custom-property" received the value "${name}", but it must begin with "--" (double-dash)`;
     },
@@ -925,7 +922,6 @@ export class StylableProcessor {
     private handleScope(atRule: postcss.AtRule) {
         const scopingRule = postcss.rule({ selector: atRule.params }) as SRule;
         this.handleRule(scopingRule, true);
-        validateScopingSelector(atRule, scopingRule, this.diagnostics);
 
         if (scopingRule.selector) {
             atRule.walkRules((rule) => {
@@ -961,16 +957,6 @@ function setImportObjectFrom(importPath: string, dirPath: string, importObj: Imp
             path.posix && path.posix.isAbsolute(dirPath) // browser has no posix methods
                 ? path.posix.resolve(dirPath, importPath)
                 : path.resolve(dirPath, importPath);
-    }
-}
-
-export function validateScopingSelector(
-    atRule: postcss.AtRule,
-    { selector: scopingSelector }: SRule,
-    diagnostics: Diagnostics
-) {
-    if (!scopingSelector) {
-        diagnostics.warn(atRule, processorWarnings.MISSING_SCOPING_PARAM());
     }
 }
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -719,8 +719,10 @@ export class StylableTransformer {
     private resolveMetaParts(meta: StylableMeta): MetaParts {
         let metaParts = this.metaParts.get(meta);
         if (!metaParts) {
-            const resolvedClasses: Record<string, Array<CSSResolve<ClassSymbol | ElementSymbol>>> =
-                {};
+            const resolvedClasses: Record<
+                string,
+                Array<CSSResolve<ClassSymbol | ElementSymbol>>
+            > = {};
             for (const className of Object.keys(meta.classes)) {
                 resolvedClasses[className] = this.resolver.resolveExtends(
                     meta,
@@ -767,8 +769,10 @@ export class StylableTransformer {
                 );
             }
 
-            const resolvedElements: Record<string, Array<CSSResolve<ClassSymbol | ElementSymbol>>> =
-                {};
+            const resolvedElements: Record<
+                string,
+                Array<CSSResolve<ClassSymbol | ElementSymbol>>
+            > = {};
             for (const k of Object.keys(meta.elements)) {
                 resolvedElements[k] = this.resolver.resolveExtends(meta, k, true);
             }
@@ -809,6 +813,10 @@ export class StylableTransformer {
 function validateScopes(transformer: StylableTransformer, meta: StylableMeta) {
     const transformedScopes: Record<string, SelectorChunk2[][]> = {};
     for (const scope of meta.scopes) {
+        if (!scope.params) {
+            continue;
+        }
+
         const len = transformer.diagnostics.reports.length;
         const rule = postcss.rule({ selector: scope.params });
 

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -112,7 +112,7 @@ describe('@st-scope', () => {
             );
         });
 
-        it('should support un scope (no param)', () => {
+        it('should support unscoped rules (no param)', () => {
             const { meta } = generateStylableResult({
                 entry: `/entry.st.css`,
                 files: {

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -112,7 +112,7 @@ describe('@st-scope', () => {
             );
         });
 
-        it('should support no scope param', () => {
+        it('should support un scope (no param)', () => {
             const { meta } = generateStylableResult({
                 entry: `/entry.st.css`,
                 files: {

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -112,6 +112,28 @@ describe('@st-scope', () => {
             );
         });
 
+        it('should support no scope param', () => {
+            const { meta } = generateStylableResult({
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                        @st-scope {
+                            html,body {}
+                            .part1 {}
+                        }
+                        `,
+                    },
+                },
+            });
+
+            shouldReportNoDiagnostics(meta);
+
+            expect((meta.outputAst!.nodes[0] as Rule).selector).to.equal('html,body');
+            expect((meta.outputAst!.nodes[1] as Rule).selector).to.equal('.entry__part1');
+        });
+
         it('should support multiple selectors', () => {
             const { meta } = generateStylableResult({
                 entry: `/entry.st.css`,
@@ -544,30 +566,6 @@ describe('@st-scope', () => {
             expect((meta.outputAst!.first as Rule).selector).to.equal(
                 '.entry__root::unknownPart .entry__part::unknownPart'
             );
-        });
-        it('should warn about a missing scoping parameter', () => {
-            const config = {
-                entry: `/entry.st.css`,
-                files: {
-                    '/entry.st.css': {
-                        namespace: 'entry',
-                        content: `
-                        |@st-scope {
-                            .part {}
-                        }|
-                        `,
-                    },
-                },
-            };
-
-            const { meta } = expectWarningsFromTransform(config, [
-                {
-                    message: processorWarnings.MISSING_SCOPING_PARAM(),
-                    file: '/entry.st.css',
-                    severity: 'warning',
-                },
-            ]);
-            expect((meta.outputAst!.first as Rule).selector).to.equal('.entry__part');
         });
 
         it('should warn about vars definition inside a scope', () => {


### PR DESCRIPTION
We want to allow users to declare unscoped rules without warning.

- [x] - Add note in documentation about this feature (https://github.com/wixplosives/stylable.io/pull/26)


Closes #1049