### PR TITLE
fix(language-service): stylable completions should be sorted above css completions

### DIFF
--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -298,7 +298,14 @@ export class StylableLanguageService {
 
         for (const stComp of stCompletions) {
             const lspCompletion = CompletionItem.create(stComp.label);
-            const ted: TextEdit = TextEdit.replace(
+
+            if (!groupedCompletions.has(lspCompletion.label)) {
+                groupedCompletions.set(lspCompletion.label, lspCompletion);
+            } else {
+                continue;
+            }
+
+            const textEdit: TextEdit = TextEdit.replace(
                 stComp.range
                     ? stComp.range
                     : new ProviderRange(
@@ -309,7 +316,7 @@ export class StylableLanguageService {
             );
             lspCompletion.insertTextFormat = 2;
             lspCompletion.detail = stComp.detail;
-            lspCompletion.textEdit = ted;
+            lspCompletion.textEdit = textEdit;
             // override sorting order to the top
             // todo: decide on actual sorting for all stylable completions
             lspCompletion.sortText = 'a';
@@ -327,9 +334,6 @@ export class StylableLanguageService {
                     'additional',
                     'editor.action.triggerParameterHints'
                 );
-            }
-            if (!groupedCompletions.has(lspCompletion.label)) {
-                groupedCompletions.set(lspCompletion.label, lspCompletion);
             }
         }
 

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -21,7 +21,6 @@ import {
 import { URI } from 'vscode-uri';
 
 import { ProviderPosition, ProviderRange } from './completion-providers';
-import type { Completion } from './completion-types';
 import { CssService } from './css-service';
 import { dedupeRefs } from './dedupe-refs';
 import { createDiagnosis } from './diagnosis';
@@ -278,7 +277,7 @@ export class StylableLanguageService {
     public getCompletions(document: TextDocument, filePath: string, position: Position) {
         const content = document.getText();
 
-        const res = this.provider.provideCompletionItemsFromSrc(
+        const stCompletions = this.provider.provideCompletionItemsFromSrc(
             content,
             {
                 line: position.line,
@@ -295,41 +294,59 @@ export class StylableLanguageService {
             document.version
         );
 
-        return res
-            .map((com: Completion) => {
-                const lspCompletion: CompletionItem = CompletionItem.create(com.label);
-                const ted: TextEdit = TextEdit.replace(
-                    com.range
-                        ? com.range
-                        : new ProviderRange(
-                              new ProviderPosition(
-                                  position.line,
-                                  Math.max(position.character - 1, 0)
-                              ),
-                              position
-                          ),
-                    typeof com.insertText === 'string' ? com.insertText : com.insertText.source
+        const groupedCompletions = new Map<string, CompletionItem>();
+
+        for (const stComp of stCompletions) {
+            const lspCompletion = CompletionItem.create(stComp.label);
+            const ted: TextEdit = TextEdit.replace(
+                stComp.range
+                    ? stComp.range
+                    : new ProviderRange(
+                          new ProviderPosition(position.line, Math.max(position.character - 1, 0)),
+                          position
+                      ),
+                typeof stComp.insertText === 'string' ? stComp.insertText : stComp.insertText.source
+            );
+            lspCompletion.insertTextFormat = 2;
+            lspCompletion.detail = stComp.detail;
+            lspCompletion.textEdit = ted;
+            // override sorting order to the top
+            // todo: decide on actual sorting for all stylable completions
+            lspCompletion.sortText = 'a';
+            lspCompletion.filterText =
+                typeof stComp.insertText === 'string'
+                    ? stComp.insertText
+                    : stComp.insertText.source;
+            if (stComp.additionalCompletions) {
+                lspCompletion.command = Command.create(
+                    'additional',
+                    'editor.action.triggerSuggest'
                 );
-                lspCompletion.insertTextFormat = 2;
-                lspCompletion.detail = com.detail;
-                lspCompletion.textEdit = ted;
-                lspCompletion.sortText = com.sortText;
-                lspCompletion.filterText =
-                    typeof com.insertText === 'string' ? com.insertText : com.insertText.source;
-                if (com.additionalCompletions) {
-                    lspCompletion.command = Command.create(
-                        'additional',
-                        'editor.action.triggerSuggest'
-                    );
-                } else if (com.triggerSignature) {
-                    lspCompletion.command = Command.create(
-                        'additional',
-                        'editor.action.triggerParameterHints'
-                    );
-                }
-                return lspCompletion;
-            })
-            .concat(this.cssService.getCompletions(cleanDocument, position));
+            } else if (stComp.triggerSignature) {
+                lspCompletion.command = Command.create(
+                    'additional',
+                    'editor.action.triggerParameterHints'
+                );
+            }
+            if (!groupedCompletions.has(lspCompletion.label)) {
+                groupedCompletions.set(lspCompletion.label, lspCompletion);
+            }
+        }
+
+        const cssCompletions = this.cssService.getCompletions(cleanDocument, position);
+
+        for (const cssComp of cssCompletions) {
+            const label = cssComp.label;
+
+            if (!groupedCompletions.has(label)) {
+                // CSS declaration property names have built in sorting
+                // at-rules, rules and declaration values do not
+                cssComp.sortText = cssComp.sortText || 'z';
+                groupedCompletions.set(label, cssComp);
+            }
+        }
+
+        return [...groupedCompletions.values()];
     }
 
     public getDefinitionLocation(src: string, position: ProviderPosition, filePath: string) {

--- a/packages/language-service/test/test-kit/asserters.ts
+++ b/packages/language-service/test/test-kit/asserters.ts
@@ -26,6 +26,19 @@ export function getCaretPosition(src: string) {
     return new ProviderPosition(linesTillCaret.length - 1, character);
 }
 
+export function getCaretOffsetAndCleanContent(content: string) {
+    const offset = content.indexOf('|');
+
+    if (offset === -1) {
+        throw Error('could not find caret in source content');
+    }
+
+    return {
+        offset,
+        content: content.replace('|', ''),
+    };
+}
+
 export function getPath(fileName: string): postcss.Node[] {
     const fullPath = path.join(CASES_PATH, fileName);
     let src: string = fs.readFileSync(fullPath).toString();

--- a/packages/language-service/test/test-kit/stylable-in-memory-lsp.ts
+++ b/packages/language-service/test/test-kit/stylable-in-memory-lsp.ts
@@ -1,0 +1,13 @@
+import { createMemoryFs } from '@file-services/memory';
+import { Stylable } from '@stylable/core';
+import { StylableLanguageService } from '@stylable/language-service';
+
+export function getInMemoryLSP() {
+    const fs = createMemoryFs();
+    const lsp = new StylableLanguageService({
+        fs,
+        stylable: Stylable.create({ fileSystem: fs, projectRoot: '/' }),
+    });
+
+    return { fs, lsp };
+}


### PR DESCRIPTION
### Tasks

- [x] - set Stylable completions to a higher priority compared to the native CSS ones
- [x] - dedupe resulting completions giving Stylable priority
- [x] - create in-memroy testing mechanism for simpler testing
- [x] - add e2e test in `stylable-intelligence` - after merge and publish test can be merged downstream (wix/stylable-intelligence#756)