### PR TITLE
fix(core): js mixin re-export arguments parsing

### DIFF
--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -406,7 +406,7 @@ function reParseMixinNamedArgs(
     const options =
         mix.mixin.valueNode?.type === 'function'
             ? strategies.named(mix.mixin.valueNode, (message, options) => {
-                  diagnostics.warn(rule, message, options);
+                  diagnostics.warn(mix.mixin.originDecl || rule, message, options);
               })
             : (mix.mixin.options as Record<string, string>) || {};
 
@@ -427,7 +427,7 @@ function reParseMixinArgs(
     const options =
         mix.mixin.valueNode?.type === 'function'
             ? strategies.args(mix.mixin.valueNode, (message, options) => {
-                  diagnostics.warn(rule, message, options);
+                  diagnostics.warn(mix.mixin.originDecl || rule, message, options);
               })
             : Array.isArray(mix.mixin.options)
             ? (mix.mixin.options as { value: string }[])

--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -110,7 +110,7 @@ export function appendMixin(
                 );
             }
         } else {
-            // TODO: error cannot resolve mixin (this might be covered by unknown symbol)
+            // TODO: error cannot resolve mixin - this should be a diagnostic covered by unknown symbol
         }
     }
 }

--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'path';
 import * as postcss from 'postcss';
+import type { Diagnostics } from './diagnostics';
 
 import { resolveArgumentsValue } from './functions';
 import { cssObjectToAst } from './parser';
@@ -9,7 +10,7 @@ import type { RefedMixin, SRule, StylableMeta } from './stylable-processor';
 import type { CSSResolve } from './stylable-resolver';
 import type { StylableTransformer } from './stylable-transformer';
 import { createSubsetAst, isValidDeclaration, mergeRules } from './stylable-utils';
