### PR TITLE
feat: handle runtime types in a dedicated package

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/template.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/template.js
@@ -1,7 +1,8 @@
 /** @type {import('create-stylable-app').TemplateDefinition} */
 module.exports = {
-    dependencies: ['@stylable/runtime', 'react', 'react-dom'],
+    dependencies: ['react', 'react-dom'],
     devDependencies: [
+        '@stylable/runtime-types',
         '@rollup/plugin-commonjs',
         '@rollup/plugin-html',
         '@rollup/plugin-image',

--- a/packages/create-stylable-app/template/ts-react-rollup/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-rollup/tsconfig.json
@@ -49,7 +49,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    "types": [],                                    /* Type declaration files to be included in compilation. */
+    "types": ["@stylable/runtime-types"],                                    /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */

--- a/packages/create-stylable-app/template/ts-react-rollup/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-rollup/tsconfig.json
@@ -49,7 +49,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    "types": ["@stylable/runtime-types"],                                    /* Type declaration files to be included in compilation. */
+    "types": ["@stylable/runtime-types"],           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */

--- a/packages/create-stylable-app/template/ts-react-rollup/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-rollup/typings/globals.d.ts
@@ -1,10 +1,3 @@
-declare module '*.st.css' {
-    export * from '@stylable/runtime/stylesheet';
-
-    const defaultExport: unknown;
-    export default defaultExport;
-}
-
 declare module '*.png' {
     const urlToFile: string;
     export default urlToFile;

--- a/packages/create-stylable-app/template/ts-react-webpack/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/template.js
@@ -1,7 +1,8 @@
 /** @type {import('create-stylable-app').TemplateDefinition} */
 module.exports = {
-    dependencies: ['@stylable/runtime', 'react', 'react-dom'],
+    dependencies: ['react', 'react-dom'],
     devDependencies: [
+        '@stylable/runtime-types',
         '@stylable/core',
         '@stylable/webpack-plugin',
         '@types/react',

--- a/packages/create-stylable-app/template/ts-react-webpack/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-webpack/tsconfig.json
@@ -49,7 +49,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    "types": [],                                    /* Type declaration files to be included in compilation. */
+    "types": ["@stylable/runtime-types"],                                    /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */

--- a/packages/create-stylable-app/template/ts-react-webpack/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-webpack/tsconfig.json
@@ -49,7 +49,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    "types": ["@stylable/runtime-types"],                                    /* Type declaration files to be included in compilation. */
+    "types": ["@stylable/runtime-types"],           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */

--- a/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
@@ -1,10 +1,3 @@
-declare module '*.st.css' {
-    export * from '@stylable/runtime/stylesheet';
-
-    const defaultExport: unknown;
-    export default defaultExport;
-}
-
 declare module '*.png' {
     const urlToFile: string;
     export default urlToFile;

--- a/packages/runtime-types/LICENSE
+++ b/packages/runtime-types/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright 2021 Wix.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/runtime-types/README.md
+++ b/packages/runtime-types/README.md
@@ -1,0 +1,20 @@
+# @stylable/runtime-types
+
+[![npm version](https://img.shields.io/npm/v/@stylable/runtime-types.svg)](https://www.npmjs.com/package/@stylable/runtime-types)
+
+`@stylable/runtime-types` provides the utility types for the runtime experience.
+Regardless we highly encourage to use the Stylable CLI declaration types instead.
+
+## Usage
+
+Add `@stylable/runtime-types` to your `tsconfig.json`
+
+```json
+{
+    "compilerOptions": {
+        //...
+        "types": ["@stylable/runtime-types"],           
+        //...
+    }
+}
+```

--- a/packages/runtime-types/README.md
+++ b/packages/runtime-types/README.md
@@ -9,7 +9,7 @@ Regardless we highly encourage to use the Stylable CLI declaration types instead
 
 Add `@stylable/runtime-types` to your `tsconfig.json`
 
-```json
+```jsonc
 {
     "compilerOptions": {
         //...

--- a/packages/runtime-types/index.d.ts
+++ b/packages/runtime-types/index.d.ts
@@ -1,0 +1,6 @@
+declare module '*.st.css' {
+    export * from '@stylable/runtime/stylesheet';
+
+    const defaultExport: unknown;
+    export default defaultExport;
+}

--- a/packages/runtime-types/package.json
+++ b/packages/runtime-types/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@stylable/runtime-types",
+  "version": "4.6.0",
+  "description": "Stylable runtime types",
+  "typings": "index.d.ts",
+  "scripts": {},
+  "files": [
+    "index.d.ts"
+  ],
+  "engines": {
+    "node": ">=12"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Wix.com",
+  "license": "MIT",
+  "dependencies": {
+    "@stylable/runtime": "^4.6.0"
+  }
+}


### PR DESCRIPTION
Today when using stylable with typescript, the user will have to declare the `*.st.css` types globally.
This has a lot of limitations. The biggest one is that we have no control over it.

For example, if we support another extension, all the users will have to add the same code for `*.stcss` (https://github.com/wix/stylable/issues/1216).

This PR suggests creating a dedicated package that will handle all the `runtime-types`, and the user will need to specify it inside the `types` array inside the `tsconfig.json`.



```jsonc
{
    "compilerOptions": {
        //...
        "types": ["@stylable/runtime-types"],           
        //...
    }
}
```