### PR TITLE
fix(experimental-loader): adopt css-loader API changes

### DIFF
--- a/packages/experimental-loader/package.json
+++ b/packages/experimental-loader/package.json
@@ -9,7 +9,7 @@
     "@stylable/core": "^4.6.0",
     "@stylable/optimizer": "^4.6.0",
     "@stylable/runtime": "^4.6.0",
-    "css-loader": "^6.2.0",
+    "css-loader": "^6.3.0",
     "decache": "^4.6.0"
   },
   "files": [

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -15,6 +15,7 @@ import type { LoaderContext, Loader } from '@stylable/webpack-plugin';
 const { urlParser } = require('css-loader/dist/plugins');
 const { getImportCode, getModuleCode, sort } = require('css-loader/dist/utils');
 const cssLoaderRuntimeApiPath = require.resolve('css-loader/dist/runtime/api');
+const cssLoaderNoSourceMapRuntime  = require.resolve('css-loader/dist/runtime/noSourceMaps')
 const { isUrlRequest, stringifyRequest } = require('loader-utils');
 
 export interface LoaderOptions {
@@ -39,6 +40,7 @@ interface UrlReplacement {
     needQuotes: boolean;
 }
 interface LoaderImport {
+    type: string;
     importName: string;
     url: string;
     index: number;
@@ -87,11 +89,19 @@ const stylableLoader: Loader = function (content) {
 
     const urlPluginImports: LoaderImport[] = [
         {
+            type: 'api_import',
             importName: '___CSS_LOADER_API_IMPORT___',
             url: stringifyRequest(this, cssLoaderRuntimeApiPath),
             index: -1,
         },
+        {
+            type: 'api_sourcemap_import',
+            importName: '___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___',
+            url: stringifyRequest(this, cssLoaderNoSourceMapRuntime),
+            index: 0,
+        },
     ];
+
     const urlReplacements: UrlReplacement[] = [];
 
     const urlResolver = (this as any).getResolve({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,20 +2450,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.2.0.tgz#9663d9443841de957a3cb9bcea2eda65b3377071"
-  integrity sha512-/rvHfYRjIpymZblf49w8jYcRo2y9gj6rV8UroHGmBxKrIyGLokpycyKzp9OkitvqT29ZSpzJ0Ic7SpnJX3sC8g==
-  dependencies:
-    icss-utils "^5.1.0"
-    postcss "^8.2.15"
-    postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.0"
-    postcss-modules-scope "^3.0.0"
-    postcss-modules-values "^4.0.0"
-    postcss-value-parser "^4.1.0"
-    semver "^7.3.5"
-
 css-loader@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.3.0.tgz#334d3500ff0a0c14cfbd4b0670088dbb5b5c1530"


### PR DESCRIPTION
Use the new no source map runtime of css-loader@6.3.0