### PR TITLE
fix(webpack-extensions): metadata support for st-import

### DIFF
--- a/packages/webpack-extensions/src/create-metadata-stylesheet.ts
+++ b/packages/webpack-extensions/src/create-metadata-stylesheet.ts
@@ -64,6 +64,11 @@ export function rewriteImports(
                             );
                         }
                     });
+                } else if (rawRule.type === 'atrule') {
+                    rawRule.params = rawRule.params.replace(
+                        stImport.request,
+                        `/${ensureHash(resolved.meta, hashes)}.st.css`
+                    );
                 } else {
                     throw new Error('Unknown import rule ' + rawRule.toString());
                 }

--- a/packages/webpack-extensions/test/e2e/metadata-loader-case.spec.ts
+++ b/packages/webpack-extensions/test/e2e/metadata-loader-case.spec.ts
@@ -28,12 +28,17 @@ describe(`(${project})`, () => {
         // eslint-disable-next-line @typescript-eslint/no-implied-eval
         const getMetadataFromLibraryBundle = new Function(bundleContent + '\nreturn metadata;');
 
+        const compXContent = readFileSync(join(projectRunner.testDir, 'comp-x.st.css'), 'utf-8');
         const compContent = readFileSync(join(projectRunner.testDir, 'comp.st.css'), 'utf-8');
         const indexContent = readFileSync(join(projectRunner.testDir, 'index.st.css'), 'utf-8');
         const indexHash = hashContent(indexContent);
         const compHash = hashContent(compContent);
+        const compXHash = hashContent(compXContent);
         const stylesheetMapping = {
-            [`/${indexHash}.st.css`]: indexContent.replace('./comp.st.css', `/${compHash}.st.css`),
+            [`/${indexHash}.st.css`]: indexContent
+                .replace('./comp.st.css', `/${compHash}.st.css`)
+                .replace('./comp-x.st.css', `/${compXHash}.st.css`),
+            [`/${compXHash}.st.css`]: compXContent,
             [`/${compHash}.st.css`]: compContent,
         };
         const metadata = getMetadataFromLibraryBundle().default;
@@ -48,5 +53,6 @@ describe(`(${project})`, () => {
 
         expect(metadata.namespaceMapping[`/${indexHash}.st.css`]).to.match(/index\d+/);
         expect(metadata.namespaceMapping[`/${compHash}.st.css`]).to.match(/comp\d+/);
+        expect(metadata.namespaceMapping[`/${compXHash}.st.css`]).to.match(/compx\d+/);
     });
 });

--- a/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/comp-x.st.css
+++ b/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/comp-x.st.css
@@ -1,0 +1,3 @@
+.root {
+    color: yellow
+}

--- a/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/index.st.css
+++ b/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/index.st.css
@@ -1,4 +1,4 @@
-
+@st-import CompX from "./comp-x.st.css";
 :import {
     -st-from: "./comp.st.css";
     -st-default: Comp;
@@ -7,4 +7,9 @@
 .root {
     -st-extends: Comp;
     color: green;
+}
+
+.part {
+    -st-extends: CompX;
+    color: purple;
 }


### PR DESCRIPTION
This PR added missing support for `@st-import` in the metadata creation process