### PR TITLE
fix(core): set the property of setFieldForDeprecation to be configurable

### DIFF
--- a/packages/core/src/helpers/deprecation.ts
+++ b/packages/core/src/helpers/deprecation.ts
@@ -21,6 +21,7 @@ export function setFieldForDeprecation(
         valueMaps[fieldName] = new WeakMap();
     }
     Object.defineProperty(object, fieldName, {
+        configurable: true,
         get() {
             warnOnce(`"${objectPrefix}${fieldName}" is deprecated${alternative}`);
             return fieldOnThis ? this[fieldOnThis] : valueMaps[fieldName].get(this);


### PR DESCRIPTION
Somehow in jest our module evaluated multiple times and tries to set the deprecation field twice and fail since it's not configurable. this PR changes the property to be configurable