### PR TITLE
fix(node): add resolver cache to require hook

### DIFF
--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -95,10 +95,11 @@ export class Stylable {
         );
         this.resolvePath = resolvePath;
         this.fileProcessor = fileProcessor;
-        this.resolver = new StylableResolver(this.fileProcessor, this.requireModule);
+        this.resolver = this.createResolver();
     }
     public initCache() {
         this.resolverCache = new Map();
+        this.resolver = this.createResolver();
     }
     public createResolver({
         requireModule,

--- a/packages/node/src/require-hook.ts
+++ b/packages/node/src/require-hook.ts
@@ -28,6 +28,7 @@ export function attachHook({
             fileSystem: fs,
             requireModule: require,
             resolveNamespace,
+            resolverCache: new Map(),
             ...stylableConfig,
         },
         { runtimePath }


### PR DESCRIPTION
10x to @AviVahl we found that we are missing `resolverCache` in `@stylable/node`, that cause a regression in performance when we disabled the timed cache.