### PR TITLE
fix(templates): pin to eslint@7

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/template.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/template.js
@@ -14,7 +14,7 @@ module.exports = {
         '@types/react-dom',
         '@typescript-eslint/eslint-plugin',
         '@typescript-eslint/parser',
-        'eslint',
+        'eslint@7',
         'eslint-config-prettier',
         'eslint-plugin-react',
         'eslint-plugin-react-hooks',

--- a/packages/create-stylable-app/template/ts-react-webpack/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/template.js
@@ -12,7 +12,7 @@ module.exports = {
         'eslint-plugin-react',
         'eslint-plugin-react-hooks',
         'eslint-plugin-stylable',
-        'eslint',
+        'eslint@7',
         'html-webpack-plugin',
         'rimraf',
         'serve',


### PR DESCRIPTION
until `eslint-plugin-react` and `eslint-plugin-react-hooks` release `eslint@8` compatible versions