### PR TITLE
feat(cli): use stylable diagnostics in the code-mod CLI

### DIFF
--- a/packages/cli/src/code-mods/apply-code-mods.ts
+++ b/packages/cli/src/code-mods/apply-code-mods.ts
@@ -1,5 +1,5 @@
 import { Diagnostic, Diagnostics } from '@stylable/core';
-import { Root, parse } from 'postcss';
+import { Root, parse, CssSyntaxError } from 'postcss';
 import { stImportToAtImport } from './st-import-to-at-import';
 
 export type CodeMod = (ast: Root, diagnostics: Diagnostics) => void;
@@ -8,9 +8,42 @@ export const registeredMods: Map<string, CodeMod> = new Map([
     ['st-import-to-at-import', stImportToAtImport],
 ]);
 
-export function applyCodeMods(css: string, mods: Set<{ id: string; apply: CodeMod }>) {
+interface ApplyCodeModsFailure {
+    type: 'failure';
+    error: CssSyntaxError | Error;
+}
+
+interface ApplyCodeModsSuccess {
+    type: 'success';
+    css: string;
+    reports: Map<string, Diagnostic[]>;
+}
+
+type ApplyCodeModsResult = ApplyCodeModsSuccess | ApplyCodeModsFailure;
+
+export function applyCodeMods(
+    css: string,
+    mods: Set<{ id: string; apply: CodeMod }>
+): ApplyCodeModsResult {
     const reports = new Map<string, Diagnostic[]>();
-    const ast = parse(css);
+    let ast: Root;
+
+    try {
+        ast = parse(css);
+    } catch (error) {
+        if (error instanceof CssSyntaxError || error instanceof Error) {
+            return {
+                type: 'failure',
+                error,
+            };
+        } else {
+            return {
+                type: 'failure',
+                error: new Error(String(error)),
+            };
+        }
+    }
+
     for (const { id, apply } of mods) {
         const diagnostics = new Diagnostics();
 
@@ -20,8 +53,8 @@ export function applyCodeMods(css: string, mods: Set<{ id: string; apply: CodeMo
             reports.set(id, diagnostics.reports);
         }
     }
-
     return {
+        type: 'success',
         css: ast.toString(),
         reports,
     };

--- a/packages/cli/src/code-mods/apply-code-mods.ts
+++ b/packages/cli/src/code-mods/apply-code-mods.ts
@@ -1,20 +1,23 @@
+import { Diagnostic, Diagnostics } from '@stylable/core';
 import { Root, parse } from 'postcss';
 import { stImportToAtImport } from './st-import-to-at-import';
 
-export type CodeMod = (ast: Root, messages: string[]) => void;
+export type CodeMod = (ast: Root, diagnostics: Diagnostics) => void;
 
 export const registeredMods: Map<string, CodeMod> = new Map([
     ['st-import-to-at-import', stImportToAtImport],
 ]);
 
 export function applyCodeMods(css: string, mods: Set<{ id: string; apply: CodeMod }>) {
-    const reports = new Map<string, string[]>();
+    const reports = new Map<string, Diagnostic[]>();
     const ast = parse(css);
     for (const { id, apply } of mods) {
-        const messages: string[] = [];
-        apply(ast, messages);
-        if (messages.length) {
-            reports.set(id, messages);
+        const diagnostics = new Diagnostics();
+
+        apply(ast, diagnostics);
+
+        if (diagnostics.reports.length) {
+            reports.set(id, diagnostics.reports);
         }
     }
 

--- a/packages/cli/src/code-mods/code-mods.ts
+++ b/packages/cli/src/code-mods/code-mods.ts
@@ -49,9 +49,14 @@ export function codeMods({ fs, rootDir, extension, mods, log }: BuildOptions) {
     for (const filePath of files) {
         const { css, reports } = applyCodeMods(fs.readFileSync(filePath).toString(), loadedMods);
         if (reports.size) {
-            for (const [modName, messages] of reports) {
-                for (const message of messages) {
-                    log(`[${modName}]`, `${filePath}: ${message}`);
+            for (const [modName, diagnosticsReports] of reports) {
+                for (const report of diagnosticsReports) {
+                    const error = report.node.error(report.message, report.options);
+
+                    log(
+                        `[${modName}]`,
+                        `${filePath}: ${report.message}\n${error.showSourceCode()}`
+                    );
                 }
             }
             skipped.push(filePath);

--- a/packages/cli/src/code-mods/code-mods.ts
+++ b/packages/cli/src/code-mods/code-mods.ts
@@ -47,22 +47,30 @@ export function codeMods({ fs, rootDir, extension, mods, log }: BuildOptions) {
     const skipped = [];
     const finished = [];
     for (const filePath of files) {
-        const { css, reports } = applyCodeMods(fs.readFileSync(filePath).toString(), loadedMods);
-        if (reports.size) {
-            for (const [modName, diagnosticsReports] of reports) {
-                for (const report of diagnosticsReports) {
-                    const error = report.node.error(report.message, report.options);
+        const result = applyCodeMods(fs.readFileSync(filePath).toString(), loadedMods);
 
-                    log(
-                        `[${modName}]`,
-                        `${filePath}: ${report.message}\n${error.showSourceCode()}`
-                    );
-                }
-            }
+        if (result.type === 'failure') {
+            log(`${filePath}: failed to parse\n${result.error.toString()}`);
             skipped.push(filePath);
         } else {
-            fs.writeFileSync(filePath, css);
-            finished.push(filePath);
+            const { css, reports } = result;
+
+            if (reports.size) {
+                for (const [modName, diagnosticsReports] of reports) {
+                    for (const report of diagnosticsReports) {
+                        const error = report.node.error(report.message, report.options);
+
+                        log(
+                            `[${modName}]`,
+                            `${filePath}: ${report.message}\n${error.showSourceCode()}`
+                        );
+                    }
+                }
+                skipped.push(filePath);
+            } else {
+                fs.writeFileSync(filePath, css);
+                finished.push(filePath);
+            }
         }
     }
 

--- a/packages/cli/src/code-mods/st-import-to-at-import.ts
+++ b/packages/cli/src/code-mods/st-import-to-at-import.ts
@@ -4,16 +4,14 @@ import postcss, { Root, AtRule } from 'postcss';
 export function stImportToAtImport(ast: Root, diagnostics: Diagnostics) {
     ast.walkRules((rule) => {
         if (rule.selector === ':import') {
-            const currentDiagnostics = new Diagnostics();
-            const importObj = parsePseudoImport(rule, '*', currentDiagnostics);
-            const fatalDiagnostics = currentDiagnostics.reports.filter(
-                (report) => report.type !== 'info'
-            );
+            const importObj = parsePseudoImport(rule, '*', diagnostics);
+            const fatalDiagnostics = diagnostics.reports.filter((report) => report.type !== 'info');
 
             if (fatalDiagnostics.length) {
-                diagnostics.reports.push(...fatalDiagnostics);
+                diagnostics.reports = fatalDiagnostics;
             } else {
                 rule.replaceWith(createAtImport(importObj));
+                diagnostics.reports = [];
             }
         }
     });

--- a/packages/cli/src/code-mods/st-import-to-at-import.ts
+++ b/packages/cli/src/code-mods/st-import-to-at-import.ts
@@ -1,13 +1,17 @@
 import { parsePseudoImport, Diagnostics, Imported } from '@stylable/core';
 import postcss, { Root, AtRule } from 'postcss';
 
-export function stImportToAtImport(ast: Root, messages: string[]) {
+export function stImportToAtImport(ast: Root, diagnostics: Diagnostics) {
     ast.walkRules((rule) => {
         if (rule.selector === ':import') {
-            const diagnostics = new Diagnostics();
-            const importObj = parsePseudoImport(rule, '*', diagnostics);
-            if (diagnostics.reports.some((report) => report.type !== 'info')) {
-                messages.push(`failed to parse/replace :import`);
+            const currentDiagnostics = new Diagnostics();
+            const importObj = parsePseudoImport(rule, '*', currentDiagnostics);
+            const fatalDiagnostics = currentDiagnostics.reports.filter(
+                (report) => report.type !== 'info'
+            );
+
+            if (fatalDiagnostics.length) {
+                diagnostics.reports.push(...fatalDiagnostics);
             } else {
                 rule.replaceWith(createAtImport(importObj));
             }

--- a/packages/cli/test/cli-codemod.spec.ts
+++ b/packages/cli/test/cli-codemod.spec.ts
@@ -1,3 +1,4 @@
+import { processorWarnings } from '@stylable/core';
 import { expect } from 'chai';
 import { createTempDirectory, ITempDirectory } from 'create-temp-directory';
 import { populateDirectorySync, loadDirSync } from './test-kit/cli-test-kit';
@@ -39,6 +40,27 @@ describe('Stylable Cli Code Mods', () => {
             expect(dirContent['style.st.css']).equal(
                 '@st-import Name, [name1 as name1Alias, name2, --var1, keyframes(kf1 as kf1Alias, kf2, kf3, kf4)] from "./x";'
             );
+        });
+
+        it('handle import error', () => {
+            populateDirectorySync(tempDir.path, {
+                'package.json': `{"name": "test", "version": "0.0.0"}`,
+                'style.st.css': `:import {-st-from: './x.st.css'; -st-from: './y.st.css';}`,
+            });
+
+            const { stdout } = runCliCodeMod([
+                '--rootDir',
+                tempDir.path,
+                '--mods',
+                'st-import-to-at-import',
+            ]);
+
+            const dirContent = loadDirSync(tempDir.path);
+
+            expect(dirContent['style.st.css']).equal(
+                `:import {-st-from: './x.st.css'; -st-from: './y.st.css';}`
+            );
+            expect(stdout).to.match(new RegExp(processorWarnings.MULTIPLE_FROM_IN_IMPORT()));
         });
     });
 });

--- a/packages/cli/test/cli-codemod.spec.ts
+++ b/packages/cli/test/cli-codemod.spec.ts
@@ -26,6 +26,26 @@ describe('Stylable Cli Code Mods', () => {
         expect(dirContent['style.st.css']).equal('@st-import Name from "./x";');
     });
 
+    it('should handle parse failure', () => {
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            'style.st.css': `:import {-st-from: './x' -st-default: Name}`, // missing semi column
+        });
+
+        const { stdout } = runCliCodeMod([
+            '--rootDir',
+            tempDir.path,
+            '--mods',
+            'st-import-to-at-import',
+        ]);
+
+        const dirContent = loadDirSync(tempDir.path);
+
+        expect(dirContent['style.st.css']).equal(`:import {-st-from: './x' -st-default: Name}`);
+        expect(stdout).to.match(/failed to parse/);
+        expect(stdout).to.match(/CssSyntaxError: <css input>:1:20: Missed semicolon/);
+    });
+
     describe('st-import-to-at-import', () => {
         it('handle all named cases', () => {
             populateDirectorySync(tempDir.path, {


### PR DESCRIPTION
This PR uses the diagnostics of stylable inside the code-mod.
Regardless it handles parsing errors that the code-mod did not handle before.