### PR TITLE
fix(create-stylable-app): missing demand for project name

### DIFF
--- a/packages/create-stylable-app/src/cli-main.ts
+++ b/packages/create-stylable-app/src/cli-main.ts
@@ -4,6 +4,7 @@ import { createProjectFromTemplate } from './create-project';
 
 const argv = yargs
     .usage('npm init stylable-app <project-name>')
+    .demand(1, 'missing project-name')
     .option('template', {
         alias: 't',
         type: 'string',


### PR DESCRIPTION
`yarg` released a new minor version which contains a breaking change related to strict arguments parsing. this PR fixes this issue by demanding the project-name 

Note: we need a basic test for this package as well