### PR TITLE
docs(e2e-test-kit): Fix broken link in readme

### DIFF
--- a/packages/e2e-test-kit/README.md
+++ b/packages/e2e-test-kit/README.md
@@ -8,7 +8,7 @@
 
 Used to setup an E2E test project with `@stylable/webpack-plugin` and `playwright`. This allows testing an entire project setup, including stylable configuration, webpack configuration and the process of transpiling the project, performing your tests against a running browser.
 
-You can find a set of example configuration setups [here](./packages/webpack-plugin/test/e2e).
+You can find a set of example configuration setups [here](/packages/webpack-plugin/test/e2e).
 
 ### `getStyleElementsMetadata`
 


### PR DESCRIPTION
Came across a broken link when looking at e2e-test-kit package readme.

![honest-work](https://en.meming.world/images/en/b/be/But_It%27s_Honest_Work.jpg)