### PR TITLE
use IStylableOptimizer for StylableWebpackPluginOptions

### DIFF
--- a/packages/optimizer/src/index.ts
+++ b/packages/optimizer/src/index.ts
@@ -7,4 +7,5 @@ export {
     removeRecursiveUpIfEmpty,
     replaceRecursiveUpIfEmpty,
 } from './stylable-optimizer';
+export { IStylableOptimizer } from '@stylable/core';
 export { MappedName, Name, NameMapper, Prefix } from './name-mapper';

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -6,7 +6,7 @@ import {
     DiagnosticsMode,
 } from '@stylable/core';
 import { sortModulesByDepth, loadStylableConfig, calcDepth } from '@stylable/build-tools';
-import { StylableOptimizer } from '@stylable/optimizer';
+import { StylableOptimizer, IStylableOptimizer } from '@stylable/optimizer';
 import cloneDeep from 'lodash.clonedeep';
 import { dirname, relative } from 'path';
 import type { Compilation, Compiler, NormalModule, WebpackError } from 'webpack';
@@ -96,7 +96,7 @@ export interface StylableWebpackPluginOptions {
     /**
      * Provide custom StylableOptimizer
      */
-    optimizer?: StylableOptimizer;
+    optimizer?: IStylableOptimizer;
     /**
      * A function to override Stylable instance default configuration options
      */


### PR DESCRIPTION
Currently the webpack plugin options expect `StylableOptimizer`, so a class or an extending class. But when a consumer has more than a single instance of `@stylable/optimizer` in their dependency tree in different versions, Typescript fails on the types of the different `StyleableOptmizer` classes not matching.

So I noticed you have an interface of IStylableOptmizer which could also be used for the webpack plugin options and prevents this problem as Typescript would accept different concrete classes of `StylableOptmizer` even if they come from different versions.