### PR TITLE
refactor: rename keyframes "stGlobal" function to "st-global"

### DIFF
--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -71,7 +71,7 @@ export const valueMapping = {
 };
 
 export const paramMapping = {
-    global: 'stGlobal' as const,
+    global: 'st-global' as const,
 };
 
 export const mixinDeclRegExp = new RegExp(`(${valueMapping.mixin})|(${valueMapping.partialMixin})`);

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -43,7 +43,7 @@ describe('Stylable postcss process', () => {
     });
 
     it('warn on missing keyframes parameter (global)', () => {
-        const { diagnostics } = processSource(`@keyframes stGlobal() {}`, {
+        const { diagnostics } = processSource(`@keyframes st-global() {}`, {
             from: '/path/to/source',
         });
 
@@ -374,7 +374,7 @@ describe('Stylable postcss process', () => {
     it('collect global @keyframes', () => {
         const result = processSource(
             `
-            @keyframes stGlobal(name) {
+            @keyframes st-global(name) {
                 from{}
                 to{}
             }

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -158,7 +158,7 @@ describe('Stylable postcss transform (Global)', () => {
                         content: `
 
                         /* @check global-name */
-                        @keyframes stGlobal(global-name) {
+                        @keyframes st-global(global-name) {
                             from {}
                             to {}
                         }
@@ -188,7 +188,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/a.st.css': {
                         namespace: 'a',
                         content: `
-                        @keyframes stGlobal(globalName) {
+                        @keyframes st-global(globalName) {
                             from {}
                             to {}
                         }
@@ -220,7 +220,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/a.st.css': {
                         namespace: 'a',
                         content: `
-                        @keyframes stGlobal(globalName) {
+                        @keyframes st-global(globalName) {
                             from {}
                             to {}
                         }
@@ -241,7 +241,7 @@ describe('Stylable postcss transform (Global)', () => {
                     '/style.st.css': {
                         namespace: 'style',
                         content: `
-                        @keyframes stGlobal(globalName) {
+                        @keyframes st-global(globalName) {
                             from {}
                             to {}
                         }


### PR DESCRIPTION
We were rethinking the naming of our st function (`stGlobal`, `stArray`, `stMap`) and we would like to stick with the native CSS naming conventions ([CSS Functional Notation
](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions)).

Syntax:
```css
selector {
  property: functional-notation( [argument]? [, argument]! );
}
```