### PR TITLE
fix(core): restrict functional nested selectors analyze

### DIFF
--- a/packages/core/src/native-reserved-lists.ts
+++ b/packages/core/src/native-reserved-lists.ts
@@ -51,9 +51,9 @@ export const nativePseudoClasses = [
 ];
 
 /**
- * list names of pseudo classes that cannot be override by custom states
- * // [breaking] ToDo: add names of general pseudo classes that are not specific to elements
- * // like: root, only-child, nth-of-type, nth-last-child, nth-last-of-type, only-of-type...
+ * list names of functional pseudo classes
+ * - cannot be override by custom states
+ * - might contain nested selectors
  */
 export const reservedPseudoClasses = [
     `not`,
@@ -62,6 +62,12 @@ export const reservedPseudoClasses = [
     `is`,
     `where`,
     `has`,
+    `host`,
+    `host-context`,
+    `nth-child`,
+    `nth-last-child`,
+    `nth-of-type`,
+    `nth-last-of-type`,
     // not native
     `global`,
     `local`,

--- a/packages/core/src/native-reserved-lists.ts
+++ b/packages/core/src/native-reserved-lists.ts
@@ -55,7 +55,7 @@ export const nativePseudoClasses = [
  * - cannot be overridden by custom states
  * - might contain nested selectors
  */
-export const reservedPseudoClasses = [
+export const reservedFunctionalPseudoClasses = [
     `not`,
     `any`,
     `matches`,
@@ -72,6 +72,17 @@ export const reservedPseudoClasses = [
     `global`,
     `local`,
 ];
+export const knownPseudoClassesWithNestedSelectors = reservedFunctionalPseudoClasses.filter(name => {
+    switch(name) {
+        case `global`:
+        case `local`:
+        case `nth-of-type`:
+        case `nth-last-of-type`:
+            return false;
+
+    }
+    return true;
+});
 
 export const nativePseudoElements = [
     'after',

--- a/packages/core/src/pseudo-states.ts
+++ b/packages/core/src/pseudo-states.ts
@@ -17,7 +17,7 @@ import { groupValues, listOptions, MappedStates } from './stylable-value-parsers
 import { valueMapping } from './stylable-value-parsers';
 import type { ParsedValue, StateParsedValue } from './types';
 import { stripQuotation } from './utils';
-import { reservedPseudoClasses } from './native-reserved-lists';
+import { reservedFunctionalPseudoClasses } from './native-reserved-lists';
 import cssesc from 'cssesc';
 
 export const stateMiddleDelimiter = '-';
@@ -61,7 +61,7 @@ export function processPseudoStates(
             diagnostics.error(decl, stateErrors.STATE_STARTS_WITH_HYPHEN(stateDefinition.value), {
                 word: stateDefinition.value,
             });
-        } else if (reservedPseudoClasses.includes(stateDefinition.value)) {
+        } else if (reservedFunctionalPseudoClasses.includes(stateDefinition.value)) {
             diagnostics.warn(decl, stateErrors.RESERVED_NATIVE_STATE(stateDefinition.value), {
                 word: stateDefinition.value,
             });

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -5,7 +5,7 @@ import { deprecatedStFunctions } from './custom-values';
 import { Diagnostics } from './diagnostics';
 import { parseSelector as deprecatedParseSelector } from './deprecated/deprecated-selector-utils';
 import { murmurhash3_32_gc } from './murmurhash';
-import { reservedKeyFrames } from './native-reserved-lists';
+import { reservedKeyFrames, reservedPseudoClasses } from './native-reserved-lists';
 import { StylableMeta } from './stylable-meta';
 import type {
     ClassSymbol,
@@ -503,7 +503,7 @@ export class StylableProcessor {
                             )
                         );
                     }
-                } else if (node.value === `global`) {
+                } else if (node.value === `global` || !reservedPseudoClasses.includes(node.value)) {
                     return walkSelector.skipNested;
                 }
             } else if (node.type === 'class') {

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -5,7 +5,7 @@ import { deprecatedStFunctions } from './custom-values';
 import { Diagnostics } from './diagnostics';
 import { parseSelector as deprecatedParseSelector } from './deprecated/deprecated-selector-utils';
 import { murmurhash3_32_gc } from './murmurhash';
-import { reservedKeyFrames, reservedPseudoClasses } from './native-reserved-lists';
+import { reservedKeyFrames, knownPseudoClassesWithNestedSelectors } from './native-reserved-lists';
 import { StylableMeta } from './stylable-meta';
 import type {
     ClassSymbol,
@@ -503,7 +503,7 @@ export class StylableProcessor {
                             )
                         );
                     }
-                } else if (node.value === `global` || !reservedPseudoClasses.includes(node.value)) {
+                } else if (!knownPseudoClassesWithNestedSelectors.includes(node.value)) {
                     return walkSelector.skipNested;
                 }
             } else if (node.type === 'class') {

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -11,7 +11,7 @@ import {
     testInlineExpects,
 } from '@stylable/core-test-kit';
 import { processorWarnings, valueMapping, nativePseudoClasses, pseudoStates } from '@stylable/core';
-import { reservedPseudoClasses } from '@stylable/core/dist/native-reserved-lists';
+import { reservedFunctionalPseudoClasses } from '@stylable/core/dist/native-reserved-lists';
 
 chai.use(chaiSubset); // move all of these to a central place
 chai.use(styleRules);
@@ -29,7 +29,7 @@ describe('pseudo-states', () => {
         // What does it do?
         // Works in the scope of a single file, collecting state definitions for later usage
         describe(`reserved pseudo classes`, () => {
-            reservedPseudoClasses.forEach((name) => {
+            reservedFunctionalPseudoClasses.forEach((name) => {
                 it(`should NOT collect "${name}"`, () => {
                     const { classes } = processSource(
                         `

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -314,7 +314,7 @@ describe('Stylable postcss process', () => {
                 name.startsWith(`nth`)
                     ? `:${name}(5n, El-${name}.cls-${name}) {}`
                     : `:${name}(El-${name}.cls-${name}) {}`
-            )}
+            ).join(``)}
         `,
             { from: 'path/to/style.css' }
         );


### PR DESCRIPTION
We have a regression that can potentially pick up `custom pseudo states` with parameter which matches an `element` for a value with a first capital letter or a `class` for a value that starts with a dot (e.g. `:custom(Comp)` or `:custom(.part)`).

That might cause unintended symbol conflict that reports a `error/warning` diagnostics and even cause transpilation errors.

The fix:

- skip analyze of nested AST of unknown functional pseudo classes (that contain selectors)
- add the other native pseudo-classes to the restricted list - this is a breaking change that disallows states with the names:  `host`, `host-context`, `nth-child`, `nth-last-child`, `nth-of-type`, and `nth-last-of-type`. 

```css
:not(Comp.part) {}

:custom(Xxx.yyy) {}
```

In the example, `Comp` type and `part` class symbols are collected since `:not` is listed in `knownPseudoClassesWithNestedSelectors`, but `Xxx` type and the `yyy` class are not.
