### PR TITLE
feat(core): support defining and using global keyframes

### DIFF
--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -114,7 +114,7 @@ export interface KeyframesSymbol {
     alias: string;
     name: string;
     import?: Imported;
-    globalName?: string;
+    global?: boolean;
 }
 
 export interface CSSVarSymbol {

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -114,6 +114,7 @@ export interface KeyframesSymbol {
     alias: string;
     name: string;
     import?: Imported;
+    globalName?: string;
 }
 
 export interface CSSVarSymbol {

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -1,14 +1,14 @@
-import { murmurhash3_32_gc } from './murmurhash';
 import path from 'path';
 import * as postcss from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
 import { tokenizeImports } from 'toky';
 import { Diagnostics } from './diagnostics';
+import { murmurhash3_32_gc } from './murmurhash';
+import { reservedKeyFrames } from './native-reserved-lists';
 import {
     createSimpleSelectorChecker,
     isChildOfAtRule,
     isCompRoot,
-    isGlobal,
     isNested,
     isRootValid,
     parseSelector,
@@ -43,7 +43,6 @@ import {
     valueMapping,
 } from './stylable-value-parsers';
 import { deprecated, filename2varname, globalValue, stripQuotation } from './utils';
-import { reservedKeyFrames } from './native-reserved-lists';
 export * from './stylable-meta'; /* TEMP EXPORT */
 
 const parseNamed = SBTypesParsers[valueMapping.named];

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -501,7 +501,7 @@ export class StylableProcessor {
                         locallyScoped = true;
                     }
                 }
-            } else if (node.type === 'nested-pseudo-class' && node.name === 'global') {
+            } else if (type === 'nested-pseudo-class' && name === 'global') {
                 return true;
             }
             return void 0;

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -141,10 +141,10 @@ export const processorWarnings = {
     MISSING_SCOPING_PARAM() {
         return '"@st-scope" missing scoping selector parameter';
     },
-    MISSING_KEYFRAMES_PARAM() {
+    MISSING_KEYFRAMES_NAME() {
         return '"@keyframes" missing parameter';
     },
-    MISSING_KEYFRAMES_PARAM_INSIDE_GLOBAL() {
+    MISSING_KEYFRAMES_NAME_INSIDE_GLOBAL() {
         return `"@keyframes" missing parameter inside "${paramMapping.global}()"`;
     },
     ILLEGAL_GLOBAL_CSS_VAR(name: string) {
@@ -283,7 +283,7 @@ export class StylableProcessor {
                             if (name === '') {
                                 this.diagnostics.warn(
                                     atRule,
-                                    processorWarnings.MISSING_KEYFRAMES_PARAM_INSIDE_GLOBAL()
+                                    processorWarnings.MISSING_KEYFRAMES_NAME_INSIDE_GLOBAL()
                                 );
                             }
 
@@ -307,7 +307,7 @@ export class StylableProcessor {
                         } else {
                             this.diagnostics.warn(
                                 atRule,
-                                processorWarnings.MISSING_KEYFRAMES_PARAM()
+                                processorWarnings.MISSING_KEYFRAMES_NAME()
                             );
                         }
                     } else {

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -269,31 +269,26 @@ export class StylableProcessor {
                 case 'keyframes':
                     if (!isChildOfAtRule(atRule, rootValueMapping.stScope)) {
                         this.meta.keyframes.push(atRule);
-                        const { params: name } = atRule;
+                        let { params: name } = atRule;
 
                         if (name) {
+                            let global: boolean | undefined;
                             const globalName = globalValue(name);
 
+                            if (globalName !== undefined) {
+                                name = globalName;
+                                global = true;
+                            }
+
                             // No name inside :global (:global())
-                            if (globalName === '') {
+                            if (name === '') {
                                 this.diagnostics.warn(
                                     atRule,
                                     processorWarnings.MISSING_KEYFRAMES_PARAM_INSIDE_GLOBAL()
                                 );
                             }
 
-                            if (
-                                globalName !== undefined &&
-                                reservedKeyFrames.includes(globalName)
-                            ) {
-                                this.diagnostics.error(
-                                    atRule,
-                                    processorWarnings.KEYFRAME_NAME_RESERVED(globalName),
-                                    {
-                                        word: globalName,
-                                    }
-                                );
-                            } else if (reservedKeyFrames.includes(name)) {
+                            if (reservedKeyFrames.includes(name)) {
                                 this.diagnostics.error(
                                     atRule,
                                     processorWarnings.KEYFRAME_NAME_RESERVED(name),
@@ -308,7 +303,7 @@ export class StylableProcessor {
                                 _kind: 'keyframes',
                                 alias: name,
                                 name,
-                                globalName,
+                                global,
                             };
                         } else {
                             this.diagnostics.warn(

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -280,7 +280,6 @@ export class StylableProcessor {
                                 global = true;
                             }
 
-                            // No name inside :global (:global())
                             if (name === '') {
                                 this.diagnostics.warn(
                                     atRule,

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -35,6 +35,7 @@ import {
     scopeSelector,
 } from './stylable-utils';
 import {
+    paramMapping,
     rootValueMapping,
     SBTypesParsers,
     stValuesMap,
@@ -145,7 +146,7 @@ export const processorWarnings = {
         return '"@keyframes" missing parameter';
     },
     MISSING_KEYFRAMES_PARAM_INSIDE_GLOBAL() {
-        return '"@keyframes" missing parameter inside ":global()"';
+        return `"@keyframes" missing parameter inside "${paramMapping.global}()"`;
     },
     ILLEGAL_GLOBAL_CSS_VAR(name: string) {
         return `"@st-global-custom-property" received the value "${name}", but it must begin with "--" (double-dash)`;
@@ -501,7 +502,7 @@ export class StylableProcessor {
                         locallyScoped = true;
                     }
                 }
-            } else if (isGlobal(node)) {
+            } else if (node.type === 'nested-pseudo-class' && node.name === 'global') {
                 return true;
             }
             return void 0;

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -285,9 +285,12 @@ export class StylableTransformer {
     public scopeKeyframes(ast: postcss.Root, meta: StylableMeta) {
         ast.walkAtRules(/keyframes$/, (atRule) => {
             const name = atRule.params;
+            const globalName = globalValue(name);
 
-            if (globalValue(name) === undefined) {
+            if (globalName === undefined) {
                 atRule.params = this.scope(name, meta.namespace);
+            } else {
+                atRule.params = globalName;
             }
         });
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -1,9 +1,8 @@
+import isVendorPrefixed from 'is-vendor-prefixed';
+import cloneDeep from 'lodash.clonedeep';
 import { basename } from 'path';
 import * as postcss from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
-import isVendorPrefixed from 'is-vendor-prefixed';
-import cloneDeep from 'lodash.clonedeep';
-
 import type { FileProcessor } from './cached-process-file';
 import { unbox } from './custom-values';
 import type { Diagnostics } from './diagnostics';
@@ -31,9 +30,9 @@ import type {
     StylableMeta,
     StylableSymbol,
 } from './stylable-processor';
-import { CSSResolve, StylableResolverCache, StylableResolver } from './stylable-resolver';
+import { CSSResolve, StylableResolver, StylableResolverCache } from './stylable-resolver';
 import { findRule, generateScopedCSSVar, getDeclStylable, isCSSVarProp } from './stylable-utils';
-import { animationPropRegExp, paramMapping, valueMapping } from './stylable-value-parsers';
+import { animationPropRegExp, valueMapping } from './stylable-value-parsers';
 import { globalValue } from './utils';
 
 const { hasOwnProperty } = Object.prototype;

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -123,7 +123,7 @@ export const transformerWarnings = {
         return `cannot use alias for unknown import "${name}"`;
     },
     CANNOT_FIND_SYMBOL(name: string) {
-        return `Cannot find symbol named "${name}".\nDid you mean to target a global symbol? (use "${paramMapping.global}(${name})")`;
+        return `Cannot find a symbol named "${name}".\nDid you mean to target a global symbol? (use "${paramMapping.global}(${name})")`;
     },
 };
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -122,9 +122,6 @@ export const transformerWarnings = {
     UNKNOWN_IMPORT_ALIAS(name: string) {
         return `cannot use alias for unknown import "${name}"`;
     },
-    CANNOT_FIND_SYMBOL(name: string) {
-        return `Cannot find a symbol named "${name}".\nDid you mean to target a global symbol? (use "${paramMapping.global}(${name})")`;
-    },
 };
 
 export class StylableTransformer {
@@ -312,12 +309,6 @@ export class StylableTransformer {
                 const scoped = keyframesExports[node.value];
                 if (scoped) {
                     node.value = scoped;
-                } else {
-                    this.diagnostics.warn(
-                        decl,
-                        transformerWarnings.CANNOT_FIND_SYMBOL(node.value),
-                        { word: node.value }
-                    );
                 }
             });
             decl.value = parsed.toString();

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -294,7 +294,9 @@ export class StylableTransformer {
             const res = this.resolver.resolveKeyframes(meta, key);
 
             if (res) {
-                keyframesExports[key] = this.scope(res.symbol.alias, res.meta.namespace);
+                keyframesExports[key] = res.symbol.global
+                    ? res.symbol.alias
+                    : this.scope(res.symbol.alias, res.meta.namespace);
             }
         });
 

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -71,7 +71,7 @@ export const valueMapping = {
 };
 
 export const paramMapping = {
-    global: ':global' as const,
+    global: 'st-global' as const,
 };
 
 export const mixinDeclRegExp = new RegExp(`(${valueMapping.mixin})|(${valueMapping.partialMixin})`);

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -77,6 +77,9 @@ export type stKeys = keyof typeof valueMapping;
 export const stValues: string[] = Object.keys(valueMapping).map(
     (key) => valueMapping[key as stKeys]
 );
+
+export const globalValueRegExp = /^:global\((.*?)\)$/;
+
 export const stValuesMap: Record<string, boolean> = Object.keys(valueMapping).reduce((acc, key) => {
     acc[valueMapping[key as stKeys]] = true;
     return acc;

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -70,6 +70,10 @@ export const valueMapping = {
     global: '-st-global' as const,
 };
 
+export const paramMapping = {
+    global: ':global' as const,
+};
+
 export const mixinDeclRegExp = new RegExp(`(${valueMapping.mixin})|(${valueMapping.partialMixin})`);
 
 export type stKeys = keyof typeof valueMapping;
@@ -78,7 +82,9 @@ export const stValues: string[] = Object.keys(valueMapping).map(
     (key) => valueMapping[key as stKeys]
 );
 
-export const globalValueRegExp = /^:global\((.*?)\)$/;
+export const animationPropRegExp = /animation$|animation-name$/;
+
+export const globalValueRegExp = new RegExp(`^${paramMapping.global}\\((.*?)\\)$`);
 
 export const stValuesMap: Record<string, boolean> = Object.keys(valueMapping).reduce((acc, key) => {
     acc[valueMapping[key as stKeys]] = true;

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -71,7 +71,7 @@ export const valueMapping = {
 };
 
 export const paramMapping = {
-    global: 'st-global' as const,
+    global: 'stGlobal' as const,
 };
 
 export const mixinDeclRegExp = new RegExp(`(${valueMapping.mixin})|(${valueMapping.partialMixin})`);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,6 +2,12 @@
 //     return namespace ? namespace + separator + name : name;
 // }
 
+export function globalValue(str: string) {
+    const match = str.match(/^:global\((.*?)\)$/);
+
+    return match?.[1];
+}
+
 export function stripQuotation(str: string) {
     return str.replace(/^['"](.*?)['"]$/g, '$1');
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,9 +1,7 @@
-// export function scope(name: string, namespace: string, separator: string = '-') {
-//     return namespace ? namespace + separator + name : name;
-// }
+import { globalValueRegExp } from './stylable-value-parsers';
 
 export function globalValue(str: string) {
-    const match = str.match(/^:global\((.*?)\)$/);
+    const match = str.match(globalValueRegExp);
 
     return match?.[1];
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,7 +2,6 @@ import { globalValueRegExp } from './stylable-value-parsers';
 
 export function globalValue(str: string) {
     const match = str.match(globalValueRegExp);
-
     return match?.[1];
 }
 

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -1183,7 +1183,7 @@ describe('diagnostics: warnings and errors', () => {
                     },
                 };
                 expectWarningsFromTransform(config, [
-                    { message: transformerWarnings.KEYFRAME_NAME_RESERVED(key), file: '/main.css' },
+                    { message: processorWarnings.KEYFRAME_NAME_RESERVED(key), file: '/main.css' },
                 ]);
             });
         });
@@ -1363,7 +1363,7 @@ describe('diagnostics: warnings and errors', () => {
                     {
                         message: resolverWarnings.UNKNOWN_IMPORTED_FILE('./missing.st.css'),
                         file: '/main.st.css',
-                    }
+                    },
                 ]);
             });
 

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -43,7 +43,7 @@ describe('Stylable postcss process', () => {
     });
 
     it('warn on missing keyframes parameter (global)', () => {
-        const { diagnostics } = processSource(`@keyframes st-global() {}`, {
+        const { diagnostics } = processSource(`@keyframes stGlobal() {}`, {
             from: '/path/to/source',
         });
 
@@ -374,7 +374,7 @@ describe('Stylable postcss process', () => {
     it('collect global @keyframes', () => {
         const result = processSource(
             `
-            @keyframes st-global(name) {
+            @keyframes stGlobal(name) {
                 from{}
                 to{}
             }

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -33,6 +33,15 @@ describe('Stylable postcss process', () => {
         });
     });
 
+    it.only('warn on missing keyframes parameter', () => {
+        const { diagnostics } = processSource(`@keyframes {}`, { from: '/path/to/source' });
+
+        expect(diagnostics.reports[0]).to.include({
+            type: 'warning',
+            message: processorWarnings.MISSING_KEYFRAMES_PARAM(),
+        });
+    });
+
     it('error on invalid rule nesting', () => {
         const { diagnostics } = processSource(
             `

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -38,7 +38,7 @@ describe('Stylable postcss process', () => {
 
         expect(diagnostics.reports[0]).to.include({
             type: 'warning',
-            message: processorWarnings.MISSING_KEYFRAMES_PARAM(),
+            message: processorWarnings.MISSING_KEYFRAMES_NAME(),
         });
     });
 
@@ -49,7 +49,7 @@ describe('Stylable postcss process', () => {
 
         expect(diagnostics.reports[0]).to.include({
             type: 'warning',
-            message: processorWarnings.MISSING_KEYFRAMES_PARAM_INSIDE_GLOBAL(),
+            message: processorWarnings.MISSING_KEYFRAMES_NAME_INSIDE_GLOBAL(),
         });
     });
 

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -43,7 +43,7 @@ describe('Stylable postcss process', () => {
     });
 
     it('warn on missing keyframes parameter (global)', () => {
-        const { diagnostics } = processSource(`@keyframes :global() {}`, {
+        const { diagnostics } = processSource(`@keyframes st-global() {}`, {
             from: '/path/to/source',
         });
 
@@ -374,7 +374,7 @@ describe('Stylable postcss process', () => {
     it('collect global @keyframes', () => {
         const result = processSource(
             `
-            @keyframes :global(name) {
+            @keyframes st-global(name) {
                 from{}
                 to{}
             }

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -33,7 +33,7 @@ describe('Stylable postcss process', () => {
         });
     });
 
-    it.only('warn on missing keyframes parameter', () => {
+    it('warn on missing keyframes parameter', () => {
         const { diagnostics } = processSource(`@keyframes {}`, { from: '/path/to/source' });
 
         expect(diagnostics.reports[0]).to.include({

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -42,6 +42,17 @@ describe('Stylable postcss process', () => {
         });
     });
 
+    it('warn on missing keyframes parameter (global)', () => {
+        const { diagnostics } = processSource(`@keyframes :global() {}`, {
+            from: '/path/to/source',
+        });
+
+        expect(diagnostics.reports[0]).to.include({
+            type: 'warning',
+            message: processorWarnings.MISSING_KEYFRAMES_PARAM_INSIDE_GLOBAL(),
+        });
+    });
+
     it('error on invalid rule nesting', () => {
         const { diagnostics } = processSource(
             `
@@ -353,11 +364,15 @@ describe('Stylable postcss process', () => {
                 from{}
                 to{}
             }
+            @keyframes :global(global-name) {
+                from{}
+                to{}
+            }
         `,
             { from: 'path/to/style.css' }
         );
 
-        expect(result.keyframes.length).to.eql(2);
+        expect(result.keyframes.length).to.eql(3);
     });
 
     it('should collect mixins on rules', () => {

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -364,7 +364,17 @@ describe('Stylable postcss process', () => {
                 from{}
                 to{}
             }
-            @keyframes :global(global-name) {
+        `,
+            { from: 'path/to/style.css' }
+        );
+
+        expect(result.keyframes.length).to.eql(2);
+    });
+
+    it('collect global @keyframes', () => {
+        const result = processSource(
+            `
+            @keyframes :global(name) {
                 from{}
                 to{}
             }
@@ -372,7 +382,14 @@ describe('Stylable postcss process', () => {
             { from: 'path/to/style.css' }
         );
 
-        expect(result.keyframes.length).to.eql(3);
+        expect(result.mappedKeyframes).to.eql({
+            name: {
+                _kind: 'keyframes',
+                alias: 'name',
+                name: 'name',
+                global: true,
+            },
+        });
     });
 
     it('should collect mixins on rules', () => {

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -157,8 +157,8 @@ describe('Stylable postcss transform (Global)', () => {
                         namespace: 'style',
                         content: `
 
-                        /* @check :global(global-name) */
-                        @keyframes :global(global-name) {
+                        /* @check st-global(global-name) */
+                        @keyframes st-global(global-name) {
                             from {}
                             to {}
                         }
@@ -188,7 +188,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/a.st.css': {
                         namespace: 'a',
                         content: `
-                        @keyframes :global(globalName) {
+                        @keyframes st-global(globalName) {
                             from {}
                             to {}
                         }
@@ -220,7 +220,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/a.st.css': {
                         namespace: 'a',
                         content: `
-                        @keyframes :global(globalName) {
+                        @keyframes st-global(globalName) {
                             from {}
                             to {}
                         }

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -157,7 +157,7 @@ describe('Stylable postcss transform (Global)', () => {
                         namespace: 'style',
                         content: `
 
-                        /* @check st-global(global-name) */
+                        /* @check global-name */
                         @keyframes st-global(global-name) {
                             from {}
                             to {}

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -233,30 +233,5 @@ describe('Stylable postcss transform (Global)', () => {
             testInlineExpects(generateStylableRoot(config));
             expectWarningsFromTransform(config, []);
         });
-
-        describe('diagnostics', () => {
-            it('should show diagnostic when used animation/animation-name without known keyframe symbol', () => {
-                const config = {
-                    entry: `/style.st.css`,
-                    files: {
-                        '/style.st.css': {
-                            namespace: 'style',
-                            content: `
-                            .foo {
-                                |animation-name: $globalName$|;
-                            }
-                            `,
-                        },
-                    },
-                };
-
-                expectWarningsFromTransform(config, [
-                    {
-                        file: '/style.st.css',
-                        message: transformerWarnings.CANNOT_FIND_SYMBOL('globalName'),
-                    },
-                ]);
-            });
-        });
     });
 });

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -1,5 +1,6 @@
 import {
     expectWarningsFromTransform,
+    generateStylableExports,
     generateStylableResult,
     generateStylableRoot,
     testInlineExpects,
@@ -169,7 +170,7 @@ describe('Stylable postcss transform (Global)', () => {
             testInlineExpects(result);
         });
 
-        it('should export global keyframe', () => {
+        it('should import global keyframe', () => {
             const config = {
                 entry: `/style.st.css`,
                 files: {
@@ -201,7 +202,7 @@ describe('Stylable postcss transform (Global)', () => {
             expectWarningsFromTransform(config, []);
         });
 
-        it('should export global keyframe (alias)', () => {
+        it('should import global keyframe (alias)', () => {
             const config = {
                 entry: `/style.st.css`,
                 files: {
@@ -231,6 +232,29 @@ describe('Stylable postcss transform (Global)', () => {
 
             testInlineExpects(generateStylableRoot(config));
             expectWarningsFromTransform(config, []);
+        });
+
+        it('should export global keyframe', () => {
+            const config = {
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'style',
+                        content: `
+                        @keyframes stGlobal(globalName) {
+                            from {}
+                            to {}
+                        }
+                        `,
+                    },
+                },
+            };
+
+            const cssExports = generateStylableExports(config);
+
+            expect(cssExports.keyframes).to.eql({
+                globalName: 'globalName',
+            });
         });
     });
 });

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
-import { transformerWarnings } from '@stylable/core';
 
 describe('Stylable postcss transform (Global)', () => {
     it('should support :global()', () => {

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -157,7 +157,7 @@ describe('Stylable postcss transform (Global)', () => {
                         content: `
 
                         /* @check global-name */
-                        @keyframes st-global(global-name) {
+                        @keyframes stGlobal(global-name) {
                             from {}
                             to {}
                         }
@@ -187,7 +187,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/a.st.css': {
                         namespace: 'a',
                         content: `
-                        @keyframes st-global(globalName) {
+                        @keyframes stGlobal(globalName) {
                             from {}
                             to {}
                         }
@@ -219,7 +219,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/a.st.css': {
                         namespace: 'a',
                         content: `
-                        @keyframes st-global(globalName) {
+                        @keyframes stGlobal(globalName) {
                             from {}
                             to {}
                         }

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
+import { transformerWarnings } from '@stylable/core';
 
 describe('Stylable postcss transform (Global)', () => {
     it('should support :global()', () => {
@@ -231,6 +232,31 @@ describe('Stylable postcss transform (Global)', () => {
 
             testInlineExpects(generateStylableRoot(config));
             expectWarningsFromTransform(config, []);
+        });
+
+        describe('diagnostics', () => {
+            it('should show diagnostic when used animation/animation-name without known keyframe symbol', () => {
+                const config = {
+                    entry: `/style.st.css`,
+                    files: {
+                        '/style.st.css': {
+                            namespace: 'style',
+                            content: `
+                            .foo {
+                                |animation-name: $globalName$|;
+                            }
+                            `,
+                        },
+                    },
+                };
+
+                expectWarningsFromTransform(config, [
+                    {
+                        file: '/style.st.css',
+                        message: transformerWarnings.CANNOT_FIND_SYMBOL('globalName'),
+                    },
+                ]);
+            });
         });
     });
 });

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -1,5 +1,4 @@
 import {
-    Diagnostic,
     expectWarningsFromTransform,
     generateStylableResult,
     generateStylableRoot,
@@ -182,6 +181,38 @@ describe('Stylable postcss transform (Global)', () => {
                         /* @check .style__foo {animation-name: globalName;} */
                         .foo {
                             animation-name: globalName;
+                        }
+                        `,
+                    },
+                    '/a.st.css': {
+                        namespace: 'a',
+                        content: `
+                        @keyframes :global(globalName) {
+                            from {}
+                            to {}
+                        }
+                        
+                        `,
+                    },
+                },
+            };
+
+            testInlineExpects(generateStylableRoot(config));
+            expectWarningsFromTransform(config, []);
+        });
+
+        it('should export global keyframe (alias)', () => {
+            const config = {
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'style',
+                        content: `
+                        @st-import [keyframes(globalName as bar)] from "./a.st.css";
+
+                        /* @check .style__foo {animation-name: globalName;} */
+                        .foo {
+                            animation-name: bar;
                         }
                         `,
                     },


### PR DESCRIPTION
We want to allow to expose and use global keyframes.
Importing global keyframes should be seamless and be resolve like other keyframes.

- [x] - when declaring global keyframe:
```css

@keyframes stGlobal(my-global-keyframes) {
	from {}
	to {}
}

```

- [x] - add section in `stylable.io`. https://github.com/wixplosives/stylable.io/pull/27

Closes #1559