### PR TITLE
feat(core): stylable resolver cache filter

### DIFF
--- a/packages/core-test-kit/package.json
+++ b/packages/core-test-kit/package.json
@@ -7,6 +7,7 @@
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },
   "dependencies": {
+    "@file-services/memory": "^5.4.1",
     "@stylable/core": "^4.8.3",
     "chai": "^4.3.4",
     "flat": "^5.0.2",

--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -11,9 +11,13 @@ import {
     StylableTransformer,
     createStylableFileProcessor,
     createDefaultResolver,
+    Stylable,
+    StylableConfig,
 } from '@stylable/core';
 import { isAbsolute } from 'path';
 import * as postcss from 'postcss';
+import { createMemoryFs } from '@file-services/memory';
+import type { IDirectoryContents } from '@file-services/types';
 
 export interface File {
     content: string;
@@ -110,4 +114,23 @@ export function generateStylableRoot(config: Config) {
 
 export function generateStylableExports(config: Config) {
     return generateStylableResult(config).exports;
+}
+
+export function generateStyleableEnvironment(
+    content: IDirectoryContents,
+    stylableConfig: Partial<StylableConfig> = {}
+) {
+    const fs = createMemoryFs(content);
+
+    const stylable = Stylable.create({
+        fileSystem: fs,
+        projectRoot: '/',
+        resolveNamespace: (ns) => ns,
+        ...stylableConfig,
+    });
+
+    return {
+        stylable,
+        fs,
+    };
 }

--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -116,7 +116,7 @@ export function generateStylableExports(config: Config) {
     return generateStylableResult(config).exports;
 }
 
-export function generateStyleableEnvironment(
+export function generateStylableEnvironment(
     content: IDirectoryContents,
     stylableConfig: Partial<StylableConfig> = {}
 ) {

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -17,6 +17,7 @@ export {
     generateStylableResult,
     generateStylableRoot,
     processSource,
+    generateStyleableEnvironment,
 } from './generate-test-util';
 export { flatMatch } from './matchers/flat-match';
 export { matchCSSMatchers } from './matchers/match-css';

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -17,7 +17,7 @@ export {
     generateStylableResult,
     generateStylableRoot,
     processSource,
-    generateStyleableEnvironment,
+    generateStylableEnvironment,
 } from './generate-test-util';
 export { flatMatch } from './matchers/flat-match';
 export { matchCSSMatchers } from './matchers/match-css';

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -4,7 +4,7 @@ import { Diagnostics } from './diagnostics';
 import { CssParser, cssParse } from './parser';
 import { processNamespace, StylableProcessor } from './stylable-processor';
 import type { StylableMeta } from './stylable-meta';
-import { StylableResolverCache, StylableResolver } from './stylable-resolver';
+import { StylableResolverCache, StylableResolver, CachedModuleEntity } from './stylable-resolver';
 import {
     StylableResults,
     StylableTransformer,
@@ -96,9 +96,21 @@ export class Stylable {
 
         this.resolver = this.createResolver();
     }
-    public initCache() {
-        this.resolverCache = new Map();
-        this.resolver = this.createResolver();
+    public initCache({
+        filter,
+    }: { filter?: (key: string, entity: CachedModuleEntity) => boolean } = {}) {
+        if (filter && this.resolverCache) {
+            for (const [key, cacheEntity] of this.resolverCache) {
+                const keep = filter(key, cacheEntity);
+
+                if (!keep) {
+                    this.resolverCache.delete(key);
+                }
+            }
+        } else {
+            this.resolverCache = new Map();
+            this.resolver = this.createResolver();
+        }
     }
     public createResolver({
         requireModule = this.requireModule,

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -4,14 +4,14 @@ import { Diagnostics } from './diagnostics';
 import { CssParser, cssParse } from './parser';
 import { processNamespace, StylableProcessor } from './stylable-processor';
 import type { StylableMeta } from './stylable-meta';
-import { StylableResolverCache, StylableResolver, CachedModuleEntity } from './stylable-resolver';
+import { StylableResolverCache, StylableResolver } from './stylable-resolver';
 import {
     StylableResults,
     StylableTransformer,
     TransformerOptions,
     TransformHooks,
 } from './stylable-transformer';
-import type { IStylableOptimizer, ModuleResolver } from './types';
+import type { InitCacheParams, IStylableOptimizer, ModuleResolver } from './types';
 import { createDefaultResolver } from './module-resolver';
 import { warnOnce } from './helpers/deprecation';
 
@@ -96,9 +96,7 @@ export class Stylable {
 
         this.resolver = this.createResolver();
     }
-    public initCache({
-        filter,
-    }: { filter?: (key: string, entity: CachedModuleEntity) => boolean } = {}) {
+    public initCache({ filter }: InitCacheParams = {}) {
         if (filter && this.resolverCache) {
             for (const [key, cacheEntity] of this.resolverCache) {
                 const keep = filter(key, cacheEntity);

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -4,14 +4,14 @@ import { Diagnostics } from './diagnostics';
 import { CssParser, cssParse } from './parser';
 import { processNamespace, StylableProcessor } from './stylable-processor';
 import type { StylableMeta } from './stylable-meta';
-import { StylableResolverCache, StylableResolver } from './stylable-resolver';
+import { StylableResolverCache, StylableResolver, CachedModuleEntity } from './stylable-resolver';
 import {
     StylableResults,
     StylableTransformer,
     TransformerOptions,
     TransformHooks,
 } from './stylable-transformer';
-import type { InitCacheParams, IStylableOptimizer, ModuleResolver } from './types';
+import type { IStylableOptimizer, ModuleResolver } from './types';
 import { createDefaultResolver } from './module-resolver';
 import { warnOnce } from './helpers/deprecation';
 
@@ -37,6 +37,11 @@ export interface StylableConfig {
     cssParser?: CssParser;
     resolverCache?: StylableResolverCache;
     fileProcessorCache?: Record<string, CacheItem<StylableMeta>>;
+}
+
+interface InitCacheParams {
+    /* Keeps cache entities that meet the condition specified in a callback function. Return `true` to keep the iterated entity. */
+    filter?(key: string, entity: CachedModuleEntity): boolean;
 }
 
 export type CreateProcessorOptions = Pick<StylableConfig, 'resolveNamespace'>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,6 @@
 import type * as postcss from 'postcss';
 import type { Box } from './custom-values';
 import type { StylableMeta } from './stylable-meta';
-import type { CachedModuleEntity } from './stylable-resolver';
 import type { StylableExports, StylableResults } from './stylable-transformer';
 
 export type PartialObject<T> = Partial<T> & object;
@@ -84,8 +83,3 @@ export interface IStylableNamespaceOptimizer {
 }
 
 export type ModuleResolver = (directoryPath: string, request: string) => string;
-
-export interface InitCacheParams {
-    /* Keeps cache entities that meet the condition specified in a callback function. Return `true` to keep the iterated entity. */
-    filter?(key: string, entity: CachedModuleEntity): boolean;
-}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import type * as postcss from 'postcss';
 import type { Box } from './custom-values';
 import type { StylableMeta } from './stylable-meta';
+import type { CachedModuleEntity } from './stylable-resolver';
 import type { StylableExports, StylableResults } from './stylable-transformer';
 
 export type PartialObject<T> = Partial<T> & object;
@@ -83,3 +84,8 @@ export interface IStylableNamespaceOptimizer {
 }
 
 export type ModuleResolver = (directoryPath: string, request: string) => string;
+
+export interface InitCacheParams {
+    /* Keeps cache entities that meet the condition specified in a callback function. Return `true` to keep the iterated entity. */
+    filter?(key: string, entity: CachedModuleEntity): boolean;
+}

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -1,0 +1,79 @@
+import { generateStyleableEnvironment } from '@stylable/core-test-kit';
+import { expect } from 'chai';
+
+describe('Stylable', () => {
+    describe('Cache', () => {
+        it('should invalidate cache', () => {
+            const { fs, stylable } = generateStyleableEnvironment({
+                'foo.st.css': '.foo {}',
+                'entry.st.css': `
+                  @st-import [foo] from './foo.st.css';
+                  .root .foo { }
+                `,
+            });
+
+            stylable.initCache();
+            stylable.transform(stylable.process('/entry.st.css'));
+
+            fs.writeFileSync('/foo.st.css', '.bar {}');
+            fs.writeFileSync(
+                '/entry.st.css',
+                `
+                @st-import [bar] from './foo.st.css';
+                .root .bar { }
+
+                `
+            );
+
+            // invalidate cache
+            stylable.initCache();
+
+            const res = stylable.transform(stylable.process('/entry.st.css'));
+
+            expect(res.exports.classes).to.eql({
+                bar: 'foo__bar',
+                root: 'entry__root',
+            });
+            expect(
+                res.meta.transformDiagnostics!.reports,
+                'no diagnostics reported for foo import'
+            ).to.eql([]);
+        });
+
+        it('should clear cache only for filtered items', () => {
+            const resolverCache = new Map();
+            const { fs, stylable } = generateStyleableEnvironment(
+                {
+                    'foo.st.css': '.foo {}',
+                    'bar.st.css': '.bar {}',
+                    'entry.st.css': `
+                          @st-import [bar] from './bar.st.css';
+                          @st-import [foo] from './foo.st.css';
+                          .root .foo .bar { }
+                    `,
+                },
+                { resolverCache }
+            );
+
+            stylable.transform(stylable.process('/entry.st.css'));
+
+            // remove foo class
+            fs.writeFileSync('/foo.st.css', '');
+            stylable.initCache({
+                filter(_, entity) {
+                    // keep 'foo.st.css' in cache
+                    return Boolean(entity.value && entity.resolvedPath.includes('foo.st.css'));
+                },
+            });
+
+            expect(resolverCache.size, 'has one cache entity').to.eql(1);
+
+            const res = stylable.transform(stylable.process('/entry.st.css'));
+
+            expect(
+                res.meta.transformDiagnostics!.reports,
+                'no diagnostics reported for foo import'
+            ).to.eql([]);
+        });
+    });
+});

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -1,10 +1,10 @@
-import { generateStyleableEnvironment } from '@stylable/core-test-kit';
+import { generateStylableEnvironment } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 
 describe('Stylable', () => {
     describe('Cache', () => {
         it('should invalidate cache', () => {
-            const { fs, stylable } = generateStyleableEnvironment({
+            const { fs, stylable } = generateStylableEnvironment({
                 'foo.st.css': '.foo {}',
                 'entry.st.css': `
                   @st-import [foo] from './foo.st.css';
@@ -42,7 +42,7 @@ describe('Stylable', () => {
 
         it('should clear cache only for filtered items', () => {
             const resolverCache = new Map();
-            const { fs, stylable } = generateStyleableEnvironment(
+            const { fs, stylable } = generateStylableEnvironment(
                 {
                     'foo.st.css': '.foo {}',
                     'bar.st.css': '.bar {}',


### PR DESCRIPTION
We want to have the option to filter out specific cache entries instead of invalidating all the cache at once.

I also added more cache tests that were missing.