### PR TITLE
fix(webpack-plugin): fix support of browser field

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -42,6 +42,7 @@ import type {
     EntryPoint,
     LoaderData,
     NormalModuleFactory,
+    ResolveOptionsWebpackOptions,
     StylableBuildMeta,
     StylableLoaderContext,
 } from './types';
@@ -255,7 +256,7 @@ export class StylableWebpackPlugin {
             return;
         }
 
-        const resolverOptions = {
+        const resolverOptions: ResolveOptionsWebpackOptions = {
             ...compiler.options.resolve,
             aliasFields:
                 compiler.options.resolve.byDependency?.esm?.aliasFields ||

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -255,6 +255,13 @@ export class StylableWebpackPlugin {
             return;
         }
 
+        const resolverOptions = {
+            ...compiler.options.resolve,
+            aliasFields:
+                compiler.options.resolve.byDependency?.esm?.aliasFields ||
+                compiler.options.resolve.aliasFields,
+        };
+
         this.stylable = Stylable.create(
             this.options.stylableConfig(
                 {
@@ -266,7 +273,7 @@ export class StylableWebpackPlugin {
                     fileSystem: getTopLevelInputFilesystem(compiler),
                     mode: compiler.options.mode === 'production' ? 'production' : 'development',
                     resolveOptions: {
-                        ...compiler.options.resolve,
+                        ...resolverOptions,
                         extensions: [], // use Stylable's default extensions
                     },
                     resolveNamespace: packageNamespaceFactory(

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -37,6 +37,7 @@ export interface StylableLoaderContext extends LoaderContext<{}> {
 type MapType<T> = T extends Map<any, infer U> ? U : never;
 
 export type WebpackCreateHash = Compiler['webpack']['util']['createHash'];
+export type ResolveOptionsWebpackOptions = Compiler['options']['resolve'];
 export type RuntimeTemplate = Compilation['runtimeTemplate'];
 export type WebpackOutputOptions = RuntimeTemplate['outputOptions'];
 export type CompilationParams = Parameters<Compiler['newCompilation']>[0];

--- a/packages/webpack-plugin/test/e2e/browser-field.spec.ts
+++ b/packages/webpack-plugin/test/e2e/browser-field.spec.ts
@@ -29,7 +29,7 @@ describe(`(${project})`, () => {
         }));
         /*
             Expecting the backgroundColor to be green 
-            makes sure that the ems style button is rendered
+            makes sure that the esm style button is rendered
         */
         expect(backgroundColor).to.equal('rgb(0, 128, 0)');
         /* 

--- a/packages/webpack-plugin/test/e2e/browser-field.spec.ts
+++ b/packages/webpack-plugin/test/e2e/browser-field.spec.ts
@@ -20,21 +20,27 @@ describe(`(${project})`, () => {
         after
     );
 
-    it('renders css', async () => {
+    it('renders esm button with override', async () => {
         const { page } = await projectRunner.openInBrowser();
         const styleElements = await page.evaluate(browserFunctions.getStyleElementsMetadata);
+        const { backgroundColor, fontSize } = await page.$eval('button', (el: HTMLElement) => ({
+            fontSize: getComputedStyle(el).fontSize,
+            backgroundColor: getComputedStyle(el).backgroundColor,
+        }));
+        /*
+            Expecting the backgroundColor to be green 
+            makes sure that the ems style button is rendered
+        */
+        expect(backgroundColor).to.equal('rgb(0, 128, 0)');
+        /* 
+           Expecting the font-size override is working 
+           makes sure that Stylable resolves stylesheets with the "browser" field configuration
+        */
+        expect(fontSize).to.equal('35px');
 
         expect(styleElements).to.eql([
             { id: './node_modules/test-components/esm/button.st.css', depth: '1' },
             { id: './src/app.st.css', depth: '3' },
         ]);
-    });
-
-    it('override 3rd party', async () => {
-        const { page } = await projectRunner.openInBrowser();
-        const backgroundColor = await page.evaluate(() => {
-            return getComputedStyle((window as any).btn).backgroundColor;
-        });
-        expect(backgroundColor).to.eql('rgb(255, 215, 0)');
     });
 });

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/cjs/button.js
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/cjs/button.js
@@ -2,6 +2,7 @@ import { classes } from "./button.st.css";
 const render = () => {
   const btn = document.createElement("button");
   btn.classList.add(classes.root);
+  btn.textContent = 'CJS Button';
   return btn;
 };
 export { classes, render };

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/cjs/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/cjs/button.st.css
@@ -1,3 +1,5 @@
+@namespace "cjs";
+
 .root {
     background: red;
 }

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/esm/button.js
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/esm/button.js
@@ -2,6 +2,7 @@ import { classes } from "./button.st.css";
 const render = () => {
   const btn = document.createElement("button");
   btn.classList.add(classes.root);
+  btn.textContent = 'ESM Button';
   return btn;
 };
 export { classes, render };

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/esm/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/esm/button.st.css
@@ -1,3 +1,5 @@
+@namespace "esm";
+
 .root {
     background: green;
 }

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/src/app.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/src/app.st.css
@@ -3,9 +3,6 @@
     -st-named: Button;
 }
 
-.root {
-    -st-extends: Button;
-
-    /* cjs = red, esm = green, here = gold */
-    background-color: gold; 
+Button {
+    font-size: 35px;
 }

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/src/index.js
@@ -1,8 +1,5 @@
-import { classes } from './app.st.css';
+import './app.st.css';
 import { Button } from 'test-components';
 
 const btn = Button.render();
-btn.id = 'btn';
-btn.classList.add(classes.root);
-
 document.body.appendChild(btn);


### PR DESCRIPTION
It turns out that the internal stylable resolver did not resolve stylable files **internal** requests according to the webpack target and the package.json browser field.

The test that checked this support was actually only tested the resolution of stylable requests from the JavaScript side. 

This PR fixes this issue but has one drawback:
JavaScript mixins and formatters are now also respect the browser field. This is not great because they run in node during the build but also not that bad because we can assume that no one is going to map them in the browser field. 