### PR TITLE
feat(core): export `parseStylableImport`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export {
     validateScopingSelector,
 } from './stylable-processor';
 
-export { ensureStylableImports } from './stylable-imports-tools';
+export { ensureStylableImports, parseStylableImport } from './stylable-imports-tools';
 
 export { StylableMeta, RESERVED_ROOT_NAME } from './stylable-meta';
 export {

--- a/packages/core/src/stylable-imports-tools.ts
+++ b/packages/core/src/stylable-imports-tools.ts
@@ -187,6 +187,18 @@ function setImportObjectFrom(importPath: string, dirPath: string, importObj: Imp
     }
 }
 
+export function parseStylableImport(
+    node: AtRule | Rule,
+    context: string,
+    diagnostics: Diagnostics
+) {
+    if (node.type === 'atrule') {
+        return parseStImport(node, context, diagnostics);
+    } else {
+        return parsePseudoImport(node, context, diagnostics);
+    }
+}
+
 export function parseStImport(atRule: AtRule, context: string, diagnostics: Diagnostics) {
     const importObj: Imported = {
         defaultExport: '',


### PR DESCRIPTION
So it turn out editing tools will need to parse stylable imports.