### PR TITLE
fix(jest): correct export to match Jest API expectation

### DIFF
--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,1 +1,3 @@
-export * from './jest';
+import { createTransformer } from './jest';
+
+export default { createTransformer };

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -28,24 +28,26 @@ function getCacheKey(
     );
 }
 
-interface StylableJestConfig {
+export interface StylableJestConfig {
     stylable?: Partial<StylableConfig>;
 }
 
 export const createTransformer = (options?: StylableJestConfig) => {
+    const process = stylableModuleFactory(
+        {
+            fileSystem: fs,
+            requireModule: require,
+            projectRoot: '',
+            resolveNamespace,
+            ...options?.stylable,
+        },
+        // ensure the generated module points to our own @stylable/runtime copy
+        // this allows @stylable/jest to be used as part of a globally installed CLI
+        { runtimePath: stylableRuntimePath }
+    );
+
     return {
-        process: stylableModuleFactory(
-            {
-                fileSystem: fs,
-                requireModule: require,
-                projectRoot: '',
-                resolveNamespace,
-                ...options?.stylable,
-            },
-            // ensure the generated module points to our own @stylable/runtime copy
-            // this allows @stylable/jest to be used as part of a globally installed CLI
-            { runtimePath: stylableRuntimePath }
-        ),
+        process,
         getCacheKey,
         canInstrument: false,
     };

--- a/packages/jest/test/jest.spec.ts
+++ b/packages/jest/test/jest.spec.ts
@@ -1,15 +1,17 @@
 import { expect } from 'chai';
 import { readFileSync } from 'fs';
 import nodeEval from 'node-eval';
-import { createTransformer } from '@stylable/jest';
+import stylableTransformer from '@stylable/jest';
 import type { RuntimeStylesheet } from '@stylable/runtime';
 
 describe('jest process', () => {
     it('should process stylable sources using createTransformer API', () => {
         const filename = require.resolve('@stylable/jest/test/fixtures/test.st.css');
         const content = readFileSync(filename, 'utf8');
+        const transformer = stylableTransformer.createTransformer();
+
         const module = nodeEval(
-            createTransformer().process(content, filename),
+            transformer.process(content, filename),
             filename
         ) as RuntimeStylesheet;
 
@@ -20,10 +22,12 @@ describe('jest process', () => {
     it('should process stylable sources with a custom namespace resolver', () => {
         const filename = require.resolve('@stylable/jest/test/fixtures/test.st.css');
         const content = readFileSync(filename, 'utf8');
+        const transformer = stylableTransformer.createTransformer({
+            stylable: { resolveNamespace: (ns, _srcPath) => `${ns}-custom` },
+        });
+
         const module = nodeEval(
-            createTransformer({
-                stylable: { resolveNamespace: (ns, _srcPath) => `${ns}-custom` },
-            }).process(content, filename),
+            transformer.process(content, filename),
             filename
         ) as RuntimeStylesheet;
 


### PR DESCRIPTION
While adding the configuration options in #2097, I made a mistake and created an incompatible API. This PR restores functionality to our Jest integration.

This also highlights the fact that we do not have real e2e tests for this integration.