### PR TITLE
feat(webpack-extensions): add ability to generate named exports in manifest index

### DIFF
--- a/packages/webpack-extensions/src/create-metadata-stylesheet.ts
+++ b/packages/webpack-extensions/src/create-metadata-stylesheet.ts
@@ -1,22 +1,15 @@
-import {
-    Stylable,
-    StylableMeta,
-    valueMapping,
-    Imported,
-    CSSResolve,
-    JSResolve,
-} from '@stylable/core';
+import { Stylable, StylableMeta, valueMapping } from '@stylable/core';
 import type { Rule, ChildNode, AtRule } from 'postcss';
+import type { Metadata, ResolvedImport } from './types';
 import { hashContent } from './hash-content-util';
 
 export function createMetadataForStylesheet(
     stylable: Stylable,
     content: string,
     resourcePath: string,
-    exposeNamespaceMapping = true
-) {
-    const meta = stylable.fileProcessor.processContent(content, resourcePath);
-
+    exposeNamespaceMapping = true,
+    meta = stylable.fileProcessor.processContent(content, resourcePath)
+): Metadata {
     const usedMeta = collectDependenciesDeep(stylable, meta);
 
     const hashes = createContentHashPerMeta(usedMeta.keys());
@@ -109,11 +102,6 @@ export function createContentHashPerMeta(usedMeta: Iterable<StylableMeta>) {
     }
     return hashes;
 }
-
-export type ResolvedImport = {
-    stImport: Imported;
-    resolved: CSSResolve | JSResolve | null;
-};
 
 export function collectDependenciesDeep(
     stylable: Stylable,

--- a/packages/webpack-extensions/src/index.ts
+++ b/packages/webpack-extensions/src/index.ts
@@ -25,5 +25,9 @@ export {
 } from './component-metadata-builder';
 export { hashContent } from './hash-content-util';
 export { LoaderOptions, metadataLoaderLocation } from './stylable-metadata-loader';
-export { Options, StylableManifestPlugin } from './stylable-manifest-plugin';
+export {
+    Options,
+    StylableManifestPlugin,
+    generateCssVarsNamedExport,
+} from './stylable-manifest-plugin';
 export { Manifest, Metadata } from './types';

--- a/packages/webpack-extensions/src/index.ts
+++ b/packages/webpack-extensions/src/index.ts
@@ -28,6 +28,6 @@ export { LoaderOptions, metadataLoaderLocation } from './stylable-metadata-loade
 export {
     Options,
     StylableManifestPlugin,
-    generateCssVarsNamedExport,
+    generateCssVarsNamedExports,
 } from './stylable-manifest-plugin';
 export { Manifest, Metadata } from './types';

--- a/packages/webpack-extensions/src/index.ts
+++ b/packages/webpack-extensions/src/index.ts
@@ -25,9 +25,5 @@ export {
 } from './component-metadata-builder';
 export { hashContent } from './hash-content-util';
 export { LoaderOptions, metadataLoaderLocation } from './stylable-metadata-loader';
-export {
-    Options,
-    StylableManifestPlugin,
-    generateCssVarsNamedExports,
-} from './stylable-manifest-plugin';
+export { Options, StylableManifestPlugin } from './stylable-manifest-plugin';
 export { Manifest, Metadata } from './types';

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -44,7 +44,7 @@ const defaultOptions: Options = {
     },
 };
 
