### PR TITLE
fix(core): enable resolver cache by default for the transform process

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -122,7 +122,7 @@ export class StylableTransformer {
             options.fileProcessor,
             options.requireModule,
             options.moduleResolver,
-            options.resolverCache
+            options.resolverCache || new Map()
         );
         this.mode = options.mode || 'production';
     }

--- a/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
+++ b/packages/core/test/stylable-transformer/post-process-and-hooks.spec.ts
@@ -22,10 +22,10 @@ describe('post-process-and-hooks', () => {
                     },
                 },
             },
-            undefined,
-            undefined,
-            (res) => {
-                return { ...res, postProcessed: true };
+            {
+                postProcessor: (res) => {
+                    return { ...res, postProcessed: true };
+                },
             }
         );
 
@@ -58,12 +58,13 @@ describe('post-process-and-hooks', () => {
                     },
                 },
             },
-            undefined,
-            (_resolved, fn) => {
-                if (typeof fn !== 'string') {
-                    return `hooked_${fn.name}(${fn.args})`;
-                }
-                return '';
+            {
+                replaceValueHook: (_resolved, fn) => {
+                    if (typeof fn !== 'string') {
+                        return `hooked_${fn.name}(${fn.args})`;
+                    }
+                    return '';
+                },
             }
         );
 
@@ -93,9 +94,10 @@ describe('post-process-and-hooks', () => {
                     },
                 },
             },
-            undefined,
-            (resolved, name, isLocal) => {
-                return `__VALUE__${valueCallCount++} ${resolved}-${name}-${isLocal}`;
+            {
+                replaceValueHook: (resolved, name, isLocal) => {
+                    return `__VALUE__${valueCallCount++} ${resolved}-${name}-${isLocal}`;
+                },
             }
         );
 
@@ -163,15 +165,16 @@ describe('post-process-and-hooks', () => {
                     },
                 },
             },
-            undefined,
-            (resolved, name, isLocal, path) => {
-                const m = expected[index];
-                expect(
-                    [resolved, name, isLocal, path],
-                    [resolved, name, isLocal, path].join(',')
-                ).to.eqls(m);
-                index++;
-                return isLocal && path.length === 0 ? `[${name}]` : resolved;
+            {
+                replaceValueHook: (resolved, name, isLocal, path) => {
+                    const m = expected[index];
+                    expect(
+                        [resolved, name, isLocal, path],
+                        [resolved, name, isLocal, path].join(',')
+                    ).to.eqls(m);
+                    index++;
+                    return isLocal && path.length === 0 ? `[${name}]` : resolved;
+                },
             }
         );
 

--- a/packages/core/test/stylable-transformer/transformer.unit.spec.ts
+++ b/packages/core/test/stylable-transformer/transformer.unit.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import { createTransformer } from '@stylable/core-test-kit';
+
+function createSpy<T extends (...args: any[]) => any>(fn?: T) {
+    const spy = (...args: any[]) => {
+        spy.calls.push(args);
+        spy.callCount++;
+        return fn?.(...args);
+    };
+    spy.calls = [] as unknown[][];
+    spy.callCount = 0;
+    spy.resetHistory = () => {
+        spy.calls.length = 0;
+        spy.callCount = 0;
+    };
+    return spy;
+}
+
+describe('Transformer', () => {
+    it('should not resolve path more then once', () => {
+        const onResolve = createSpy((resolved) => resolved);
+        const transformer = createTransformer(
+            {
+                files: {
+                    '/entry.st.css': {
+                        content: `
+                        @st-import Button from "./button.st.css";
+
+                        .root {
+                            -st-extends: Button;
+                        }
+
+                        .myBtn {
+                            -st-mixin: Button;
+                        }
+                        `,
+                    },
+                    '/button.st.css': {
+                        content: `
+                            .root {}
+                            .icon {}
+                        `,
+                    },
+                },
+            },
+            {
+                onResolve,
+            }
+        );
+
+        transformer.transform(transformer.fileProcessor.process('/entry.st.css'));
+
+        expect(onResolve.callCount, 'call resolve only once').to.equal(1);
+    });
+});


### PR DESCRIPTION
After removing the timed cache. I forgot that the jest integration and some other flows are now not caching the stylable symbol resolution. This PR fixes it for all flows.  