### PR TITLE
fix(core): fix regression in inherited mixin flow

### DIFF
--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -338,6 +338,7 @@ function handleLocalClassMixin(
 
 function createInheritedMeta(resolvedClass: CSSResolve) {
     const mixinMeta: StylableMeta = Object.create(resolvedClass.meta);
+    mixinMeta.data = Object.create(mixinMeta.data);
     mixinMeta.parent = resolvedClass.meta;
 
     STSymbol.inheritSymbols(resolvedClass.meta, mixinMeta);


### PR DESCRIPTION
Version `4.9.0` introduced a regression with mixins that can cause stylable `meta` to become corrupted.

This PR resolves this regression. 