### PR TITLE
feat(webpack-plugin): add ability to report DUPLICATE_MODULE_NAMESPACE as warning

### DIFF
--- a/packages/webpack-plugin/src/plugin-utils.ts
+++ b/packages/webpack-plugin/src/plugin-utils.ts
@@ -364,8 +364,12 @@ export function getSortedModules(stylableModules: Map<NormalModule, BuildData | 
 
 export function reportNamespaceCollision(
     namespaceToFileMapping: Map<string, Set<NormalModule>>,
-    compilation: Compilation
+    compilation: Compilation,
+    ignore?: boolean | 'warn'
 ) {
+    if (ignore === true) {
+        return;
+    }
     for (const [namespace, resources] of namespaceToFileMapping) {
         if (resources.size > 1) {
             const resourcesReport = [...resources]
@@ -378,7 +382,7 @@ export function reportNamespaceCollision(
                 )} found in multiple different resources:\n${resourcesReport}\nThis issue indicates multiple versions of the same library in the compilation, or different paths importing the same stylesheet like: "esm" or "cjs".`
             );
             error.hideStack = true;
-            compilation.errors.push(error);
+            compilation[ignore === 'warn' ? 'warnings' : 'errors'].push(error);
         }
     }
 }

--- a/packages/webpack-plugin/src/plugin-utils.ts
+++ b/packages/webpack-plugin/src/plugin-utils.ts
@@ -365,9 +365,9 @@ export function getSortedModules(stylableModules: Map<NormalModule, BuildData | 
 export function reportNamespaceCollision(
     namespaceToFileMapping: Map<string, Set<NormalModule>>,
     compilation: Compilation,
-    ignore?: boolean | 'warn'
+    mode: 'ignore' | 'warnings' | 'errors'
 ) {
-    if (ignore === true) {
+    if (mode === 'ignore') {
         return;
     }
     for (const [namespace, resources] of namespaceToFileMapping) {
@@ -382,8 +382,18 @@ export function reportNamespaceCollision(
                 )} found in multiple different resources:\n${resourcesReport}\nThis issue indicates multiple versions of the same library in the compilation, or different paths importing the same stylesheet like: "esm" or "cjs".`
             );
             error.hideStack = true;
-            compilation[ignore === 'warn' ? 'warnings' : 'errors'].push(error);
+            compilation[mode].push(error);
         }
+    }
+}
+
+export function normalizeNamespaceCollisionOption(opt?: boolean | 'warn') {
+    if (opt === true) {
+        return 'ignore';
+    } else if (opt === 'warn') {
+        return 'warnings';
+    } else {
+        return 'errors';
     }
 }
 

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -35,6 +35,7 @@ import {
     getOnlyChunk,
     getStylableBuildData,
     isDependencyOf,
+    normalizeNamespaceCollisionOption,
 } from './plugin-utils';
 import { injectCssModules } from './mini-css-support';
 import type {
@@ -428,7 +429,9 @@ export class StylableWebpackPlugin {
             reportNamespaceCollision(
                 namespaceToFileMapping,
                 compilation,
-                this.options.unsafeMuteDiagnostics.DUPLICATE_MODULE_NAMESPACE
+                normalizeNamespaceCollisionOption(
+                    this.options.unsafeMuteDiagnostics.DUPLICATE_MODULE_NAMESPACE
+                )
             );
 
             for (const module of sortedModules) {

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -106,7 +106,7 @@ export interface StylableWebpackPluginOptions {
      * Allow to disable specific diagnostics reports
      */
     unsafeMuteDiagnostics?: {
-        DUPLICATE_MODULE_NAMESPACE?: boolean;
+        DUPLICATE_MODULE_NAMESPACE?: boolean | 'warn';
     };
     /**
      * Set the strategy of how to spit the extracted css
@@ -425,9 +425,11 @@ export class StylableWebpackPlugin {
             const { usageMapping, namespaceMapping, namespaceToFileMapping } =
                 createOptimizationMapping(sortedModules, optimizer);
 
-            if (!this.options.unsafeMuteDiagnostics.DUPLICATE_MODULE_NAMESPACE) {
-                reportNamespaceCollision(namespaceToFileMapping, compilation);
-            }
+            reportNamespaceCollision(
+                namespaceToFileMapping,
+                compilation,
+                this.options.unsafeMuteDiagnostics.DUPLICATE_MODULE_NAMESPACE
+            );
 
             for (const module of sortedModules) {
                 const { css, globals, namespace } = getStylableBuildMeta(module);

--- a/packages/webpack-plugin/test/e2e/duplicate-namespace-warning.spec.ts
+++ b/packages/webpack-plugin/test/e2e/duplicate-namespace-warning.spec.ts
@@ -1,0 +1,32 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { dirname } from 'path';
+
+const project = 'duplicate-namespace-warning';
+const projectDir = dirname(
+    require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
+);
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir,
+            launchOptions: {
+                // headless: false
+            },
+            throwOnBuildError: false,
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('should report detailed path of duplicate namespaced files (as warning)', () => {
+        const warnings = projectRunner.getBuildWarningMessages();
+        expect(warnings.length).to.equal(1);
+        const { message } = warnings[0];
+        expect(message).to.includes('Duplicate namespace');
+        expect(message).to.includes('./src/index.js\n  ./src/index.st.css <-- Duplicate');
+        expect(message).to.includes('./src/index.js\n  ./src/same-index.st.css <-- Duplicate');
+    });
+});

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/index.js
@@ -1,0 +1,5 @@
+import { classes as a } from './index.st.css';
+import { classes as b } from './same-index.st.css';
+
+document.documentElement.classList.add(a.root);
+document.documentElement.classList.add(b.root);

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/index.st.css
@@ -1,0 +1,6 @@
+/* st-namespace-reference="x" */
+@namespace "X";
+
+.root {
+    color: red;
+}

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/same-index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/same-index.st.css
@@ -1,0 +1,6 @@
+/* st-namespace-reference="x" */
+@namespace "X";
+
+.root {
+    color: red;
+}

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/webpack.config.js
@@ -1,0 +1,15 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [
+        new StylableWebpackPlugin({
+            unsafeMuteDiagnostics: { DUPLICATE_MODULE_NAMESPACE: 'warn' },
+        }),
+        new HtmlWebpackPlugin(),
+    ],
+};


### PR DESCRIPTION
This PR add the ability to set DUPLICATE_MODULE_NAMESPACE to `warn` and not break the build

TODO: 
- [x] Add test