-import { valueMapping, mixinDeclRegExp } from './stylable-value-parsers';
+import { valueMapping, mixinDeclRegExp, strategies } from './stylable-value-parsers';
 
 export const mixinWarnings = {
     FAILED_TO_APPLY_MIXIN(error: string) {
@@ -61,16 +62,24 @@ export function appendMixin(
 
     const local = meta.mappedSymbols[mix.mixin.type];
     if (local && (local._kind === 'class' || local._kind === 'element')) {
-        handleLocalClassMixin(mix, transformer, meta, variableOverride, cssVarsMapping, path, rule);
+        handleLocalClassMixin(
+            reParseMixinNamedArgs(mix, rule, transformer.diagnostics),
+            transformer,
+            meta,
+            variableOverride,
+            cssVarsMapping,
+            path,
+            rule
+        );
     } else {
-        const resolvedMixin = transformer.resolver.resolve(mix.ref);
+        const resolvedMixin = transformer.resolver.deepResolve(mix.ref);
         if (resolvedMixin) {
             if (resolvedMixin._kind === 'js') {
                 if (typeof resolvedMixin.symbol === 'function') {
                     try {
                         handleJSMixin(
                             transformer,
-                            mix,
+                            reParseMixinArgs(mix, rule, transformer.diagnostics),
                             resolvedMixin.symbol,
                             meta,
                             rule,
@@ -92,7 +101,7 @@ export function appendMixin(
             } else {
                 handleImportedCSSMixin(
                     transformer,
-                    mix,
+                    reParseMixinNamedArgs(mix, rule, transformer.diagnostics),
                     rule,
                     meta,
                     path,
@@ -101,7 +110,7 @@ export function appendMixin(
                 );
             }
         } else {
-            // TODO: error cannot resolve mixin
+            // TODO: error cannot resolve mixin (this might be covered by unknown symbol)
         }
     }
 }
@@ -386,4 +395,49 @@ function filterPartialMixinDecl(
             }
         }
     });
+}
+
+/** this is a workaround for parsing the mixin args too early  */
+function reParseMixinNamedArgs(
+    mix: RefedMixin,
+    rule: postcss.Rule,
+    diagnostics: Diagnostics
+): RefedMixin {
+    const options =
+        mix.mixin.valueNode?.type === 'function'
+            ? strategies.named(mix.mixin.valueNode, (message, options) => {
+                  diagnostics.warn(rule, message, options);
+              })
+            : (mix.mixin.options as Record<string, string>) || {};
+
+    return {
+        ...mix,
+        mixin: {
+            ...mix.mixin,
+            options,
+        },
+    };
+}
+
+function reParseMixinArgs(
+    mix: RefedMixin,
+    rule: postcss.Rule,
+    diagnostics: Diagnostics
+): RefedMixin {
+    const options =
+        mix.mixin.valueNode?.type === 'function'
+            ? strategies.args(mix.mixin.valueNode, (message, options) => {
+                  diagnostics.warn(rule, message, options);
+              })
+            : Array.isArray(mix.mixin.options)
+            ? (mix.mixin.options as { value: string }[])
+            : [];
+
+    return {
+        ...mix,
+        mixin: {
+            ...mix.mixin,
+            options,
+        },
+    };
 }

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -795,12 +795,17 @@ export class StylableProcessor {
              * This functionality is broken we don't know what strategy to choose here.
              * Should be fixed when we refactor to the new flow
              */
-            SBTypesParsers[decl.prop](decl, (type) => {
-                const symbol = this.meta.mappedSymbols[type];
-                return symbol?._kind === 'import' && !symbol.import.from.match(/.css$/)
-                    ? 'args'
-                    : 'named';
-            }).forEach((mixin) => {
+            SBTypesParsers[decl.prop](
+                decl,
+                (type) => {
+                    const symbol = this.meta.mappedSymbols[type];
+                    return symbol?._kind === 'import' && !symbol.import.from.match(/.css$/)
+                        ? 'args'
+                        : 'named';
+                },
+                this.diagnostics,
+                false
+            ).forEach((mixin) => {
                 const mixinRefSymbol = this.meta.mappedSymbols[mixin.type];
                 if (
                     mixinRefSymbol &&

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -791,21 +791,16 @@ export class StylableProcessor {
             }
         } else if (decl.prop === valueMapping.mixin || decl.prop === valueMapping.partialMixin) {
             const mixins: RefedMixin[] = [];
-            SBTypesParsers[decl.prop](
-                decl,
-                (type) => {
-                    const mixinRefSymbol = this.meta.mappedSymbols[type];
-                    if (
-                        mixinRefSymbol &&
-                        mixinRefSymbol._kind === 'import' &&
-                        !mixinRefSymbol.import.from.match(/.css$/)
-                    ) {
-                        return 'args';
-                    }
-                    return 'named';
-                },
-                this.diagnostics
-            ).forEach((mixin) => {
+            /**
+             * This functionality is broken we don't know what strategy to choose here.
+             * Should be fixed when we refactor to the new flow
+             */
+            SBTypesParsers[decl.prop](decl, (type) => {
+                const symbol = this.meta.mappedSymbols[type];
+                return symbol?._kind === 'import' && !symbol.import.from.match(/.css$/)
+                    ? 'args'
+                    : 'named';
+            }).forEach((mixin) => {
                 const mixinRefSymbol = this.meta.mappedSymbols[mixin.type];
                 if (
                     mixinRefSymbol &&

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -41,6 +41,7 @@ export interface MixinValue {
     options: Array<{ value: string }> | Record<string, string>;
     partial?: boolean;
     valueNode?: FunctionNode | WordNode;
+    originDecl?: postcss.Declaration;
 }
 
 export interface ArgValue {
@@ -162,13 +163,16 @@ export const SBTypesParsers = {
     '-st-mixin'(
         mixinNode: postcss.Declaration,
         strategy: (type: string) => 'named' | 'args',
-        diagnostics?: Diagnostics
+        diagnostics?: Diagnostics,
+        emitStrategyDiagnostics = true
     ) {
         const ast = postcssValueParser(mixinNode.value);
         const mixins: Array<MixinValue> = [];
 
         function reportWarning(message: string, options?: { word: string }) {
-            diagnostics?.warn(mixinNode, message, options);
+            if (emitStrategyDiagnostics) {
+                diagnostics?.warn(mixinNode, message, options);
+            }
         }
 
         ast.nodes.forEach((node) => {
@@ -177,12 +181,14 @@ export const SBTypesParsers = {
                     type: node.value,
                     options: strategies[strategy(node.value)](node, reportWarning),
                     valueNode: node,
+                    originDecl: mixinNode,
                 });
             } else if (node.type === 'word') {
                 mixins.push({
                     type: node.value,
                     options: strategy(node.value) === 'named' ? {} : [],
                     valueNode: node,
+                    originDecl: mixinNode,
                 });
             } else if (node.type === 'string') {
                 diagnostics?.error(mixinNode, valueParserWarnings.VALUE_CANNOT_BE_STRING(), {

--- a/packages/core/src/stylable-value-parsers.ts
+++ b/packages/core/src/stylable-value-parsers.ts
@@ -2,6 +2,8 @@ import type * as postcss from 'postcss';
 import postcssValueParser, {
     ParsedValue as PostCSSParsedValue,
     FunctionNode,
+    WordNode,
+    Node as ValueNode,
 } from 'postcss-value-parser';
 import type { Diagnostics } from './diagnostics';
 import { processPseudoStates } from './pseudo-states';
@@ -38,6 +40,7 @@ export interface MixinValue {
     type: string;
     options: Array<{ value: string }> | Record<string, string>;
     partial?: boolean;
+    valueNode?: FunctionNode | WordNode;
 }
 
 export interface ArgValue {
@@ -165,25 +168,24 @@ export const SBTypesParsers = {
         const mixins: Array<MixinValue> = [];
 
         function reportWarning(message: string, options?: { word: string }) {
-            if (diagnostics) {
-                diagnostics.warn(mixinNode, message, options);
-            }
+            diagnostics?.warn(mixinNode, message, options);
         }
 
-        ast.nodes.forEach((node: any) => {
-            const strat = strategy(node.value);
+        ast.nodes.forEach((node) => {
             if (node.type === 'function') {
                 mixins.push({
                     type: node.value,
-                    options: strategies[strat](node, reportWarning),
+                    options: strategies[strategy(node.value)](node, reportWarning),
+                    valueNode: node,
                 });
             } else if (node.type === 'word') {
                 mixins.push({
                     type: node.value,
-                    options: strat === 'named' ? {} : [],
+                    options: strategy(node.value) === 'named' ? {} : [],
+                    valueNode: node,
                 });
-            } else if (node.type === 'string' && diagnostics) {
-                diagnostics.error(mixinNode, valueParserWarnings.VALUE_CANNOT_BE_STRING(), {
+            } else if (node.type === 'string') {
+                diagnostics?.error(mixinNode, valueParserWarnings.VALUE_CANNOT_BE_STRING(), {
                     word: mixinNode.value,
                 });
             }
@@ -332,9 +334,9 @@ export function getStringValue(nodes: ParsedValue | ParsedValue[]): string {
     });
 }
 
-export function groupValues(nodes: any[], divType = 'div') {
-    const grouped: any[] = [];
-    let current: any[] = [];
+export function groupValues(nodes: ValueNode[], divType = 'div') {
+    const grouped: ValueNode[][] = [];
+    let current: ValueNode[] = [];
 
     nodes.forEach((n: any) => {
         if (n.type === divType) {

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -317,20 +317,27 @@ describe('diagnostics: warnings and errors', () => {
             });
 
             it('should return a warning for a CSS mixin using un-named params', () => {
-                expectWarnings(
-                    `
-                    .mixed {
-                        color: red;
-                    }
-                    .gaga{
-                        |-st-mixin: mixed($1$)|;
-                    }
-
-                `,
+                expectWarningsFromTransform(
+                    {
+                        entry: '/style.st.css',
+                        files: {
+                            '/style.st.css': {
+                                content: `
+                                .mixed {
+                                    color: red;
+                                }
+                                .gaga{
+                                    |-st-mixin: mixed($1$)|;
+                                }
+            
+                            `,
+                            },
+                        },
+                    },
                     [
                         {
                             message: valueParserWarnings.CSS_MIXIN_FORCE_NAMED_PARAMS(),
-                            file: 'main.css',
+                            file: '/style.st.css',
                         },
                     ]
                 );

--- a/packages/core/test/mixins/js-mixins.spec.ts
+++ b/packages/core/test/mixins/js-mixins.spec.ts
@@ -166,6 +166,44 @@ describe('Javascript Mixins', () => {
         expect(rule.nodes[0].toString()).to.equal('color: red');
     });
 
+    it('exported js mixin via st.css file (with params)', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./index.st.css";
+                        -st-named: mixin;
+                    }
+                    .container {
+                        -st-mixin: mixin(red, green);
+                    }
+                `,
+                },
+                '/index.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./mixin";
+                        -st-default: mixin;
+                    }
+                `,
+                },
+                '/mixin.js': {
+                    content: `
+                    module.exports = function(params) {
+                        return {
+                            color: params.join(' ')
+                        }
+                    }
+                `,
+                },
+            },
+        });
+        const rule = result.nodes[0] as postcss.Rule;
+        expect(rule.nodes[0].toString()).to.equal('color: red green');
+    });
+
     it('simple mixin with element', () => {
         const result = generateStylableRoot({
             entry: `/style.st.css`,

--- a/packages/core/test/mixins/js-mixins.spec.ts
+++ b/packages/core/test/mixins/js-mixins.spec.ts
@@ -128,6 +128,44 @@ describe('Javascript Mixins', () => {
         expect(rule.nodes[1].toString()).to.equal('color: red');
     });
 
+    it('exported js mixin via st.css file', () => {
+        const result = generateStylableRoot({
+            entry: `/style.st.css`,
+            files: {
+                '/style.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./index.st.css";
+                        -st-named: mixin;
+                    }
+                    .container {
+                        -st-mixin: mixin;
+                    }
+                `,
+                },
+                '/index.st.css': {
+                    content: `
+                    :import {
+                        -st-from: "./mixin";
+                        -st-default: mixin;
+                    }
+                `,
+                },
+                '/mixin.js': {
+                    content: `
+                    module.exports = function() {
+                        return {
+                            color: "red"
+                        }
+                    }
+                `,
+                },
+            },
+        });
+        const rule = result.nodes[0] as postcss.Rule;
+        expect(rule.nodes[0].toString()).to.equal('color: red');
+    });
+
     it('simple mixin with element', () => {
         const result = generateStylableRoot({
             entry: `/style.st.css`,

--- a/packages/core/test/stylable-value-parsers.spec.ts
+++ b/packages/core/test/stylable-value-parsers.spec.ts
@@ -4,17 +4,25 @@ import { SBTypesParsers, valueMapping, Diagnostics } from '@stylable/core';
 import postcssValueParser from 'postcss-value-parser';
 
 const parseMixin = (mixinValue: string) => {
-    return SBTypesParsers[valueMapping.mixin](
+    const mix = SBTypesParsers[valueMapping.mixin](
         postcss.decl({ prop: '', value: mixinValue }),
         () => 'named'
     );
+    mix.forEach((m) => {
+        delete m.originDecl;
+    });
+    return mix;
 };
 
 const parsePartialMixin = (mixinValue: string) => {
-    return SBTypesParsers[valueMapping.partialMixin](
+    const mix = SBTypesParsers[valueMapping.partialMixin](
         postcss.decl({ prop: valueMapping.partialMixin, value: mixinValue }),
         () => 'named'
     );
+    mix.forEach((m) => {
+        delete m.originDecl;
+    });
+    return mix;
 };
 const parseNamedImport = (value: string) =>
     SBTypesParsers[valueMapping.named](value, postcss.decl(), new Diagnostics());

--- a/packages/core/test/stylable-value-parsers.spec.ts
+++ b/packages/core/test/stylable-value-parsers.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as postcss from 'postcss';
 import { SBTypesParsers, valueMapping, Diagnostics } from '@stylable/core';
+import postcssValueParser from 'postcss-value-parser';
 
 const parseMixin = (mixinValue: string) => {
     return SBTypesParsers[valueMapping.mixin](
@@ -132,16 +133,24 @@ describe('stylable-value-parsers', () => {
 
     describe('-st-mixin', () => {
         it('named arguments with no params', () => {
-            expect(parseMixin('Button')).to.eql([{ type: 'Button', options: {} }]);
+            expect(parseMixin('Button')).to.eql([
+                { type: 'Button', options: {}, valueNode: postcssValueParser('Button').nodes[0] },
+            ]);
         });
 
         it('named arguments with empty params', () => {
-            expect(parseMixin('Button()')).to.eql([{ type: 'Button', options: {} }]);
+            expect(parseMixin('Button()')).to.eql([
+                { type: 'Button', options: {}, valueNode: postcssValueParser('Button()').nodes[0] },
+            ]);
         });
 
         it('named arguments with one simple param', () => {
             expect(parseMixin('Button(color red)')).to.eql([
-                { type: 'Button', options: { color: 'red' } },
+                {
+                    type: 'Button',
+                    options: { color: 'red' },
+                    valueNode: postcssValueParser('Button(color red)').nodes[0],
+                },
             ]);
         });
 
@@ -150,6 +159,7 @@ describe('stylable-value-parsers', () => {
                 {
                     type: 'Button',
                     options: { color: 'red', color2: 'green' },
+                    valueNode: postcssValueParser('Button(color red, color2 green)').nodes[0],
                 },
             ]);
         });
@@ -159,6 +169,7 @@ describe('stylable-value-parsers', () => {
                 {
                     type: 'Button',
                     options: { color: 'red' },
+                    valueNode: postcssValueParser('Button(color red,)').nodes[0],
                 },
             ]);
         });
@@ -168,6 +179,7 @@ describe('stylable-value-parsers', () => {
                 {
                     type: 'Button',
                     options: { color: 'red', size: '2px' },
+                    valueNode: postcssValueParser('Button(color red, size 2px,)').nodes[0],
                 },
             ]);
         });
@@ -177,6 +189,7 @@ describe('stylable-value-parsers', () => {
                 {
                     type: 'Button',
                     options: { border: '1px solid red' },
+                    valueNode: postcssValueParser('Button(border 1px solid red)').nodes[0],
                 },
             ]);
         });
@@ -188,6 +201,7 @@ describe('stylable-value-parsers', () => {
                 type: 'Button',
                 options: { border: '1px solid red' },
                 partial: true,
+                valueNode: postcssValueParser('Button(border 1px solid red)').nodes[0],
             },
         ]);
     });


### PR DESCRIPTION
Currently are parsing the arguments of a any mixin in the process step and we figure out the strategy via the import type
if it's `.css` we choose `named` strategy for the rest `args`.

This is wrong since JS mixins can be exported from a stylesheet and then we choose the wrong strategy for them (`named`).
This PR keeps the old parsing of options (hopefully for a shot term) but reparse the args right after we actually know what type of mixin it is.

This PR also fixes an issue that we did not resolve the mixin deeply to figure out the origin.