-export function generateCssVarsNamedExport(name: string, meta: StylableMeta) {
+export function generateCssVarsNamedExports(name: string, meta: StylableMeta) {
     return Object.keys(meta.cssVars)
         .map((varName) => `${varName} as --${name}-${varName.slice(2)}`)
         .join(',');

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -14,7 +14,7 @@ export interface Options {
     packageAlias: Record<string, string>;
     contentHashLength?: number;
     exposeNamespaceMapping: boolean;
-    generateVarsExports: boolean;
+    generateCSSVarsExports: boolean;
     resolveNamespace(namespace: string, filePath: string): string;
     filterComponents(resourcePath: string): boolean;
     getCompId(resourcePath: string): string;
@@ -30,7 +30,7 @@ const defaultOptions: Options = {
     packageAlias: {},
     resolveNamespace,
     exposeNamespaceMapping: true,
-    generateVarsExports: false,
+    generateCSSVarsExports: false,
     filterComponents(resourcePath) {
         return resourcePath.endsWith('.comp.st.css');
     },
@@ -87,7 +87,7 @@ export class StylableManifestPlugin {
     private emitManifest(metadataList: MetadataList, compilation: Compilation) {
         const manifest = metadataList.reduce<Manifest>(
             (manifest, { meta, compId, metadata }) => {
-                const cssVars = this.options.generateVarsExports
+                const cssVars = this.options.generateCSSVarsExports
                     ? generateCssVarsNamedExports(compId, meta)
                     : null;
                 Object.assign(manifest.stylesheetMapping, metadata.stylesheetMapping);

--- a/packages/webpack-extensions/src/types.ts
+++ b/packages/webpack-extensions/src/types.ts
@@ -1,5 +1,8 @@
+import type { CSSResolve, Imported, JSResolve, StylableMeta } from '@stylable/core';
+
 export interface Metadata {
     entry: string;
+    usedMeta: Map<StylableMeta, ResolvedImport[]>;
     stylesheetMapping: Record<string, string>;
     namespaceMapping?: Record<string, string>;
 }
@@ -12,3 +15,14 @@ export interface Manifest {
     componentsEntries: Record<string, string>;
     componentsIndex: string;
 }
+
+export type MetadataList = Array<{
+    meta: StylableMeta;
+    compId: string;
+    metadata: Metadata;
+}>;
+
+export type ResolvedImport = {
+    stImport: Imported;
+    resolved: CSSResolve | JSResolve | null;
+};

--- a/packages/webpack-extensions/test/e2e/manifest.css-vars.spec.ts
+++ b/packages/webpack-extensions/test/e2e/manifest.css-vars.spec.ts
@@ -1,0 +1,64 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { hashContent } from '@stylable/webpack-extensions';
+import { EOL } from 'os';
+
+const project = 'manifest-plugin';
+const projectDir = dirname(
+    require.resolve(`@stylable/webpack-extensions/test/e2e/projects/${project}/webpack.config`)
+);
+
+describe(`${project} - manifest`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir,
+            launchOptions: {
+                // headless: false
+            },
+            configName: 'webpack.css-vars.config',
+            webpackOptions: {
+                output: { path: join(projectDir, 'dist3') },
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('Should generate manifest for the current build', () => {
+        const assets = projectRunner.getBuildAssets();
+        const manifestKey = Object.keys(assets).find((key) => key.startsWith('stylable.manifest'))!;
+        const source = assets[manifestKey].source();
+
+        const compContent = readFileSync(
+            join(projectRunner.projectDir, 'Button.comp.st.css'),
+            'utf-8'
+        );
+        const commonContent = readFileSync(
+            join(projectRunner.projectDir, 'common.st.css'),
+            'utf-8'
+        );
+        const commonHash = hashContent(commonContent);
+        const compHash = hashContent(compContent);
+
+        expect(JSON.parse(source)).to.deep.include({
+            name: 'manifest-plugin-test',
+            version: '0.0.0-test',
+            componentsIndex: `:import{-st-from: "/${compHash}.st.css";-st-default: Button;-st-named:--myColor as --Button-myColor;} .root Button{}${EOL}`,
+            componentsEntries: { Button: `/${compHash}.st.css` },
+            stylesheetMapping: {
+                [`/${compHash}.st.css`]: compContent.replace(
+                    './common.st.css',
+                    `/${commonHash}.st.css`
+                ),
+                [`/${commonHash}.st.css`]: commonContent,
+            },
+            namespaceMapping: {
+                [`/${commonHash}.st.css`]: 'common911354609',
+                [`/${compHash}.st.css`]: 'Buttoncomp1090430236',
+            },
+        });
+    });
+});

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/Button.comp.st.css
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/Button.comp.st.css
@@ -4,5 +4,6 @@
 }
 
 .root {
+    --myColor: red;
     color: value(myColor)
 }

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
@@ -1,8 +1,5 @@
 const { stylableLoaders } = require('@stylable/experimental-loader');
-const {
-    StylableManifestPlugin,
-    generateCssVarsNamedExports,
-} = require('@stylable/webpack-extensions');
+const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
@@ -16,7 +13,7 @@ module.exports = {
     plugins: [
         new StylableManifestPlugin({
             package: require('./package.json'),
-            generateNamedExports: generateCssVarsNamedExports,
+            generateVarsExports: true,
         }),
     ],
     module: {

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
@@ -1,0 +1,30 @@
+const { stylableLoaders } = require('@stylable/experimental-loader');
+const {
+    StylableManifestPlugin,
+    generateCssVarsNamedExport,
+} = require('@stylable/webpack-extensions');
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    entry: require.resolve('./index'),
+    output: {
+        library: 'metadata',
+    },
+    plugins: [
+        new StylableManifestPlugin({
+            package: require('./package.json'),
+            generateNamedExports: generateCssVarsNamedExport,
+        }),
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.st\.css?$/,
+                use: [stylableLoaders.transform({ exportsOnly: true })],
+            },
+        ],
+    },
+};

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
@@ -1,7 +1,7 @@
 const { stylableLoaders } = require('@stylable/experimental-loader');
 const {
     StylableManifestPlugin,
-    generateCssVarsNamedExport,
+    generateCssVarsNamedExports,
 } = require('@stylable/webpack-extensions');
 
 /** @type {import('webpack').Configuration} */
@@ -16,7 +16,7 @@ module.exports = {
     plugins: [
         new StylableManifestPlugin({
             package: require('./package.json'),
-            generateNamedExports: generateCssVarsNamedExport,
+            generateNamedExports: generateCssVarsNamedExports,
         }),
     ],
     module: {

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/webpack.css-vars.config.js
@@ -13,7 +13,7 @@ module.exports = {
     plugins: [
         new StylableManifestPlugin({
             package: require('./package.json'),
-            generateVarsExports: true,
+            generateCSSVarsExports: true,
         }),
     ],
     module: {


### PR DESCRIPTION
In order to allow import of named symbols inside variant files, generated by editing tools. This PR added the ability to generate the propper exports when generating index file in the manifest plugin.

We also provide a helper function `generateCssVarsNamedExports` to generate exports for all css vars of a stylesheet 

- [x] implement for 3.x 