### PR TITLE
docs(webpack-plugin): sync min required webpack version in README with package.json

### DIFF
--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@stylable/webpack-plugin.svg)](https://www.npmjs.com/package/@stylable/webpack-plugin)
 
-`@stylable/webpack-plugin` (for webpack `^5.20.0`) is the main build utility for [Stylable](https://stylable.io/). It supports both development and production modes, providing various configurations that can be tweaked according to your specific needs. It enables loading Stylable files (`.st.css`) from local projects or imported from a 3rd party source (for example, NPM node modules).
+`@stylable/webpack-plugin` (for webpack `^5.30.0`) is the main build utility for [Stylable](https://stylable.io/). It supports both development and production modes, providing various configurations that can be tweaked according to your specific needs. It enables loading Stylable files (`.st.css`) from local projects or imported from a 3rd party source (for example, NPM node modules).
 
 ## Getting started
 Install `@stylable/webpack-plugin` as a dev dependency in your local project.


### PR DESCRIPTION
[It's mentioned in the package.json](https://github.com/wix/stylable/blob/master/packages/webpack-plugin/package.json#L11) that webpack should be at least `5.30.0` version.
Updating the README
 