### PR TITLE
refactor(core): extend resolver cache entity

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,6 @@ export {
 } from './stylable-utils';
 export {
     CSSResolve,
-    CachedModule,
     JSResolve,
     JsModule,
     StylableResolver,

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -8,8 +8,10 @@ import type { MinimalFS } from './cached-process-file';
 const resolverContext = {};
 
 export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
+    const extensions = [...new Set(['.js', ...resolveOptions?.extensions])];
     const eResolver = ResolverFactory.createResolver({
         ...resolveOptions,
+        extensions,
         useSyncFileSystemCalls: true,
         cache: false,
         fileSystem,

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -8,10 +8,8 @@ import type { MinimalFS } from './cached-process-file';
 const resolverContext = {};
 
 export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
-    const extensions = [...new Set([...resolveOptions?.extensions, '.js'])];
     const eResolver = ResolverFactory.createResolver({
         ...resolveOptions,
-        extensions,
         useSyncFileSystemCalls: true,
         cache: false,
         fileSystem,

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -8,7 +8,7 @@ import type { MinimalFS } from './cached-process-file';
 const resolverContext = {};
 
 export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
-    const extensions = [...new Set(['.js', ...resolveOptions?.extensions])];
+    const extensions = [...new Set([...resolveOptions?.extensions, '.js'])];
     const eResolver = ResolverFactory.createResolver({
         ...resolveOptions,
         extensions,

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -31,24 +31,19 @@ export interface InvalidCachedModule {
     error: unknown;
 }
 
-export type CachedStylableMeta =
-    | InvalidCachedModule
-    | {
-          resolvedPath: string;
-          kind: 'css';
-          value: StylableMeta;
-      };
+export interface CachedStylableMeta {
+    resolvedPath: string;
+    kind: 'css';
+    value: StylableMeta;
+}
 
-export type CachedJsModule =
-    | InvalidCachedModule
-    | {
-          resolvedPath: string;
-          kind: 'js';
-          value: JsModule;
-      };
+export interface CachedJsModule {
+    resolvedPath: string;
+    kind: 'js';
+    value: JsModule;
+}
 
-export type CachedModuleEntity = CachedStylableMeta | CachedJsModule;
-export type CachedModule = CachedModuleEntity['value'];
+export type CachedModuleEntity = InvalidCachedModule | CachedStylableMeta | CachedJsModule;
 export type StylableResolverCache = Map<string, CachedModuleEntity>;
 
 export interface CSSResolve<T extends StylableSymbol = StylableSymbol> {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -30,7 +30,7 @@ export interface InvalidCachedModule {
     value: null;
     error: unknown;
     request: string;
-    context?: string;
+    context: string;
 }
 
 export interface CachedStylableMeta {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -29,6 +29,8 @@ export interface InvalidCachedModule {
     kind: 'js' | 'css';
     value: null;
     error: unknown;
+    request: string;
+    context?: string;
 }
 
 export interface CachedStylableMeta {
@@ -92,7 +94,7 @@ export class StylableResolver {
                 const value = this.fileProcessor.process(resolvedPath, false, context);
                 entity = { kind, value, resolvedPath };
             } catch (error) {
-                entity = { kind, value: null, error };
+                entity = { kind, value: null, error, request, context };
             }
         } else {
             const kind = 'js';
@@ -102,7 +104,7 @@ export class StylableResolver {
                 const value = this.requireModule(resolvedPath);
                 entity = { kind, value, resolvedPath };
             } catch (error) {
-                entity = { kind, value: null, error };
+                entity = { kind, value: null, error, request, context };
             }
         }
 

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -77,7 +77,7 @@ export class StylableResolver {
         protected requireModule: (modulePath: string) => any,
         protected cache?: StylableResolverCache
     ) {}
-    private getModule({ context, request, from }: Imported): CachedModuleEntity {
+    private getModule({ context, request }: Imported): CachedModuleEntity {
         const key = `${context}${safePathDelimiter}${request}`;
         if (this.cache?.has(key)) {
             return this.cache.get(key)!;

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -26,22 +26,26 @@ export type JsModule = {
 };
 
 export interface InvalidCachedModule {
+    kind: 'js' | 'css';
     value: null;
     error: unknown;
 }
 
-export interface BaseCachedModule<T> {
-    resolvedPath: string;
-    value: T;
-}
+export type CachedStylableMeta =
+    | InvalidCachedModule
+    | {
+          resolvedPath: string;
+          kind: 'css';
+          value: StylableMeta;
+      };
 
-export type CachedStylableMeta = (InvalidCachedModule | BaseCachedModule<StylableMeta>) & {
-    kind: 'css';
-};
-
-export type CachedJsModule = (InvalidCachedModule | BaseCachedModule<JsModule>) & {
-    kind: 'js';
-};
+export type CachedJsModule =
+    | InvalidCachedModule
+    | {
+          resolvedPath: string;
+          kind: 'js';
+          value: JsModule;
+      };
 
 export type CachedModuleEntity = CachedStylableMeta | CachedJsModule;
 export type CachedModule = CachedModuleEntity['value'];

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -78,33 +78,33 @@ export class StylableResolver {
         protected requireModule: (modulePath: string) => any,
         protected cache?: StylableResolverCache
     ) {}
-    private getModule({ context, request }: Imported): CachedModuleEntity {
-        const key = `${context}${safePathDelimiter}${request}`;
+    private getModule({ context, from }: Imported): CachedModuleEntity {
+        const key = `${context}${safePathDelimiter}${from}`;
         if (this.cache?.has(key)) {
             return this.cache.get(key)!;
         }
 
         let entity: CachedModuleEntity;
 
-        if (request.endsWith('.css')) {
+        if (from.endsWith('.css')) {
             const kind = 'css';
 
             try {
-                const resolvedPath = this.fileProcessor.resolvePath(request, context);
+                const resolvedPath = this.fileProcessor.resolvePath(from, context);
                 const value = this.fileProcessor.process(resolvedPath, false, context);
                 entity = { kind, value, resolvedPath };
             } catch (error) {
-                entity = { kind, value: null, error, request, context };
+                entity = { kind, value: null, error, request: from, context };
             }
         } else {
             const kind = 'js';
 
             try {
-                const resolvedPath = this.fileProcessor.resolvePath(request, context);
+                const resolvedPath = this.fileProcessor.resolvePath(from, context);
                 const value = this.requireModule(resolvedPath);
                 entity = { kind, value, resolvedPath };
             } catch (error) {
-                entity = { kind, value: null, error, request, context };
+                entity = { kind, value: null, error, request: from, context };
             }
         }
 

--- a/packages/rollup-plugin/test/projects/simple-stylable/index.st.css
+++ b/packages/rollup-plugin/test/projects/simple-stylable/index.st.css
@@ -1,4 +1,4 @@
-@st-import [jsColor] from "./js-function.js";
+@st-import [jsColor] from "./js-function";
 
 .root {
     font-size: 120px;


### PR DESCRIPTION
Today we use the resolver cache and the value of its entities is very limited.
This PR extends the current cache entity value.

#### Note:
I found a minor issue in the rollup test that used `.js` when did not need.