### PR TITLE
fix(cli): add missing 'module-utils' dependency (v3)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@stylable/core": "^3.12.4",
+    "@stylable/module-utils": "^3.12.4",
     "@stylable/node": "^3.12.4",
     "@stylable/optimizer": "^3.12.4",
     "lodash.camelcase": "^4.3.0",


### PR DESCRIPTION
`@stylable/cli` is using `@stylable/module-utils` but did not declare it as a dependency in the `package.json`