### PR TITLE
fix(optimizer): downgrade csso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1868,19 +1868,6 @@
         "fastparse": "^1.1.2"
       }
     },
-    "node_modules/css-tree": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.0.4.tgz",
-      "integrity": "sha512-b4IS9ZUMtGBiNjzYbcj9JhYbyei99R3ai2CSxlu8GQDnoPA/P+NU85hAm0eKDc/Zp660rpK6tFJQ2OSdacMHVg==",
-      "dependencies": {
-        "mdn-data": "2.0.23",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
@@ -1902,18 +1889,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/csso": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.2.tgz",
-      "integrity": "sha512-llFAe1UfFHy38ziX+YrPMGkn5MxdjzYtz0drvgnjRY/tLPmBRxotYTGO51BsKe9voQA074pEb0udV+piXH4scQ==",
-      "dependencies": {
-        "css-tree": "~2.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/cssom": {
@@ -4129,11 +4104,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.23.tgz",
-      "integrity": "sha512-IonVb7pfla2U4zW8rc7XGrtgq11BvYeCxWN8HS+KFBnLDE7XDK9AAMVhRuG6fj9BBsjc69Fqsp6WEActEdNTDQ=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7499,11 +7469,47 @@
       "dependencies": {
         "@stylable/core": "^4.9.3",
         "@tokey/css-selector-parser": "^0.5.1",
-        "csso": "^5.0.2",
+        "csso": "^4.2.0",
         "postcss": "^8.4.5"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "packages/optimizer/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/optimizer/node_modules/csso": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "dependencies": {
+        "css-tree": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/optimizer/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "packages/optimizer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/rollup-plugin": {
@@ -7923,8 +7929,37 @@
       "requires": {
         "@stylable/core": "^4.9.3",
         "@tokey/css-selector-parser": "^0.5.1",
-        "csso": "^5.0.2",
+        "csso": "^4.2.0",
         "postcss": "^8.4.5"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "csso": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+          "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+          "requires": {
+            "css-tree": "^1.1.2"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "@stylable/rollup-plugin": {
@@ -9249,15 +9284,6 @@
         "fastparse": "^1.1.2"
       }
     },
-    "css-tree": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.0.4.tgz",
-      "integrity": "sha512-b4IS9ZUMtGBiNjzYbcj9JhYbyei99R3ai2CSxlu8GQDnoPA/P+NU85hAm0eKDc/Zp660rpK6tFJQ2OSdacMHVg==",
-      "requires": {
-        "mdn-data": "2.0.23",
-        "source-map-js": "^1.0.1"
-      }
-    },
     "css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
@@ -9268,14 +9294,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
-    },
-    "csso": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.2.tgz",
-      "integrity": "sha512-llFAe1UfFHy38ziX+YrPMGkn5MxdjzYtz0drvgnjRY/tLPmBRxotYTGO51BsKe9voQA074pEb0udV+piXH4scQ==",
-      "requires": {
-        "css-tree": "~2.0.4"
-      }
     },
     "cssom": {
       "version": "0.5.0",
@@ -10929,11 +10947,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "mdn-data": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.23.tgz",
-      "integrity": "sha512-IonVb7pfla2U4zW8rc7XGrtgq11BvYeCxWN8HS+KFBnLDE7XDK9AAMVhRuG6fj9BBsjc69Fqsp6WEActEdNTDQ=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@stylable/core": "^4.9.3",
     "@tokey/css-selector-parser": "^0.5.1",
-    "csso": "^5.0.2",
+    "csso": "^4.2.0",
     "postcss": "^8.4.5"
   },
   "files": [

--- a/packages/optimizer/test/stylable-optimizer.spec.ts
+++ b/packages/optimizer/test/stylable-optimizer.spec.ts
@@ -96,4 +96,20 @@ describe('StylableOptimizer', () => {
         const output = new StylableOptimizer().minifyCSS(meta.outputAst!.toString());
         expect(output).to.equal(`.${meta.namespace}__x{color:red}`);
     }).timeout(25000);
+
+    it('preserve white space on string tokens ', () => {
+        const index = '/index.st.css';
+        const files = {
+            [index]: {
+                content: `
+                    .x {
+                        border: 1px solid "color(xxx)";
+                    }
+                `,
+            },
+        };
+        const { meta } = generateStylableResult({ entry: index, files });
+        const output = new StylableOptimizer().minifyCSS(meta.outputAst!.toString());
+        expect(output).to.equal(`.${meta.namespace}__x{border:1px solid "color(xxx)"}`);
+    });
 });


### PR DESCRIPTION
So it turns out `csso@5` which uses `css-tree@2` is kind of broken for our case that uses the `tpa-processor`. it removes whitespace where it (maybe) should not.

I also opened issue in csso repo:
https://github.com/css/csso/issues/447


We might not want to merge this and solve it from outside