### PR TITLE
refactor: remove deprecation logs from matchSelectorTarget and createSubsetAst

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -235,9 +235,7 @@ export const scopeSelector = wrapFunctionForDeprecation(deprecatedScopeSelector,
     name: `scopeSelector`,
 });
 /**@deprecated*/
-export const createSubsetAst = wrapFunctionForDeprecation(deprecatedCreateSubsetAst, {
-    name: `createSubsetAst`,
-});
+export const createSubsetAst = deprecatedCreateSubsetAst;
 /**@deprecated*/
 export const removeUnusedRules = wrapFunctionForDeprecation(deprecatedRemoveUnusedRules, {
     name: `removeUnusedRules`,
@@ -276,9 +274,7 @@ import {
     createSimpleSelectorChecker as deprecatedCreateSimpleSelectorChecker,
 } from './deprecated/deprecated-selector-utils';
 /**@deprecated*/
-export const matchSelectorTarget = wrapFunctionForDeprecation(deprecatedMatchSelectorTarget, {
-    name: `matchSelectorTarget`,
-});
+export const matchSelectorTarget = deprecatedMatchSelectorTarget;
 /**@deprecated*/
 export const fixChunkOrdering = wrapFunctionForDeprecation(deprecatedFixChunkOrdering, {
     name: `fixChunkOrdering`,


### PR DESCRIPTION
They will still marked as deprecated but no logs will be fired on usage