### PR TITLE
feat: max selector ast cache

### DIFF
--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -32,6 +32,9 @@ export function parseSelectorWithCache(
     options: { clone?: boolean } = {}
 ): ImmutableSelectorList {
     if (!selectorAstCache.has(selector)) {
+        if (selectorAstCache.size > 10000) {
+            selectorAstCache.delete(selectorAstCache.keys().next().value);
+        }
         selectorAstCache.set(selector, parseCssSelector(selector));
     }
     const cachedValue = selectorAstCache.get(selector);


### PR DESCRIPTION
This PR keep selector parser cache at 10,000 and removes the oldest cached value when limit is reached. The all cache solution is temporary until we can bring configuration deep into all parts of the process.