### PR TITLE
Unify tool to test stylable core

### DIFF
--- a/packages/core-test-kit/README.md
+++ b/packages/core-test-kit/README.md
@@ -123,6 +123,12 @@ Label - `@analyze(LABEL) MESSAGE` / `@transform(LABEL) MESSAGE`
 @keyframes unknown {}
 ```
 
+Removed in transformation - `@transform-remove`
+```css
+/* @transform-remove */
+@import X from './x.st.css';
+```
+
 ## License
 
 Copyright (c) 2019 Wix.com Ltd. All Rights Reserved. Use of this source code is governed by a [MIT license](./LICENSE).

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -24,3 +24,4 @@ export { matchCSSMatchers } from './matchers/match-css';
 export { mediaQuery, styleRules } from './matchers/results';
 export { matchAllRulesAndDeclarations, matchRuleAndDeclaration } from './match-rules';
 export { testInlineExpects, testInlineExpectsErrors } from './inline-expectation';
+export { testStylableCore } from './test-stylable-core';

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -179,7 +179,7 @@ function ruleTest(
         errors: [],
     };
     const { msg, ruleIndex, expectedSelector, expectedBody } = expectation.match(
-        /(?<msg>\(.*\))*(\[(?<ruleIndex>\d+)\])*(?<expectedSelector>[^{}]*)\s*(?<expectedBody>.*)/s
+        /(?<msg>\([^)]*\))*(\[(?<ruleIndex>\d+)\])*(?<expectedSelector>[^{}]*)\s*(?<expectedBody>.*)/s
     )!.groups!;
     const prefix = msg ? msg + `: ` : ``;
     if (!targetNode) {

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -88,6 +88,7 @@ export function testInlineExpects(result: postcss.Root | Context, expectedTestIn
             : getSourceComment(context.meta, comment) || comment;
         const nodeTarget = testCommentTarget.next() as AST;
         const nodeSrc = testCommentSrc.next() as AST;
+        const isRemoved = isRemovedFromTarget(nodeTarget, nodeSrc);
         if (nodeTarget || nodeSrc) {
             while (input.length) {
                 const next = `@` + input.shift()!;
@@ -123,7 +124,7 @@ export function testInlineExpects(result: postcss.Root | Context, expectedTestIn
                             const result = tests[testScope](
                                 context,
                                 testInput.trim(),
-                                nodeTarget,
+                                isRemoved ? undefined : nodeTarget,
                                 nodeSrc
                             );
                             result.type = testScope;
@@ -144,8 +145,13 @@ export function testInlineExpects(result: postcss.Root | Context, expectedTestIn
     }
 }
 
-function checkTest(context: Context, expectation: string, targetNode: AST, srcNode: AST): Test {
-    const type = targetNode?.type;
+function checkTest(
+    context: Context,
+    expectation: string,
+    targetNode: AST | undefined,
+    srcNode: AST
+): Test {
+    const type = srcNode?.type || targetNode?.type;
     switch (type) {
         case `rule`: {
             return tests[`@rule`](context, expectation, targetNode, srcNode);
@@ -161,7 +167,12 @@ function checkTest(context: Context, expectation: string, targetNode: AST, srcNo
             };
     }
 }
-function ruleTest(context: Context, expectation: string, targetNode: AST, _srcNode: AST): Test {
+function ruleTest(
+    context: Context,
+    expectation: string,
+    targetNode: AST | undefined,
+    srcNode: AST
+): Test {
     const result: Test = {
         type: `@rule`,
         expectation,
@@ -170,6 +181,12 @@ function ruleTest(context: Context, expectation: string, targetNode: AST, _srcNo
     const { msg, ruleIndex, expectedSelector, expectedBody } = expectation.match(
         /(?<msg>\(.*\))*(\[(?<ruleIndex>\d+)\])*(?<expectedSelector>[^{}]*)\s*(?<expectedBody>.*)/s
     )!.groups!;
+    const prefix = msg ? msg + `: ` : ``;
+    if (!targetNode) {
+        // ToDo:  maybe support nodes that are removed from target and leaves mixins
+        result.errors.push(testInlineExpectsErrors.removedNode(srcNode.type, prefix));
+        return result;
+    }
     let testNode: AST = targetNode;
     // get mixed-in rule
     if (ruleIndex) {
@@ -207,7 +224,7 @@ function ruleTest(context: Context, expectation: string, targetNode: AST, _srcNo
                 }
             }
         }
-        const prefix = msg ? msg + `: ` : ``;
+
         if (testNode.selector !== expectedSelector.trim()) {
             result.errors.push(
                 testInlineExpectsErrors.selector(expectedSelector.trim(), testNode.selector, prefix)
@@ -244,7 +261,12 @@ function ruleTest(context: Context, expectation: string, targetNode: AST, _srcNo
     }
     return result;
 }
-function atRuleTest(_context: Context, expectation: string, targetNode: AST, _srcNode: AST): Test {
+function atRuleTest(
+    _context: Context,
+    expectation: string,
+    targetNode: AST | undefined,
+    srcNode: AST
+): Test {
     const result: Test = {
         type: `@atrule`,
         expectation,
@@ -257,7 +279,10 @@ function atRuleTest(_context: Context, expectation: string, targetNode: AST, _sr
         return result;
     }
     const prefix = msg ? msg + `: ` : ``;
-    if (targetNode.type === `atrule`) {
+    if (!targetNode) {
+        // ToDo:  maybe support nodes that are removed from target and leaves mixins
+        result.errors.push(testInlineExpectsErrors.removedNode(srcNode.type, prefix));
+    } else if (targetNode.type === `atrule`) {
         if (targetNode.params !== expectedParams.trim()) {
             result.errors.push(
                 testInlineExpectsErrors.atruleParams(
@@ -272,7 +297,12 @@ function atRuleTest(_context: Context, expectation: string, targetNode: AST, _sr
     }
     return result;
 }
-function declTest(_context: Context, expectation: string, targetNode: AST, _srcNode: AST): Test {
+function declTest(
+    _context: Context,
+    expectation: string,
+    targetNode: AST | undefined,
+    srcNode: AST
+): Test {
     const result: Test = {
         type: `@decl`,
         expectation,
@@ -284,7 +314,9 @@ function declTest(_context: Context, expectation: string, targetNode: AST, _srcN
     label = label ? label + `: ` : ``;
     prop = prop.trim();
     value = value.trim();
-    if (!prop || !value) {
+    if (!targetNode) {
+        result.errors.push(testInlineExpectsErrors.removedNode(srcNode.type, label));
+    } else if (!prop || !value) {
         result.errors.push(testInlineExpectsErrors.declMalformed(prop, value, label));
     } else if (targetNode.type === `decl`) {
         if (targetNode.prop !== prop.trim() || targetNode.value !== value) {
@@ -299,10 +331,20 @@ function declTest(_context: Context, expectation: string, targetNode: AST, _srcN
     }
     return result;
 }
-function analyzeTest(context: Context, expectation: string, targetNode: AST, srcNode: AST): Test {
+function analyzeTest(
+    context: Context,
+    expectation: string,
+    targetNode: AST | undefined,
+    srcNode: AST
+): Test {
     return diagnosticTest(`analyze`, context, expectation, targetNode, srcNode);
 }
-function transformTest(context: Context, expectation: string, targetNode: AST, srcNode: AST): Test {
+function transformTest(
+    context: Context,
+    expectation: string,
+    targetNode: AST | undefined,
+    srcNode: AST
+): Test {
     // check node is removed in transformation
     const matchResult = expectation.match(/-remove(?<label>\([^)]*\))?/);
     if (matchResult) {
@@ -326,7 +368,7 @@ function diagnosticTest(
     type: `analyze` | `transform`,
     { meta }: Context,
     expectation: string,
-    _targetNode: AST,
+    _targetNode: AST | undefined,
     srcNode: AST
 ): Test {
     const result: Test = {
@@ -396,6 +438,14 @@ function getSourceComment(meta: Context['meta'], { source }: postcss.Comment) {
     return match;
 }
 
+function isRemovedFromTarget(target: AST, source: AST) {
+    return (
+        !target ||
+        target.source?.start !== source.source?.start ||
+        target.source?.end !== source.source?.end
+    );
+}
+
 function getNextMixinRule(originRule: postcss.Rule, count: number) {
     let current: postcss.Node | undefined = originRule;
     while (current && count > 0) {
@@ -412,6 +462,8 @@ export const testInlineExpectsErrors = {
         `Expected "${expectedAmount}" checks to run but "${actualAmount}" were found`,
     unsupportedNode: (testType: string, nodeType: string, label = ``) =>
         `${label}unsupported type "${testType}" for "${nodeType}"`,
+    removedNode: (nodeType: string, label = ``) =>
+        `${label}fail to check transformation on removed node with type "${nodeType}"`,
     selector: (expectedSelector: string, actualSelector: string, label = ``) =>
         `${label}expected "${actualSelector}" to transform to "${expectedSelector}"`,
     declarations: (expectedDecl: string, actualDecl: string, selector: string, label = ``) =>

--- a/packages/core-test-kit/src/test-stylable-core.ts
+++ b/packages/core-test-kit/src/test-stylable-core.ts
@@ -1,0 +1,26 @@
+import { testInlineExpects } from './inline-expectation';
+import { Stylable, StylableExports, StylableMeta } from '@stylable/core';
+import { createMemoryFs } from '@file-services/memory';
+
+export function testStylableCore(input: string) {
+    // infra
+    const fs = createMemoryFs({ '/entry.st.css': input });
+    const stylable = Stylable.create({
+        fileSystem: fs,
+        projectRoot: '/',
+        resolveNamespace: (ns) => ns,
+    });
+
+    // transform entries
+    const sheets: Record<string, { meta: StylableMeta; exports: StylableExports }> = {};
+    const path = '/entry.st.css';
+    const meta = stylable.process(path);
+    const { exports } = stylable.transform(meta);
+    sheets[path] = { meta, exports };
+
+    // inline test
+    testInlineExpects({ meta });
+
+    // expose infra and entry sheets
+    return { sheets, stylable, fs };
+}

--- a/packages/core-test-kit/src/test-stylable-core.ts
+++ b/packages/core-test-kit/src/test-stylable-core.ts
@@ -1,26 +1,52 @@
 import { testInlineExpects } from './inline-expectation';
 import { Stylable, StylableExports, StylableMeta } from '@stylable/core';
 import { createMemoryFs } from '@file-services/memory';
+import type { IDirectoryContents } from '@file-services/types';
+import { isAbsolute } from 'path';
 
-export function testStylableCore(input: string) {
+export interface TestOptions {
+    entries: string[];
+}
+export function testStylableCore(
+    input: string | IDirectoryContents,
+    options: Partial<TestOptions> = {}
+) {
     // infra
-    const fs = createMemoryFs({ '/entry.st.css': input });
+    const fs = createMemoryFs(typeof input === `string` ? { '/entry.st.css': input } : input);
     const stylable = Stylable.create({
         fileSystem: fs,
         projectRoot: '/',
         resolveNamespace: (ns) => ns,
     });
 
+    // collect sheets
+    const allSheets = fs.findFilesSync(`/`, { filterFile: ({ path }) => path.endsWith(`.st.css`) });
+    const entries = options.entries || allSheets;
+
     // transform entries
     const sheets: Record<string, { meta: StylableMeta; exports: StylableExports }> = {};
-    const path = '/entry.st.css';
-    const meta = stylable.process(path);
-    const { exports } = stylable.transform(meta);
-    sheets[path] = { meta, exports };
+    for (const path of entries) {
+        if (!isAbsolute(path || '')) {
+            throw new Error(testStylableCore.errors.absoluteEntry(path));
+        }
+        const meta = stylable.process(path);
+        const { exports } = stylable.transform(meta);
+        sheets[path] = { meta, exports };
+    }
 
     // inline test
-    testInlineExpects({ meta });
+    for (const path of allSheets) {
+        const meta = stylable.process(path);
+        if (!meta.outputAst) {
+            // ToDo: test
+            stylable.transform(meta);
+        }
+        testInlineExpects({ meta });
+    }
 
     // expose infra and entry sheets
     return { sheets, stylable, fs };
 }
+testStylableCore.errors = {
+    absoluteEntry: (entry: string) => `entry must be absolute path got: ${entry}`,
+};

--- a/packages/core-test-kit/src/test-stylable-core.ts
+++ b/packages/core-test-kit/src/test-stylable-core.ts
@@ -1,22 +1,36 @@
 import { testInlineExpects } from './inline-expectation';
-import { Stylable, StylableExports, StylableMeta } from '@stylable/core';
+import { Stylable, StylableConfig, StylableExports, StylableMeta } from '@stylable/core';
 import { createMemoryFs } from '@file-services/memory';
-import type { IDirectoryContents } from '@file-services/types';
+import type { IDirectoryContents, IFileSystem } from '@file-services/types';
 import { isAbsolute } from 'path';
 
 export interface TestOptions {
     entries: string[];
+    stylableConfig: TestStylableConfig;
 }
+
+export type TestStylableConfig = Omit<
+    StylableConfig,
+    'fileSystem' | `projectRoot` | `resolveNamespace`
+> & {
+    filesystem?: IFileSystem;
+    projectRoot?: StylableConfig['projectRoot'];
+    resolveNamespace?: StylableConfig['resolveNamespace'];
+};
+
 export function testStylableCore(
     input: string | IDirectoryContents,
     options: Partial<TestOptions> = {}
 ) {
     // infra
-    const fs = createMemoryFs(typeof input === `string` ? { '/entry.st.css': input } : input);
+    const fs =
+        options.stylableConfig?.filesystem ||
+        createMemoryFs(typeof input === `string` ? { '/entry.st.css': input } : input);
     const stylable = Stylable.create({
         fileSystem: fs,
         projectRoot: '/',
         resolveNamespace: (ns) => ns,
+        ...(options.stylableConfig || {}),
     });
 
     // collect sheets

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -133,6 +133,11 @@ describe('inline-expectations', () => {
                             }
                             /* @rule(only prop) .entry__malformed {color:}*/
                             .malformed {}
+
+                            /* @rule(with parenthesis) .entry__parenthesis {color: var(--entry-y);}*/
+                            .parenthesis {
+                                color: var(--x);
+                            }
                         `,
                     },
                 },
@@ -158,6 +163,12 @@ describe('inline-expectations', () => {
                     testInlineExpectsErrors.ruleMalformedDecl(
                         `color:`,
                         `(only prop) .entry__malformed {color:}`
+                    ),
+                    testInlineExpectsErrors.declarations(
+                        `color: var(--entry-y)`,
+                        `color: var(--entry-x)`,
+                        `.entry__parenthesis`,
+                        `(with parenthesis): `
                     ),
                 ])
             );

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -324,6 +324,26 @@ describe('inline-expectations', () => {
                 ])
             );
         });
+        it('should throw for removed rule (use @transform-remove for removal check)', () => {
+            const result = generateStylableResult({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            /* @rule(label) .entry__root*/
+                            .root {}
+                        `,
+                    },
+                },
+            });
+
+            result.meta.outputAst?.nodes[1].remove();
+
+            expect(() => testInlineExpects(result)).to.throw(
+                testInlineExpectsErrors.removedNode(`rule`, `(label): `)
+            );
+        });
     });
     describe(`@atrule`, () => {
         it('should throw for at rules params', () => {
@@ -396,6 +416,26 @@ describe('inline-expectations', () => {
 
             expect(() => testInlineExpects(result)).to.throw(
                 testInlineExpectsErrors.unsupportedNode(`@atrule`, `rule`)
+            );
+        });
+        it('should throw for removed rule (use @transform-remove for removal check)', () => {
+            const result = generateStylableResult({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            /* @atrule(label) abc */
+                            @some-rule abc {}
+                        `,
+                    },
+                },
+            });
+
+            result.meta.outputAst?.nodes[1].remove();
+
+            expect(() => testInlineExpects(result)).to.throw(
+                testInlineExpectsErrors.removedNode(`atrule`, `(label): `)
             );
         });
     });
@@ -518,6 +558,28 @@ describe('inline-expectations', () => {
             });
 
             expect(() => testInlineExpects(result)).to.not.throw();
+        });
+        it('should throw for removed declaration (use @transform-remove for removal check)', () => {
+            const result = generateStylableResult({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            .root {
+                                /* @decl(label) color: green */
+                                color: green;
+                            }
+                        `,
+                    },
+                },
+            });
+
+            (result.meta.outputAst?.nodes[0] as any).nodes[1].remove();
+
+            expect(() => testInlineExpects(result)).to.throw(
+                testInlineExpectsErrors.removedNode(`decl`, `(label): `)
+            );
         });
     });
     describe(`@analyze`, () => {

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -781,6 +781,27 @@ describe('inline-expectations', () => {
         });
     });
     describe(`@transform`, () => {
+        it(`should throw on un-removed node`, () => {
+            const result = generateStylableResult({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            /* @transform-remove(not removed) */
+                            .root {}
+                        
+                            /* @transform-remove(removed) */
+                            @st-import A from './imported.st.css';
+                        `,
+                    },
+                },
+            });
+
+            expect(() => testInlineExpects(result)).to.throw(
+                testInlineExpectsErrors.transformRemoved(`rule`, `(not removed): `)
+            );
+        });
         it(`should throw on malformed expectation`, () => {
             const result = generateStylableResult({
                 entry: `/style.st.css`,

--- a/packages/core-test-kit/test/test-stylable-core.spec.ts
+++ b/packages/core-test-kit/test/test-stylable-core.spec.ts
@@ -119,6 +119,19 @@ describe(`testStylableCore()`, () => {
                 })
             ).to.throw();
         });
+        it(`should provide default naive requireModule for JS files`, () => {
+            testStylableCore({
+                '/file.js': `module.exports.jsParam = 'green';`,
+                '/entry.st.css': `
+                    @st-import [jsParam] from './file.js';
+
+                    .root {
+                        /* @decl prop: green */
+                        prop: value(jsParam);
+                    }
+                `,
+            });
+        });
     });
     describe(`stylable config`, () => {
         it(`should pass configuration to stylable instance`, () => {

--- a/packages/core-test-kit/test/test-stylable-core.spec.ts
+++ b/packages/core-test-kit/test/test-stylable-core.spec.ts
@@ -1,5 +1,6 @@
 import { testStylableCore } from '@stylable/core-test-kit';
 import { CSSClass } from '@stylable/core/dist/features';
+import { createMemoryFs } from '@file-services/memory';
 import { expect } from 'chai';
 
 describe(`testStylableCore()`, () => {
@@ -117,6 +118,38 @@ describe(`testStylableCore()`, () => {
                     `,
                 })
             ).to.throw();
+        });
+    });
+    describe(`stylable config`, () => {
+        it(`should pass configuration to stylable instance`, () => {
+            const onProcessCalls: any[] = [];
+            const { sheets } = testStylableCore(``, {
+                stylableConfig: {
+                    onProcess(meta, path) {
+                        onProcessCalls.push({ meta, path });
+                        return meta;
+                    },
+                },
+            });
+
+            expect(onProcessCalls).to.eql([
+                { meta: sheets[`/entry.st.css`].meta, path: `/entry.st.css` },
+            ]);
+        });
+        it(`should use filesystem from configuration (ignore input)`, () => {
+            const inputFS = createMemoryFs({
+                '/abc.st.css': ``,
+            });
+            const { fs, sheets } = testStylableCore(``, {
+                stylableConfig: {
+                    filesystem: inputFS,
+                },
+            });
+
+            expect(fs, `filesystem`).to.equal(inputFS);
+            expect(sheets['/abc.st.css'].exports.classes.root, `sheet from config fs`).to.equal(
+                `abc__root`
+            );
         });
     });
 });

--- a/packages/core-test-kit/test/test-stylable-core.spec.ts
+++ b/packages/core-test-kit/test/test-stylable-core.spec.ts
@@ -44,4 +44,79 @@ describe(`testStylableCore()`, () => {
 
         expect(newMeta.outputAst?.toString().trim()).to.equal(`.entry__part {}`);
     });
+    describe(`multiple files`, () => {
+        it(`should accept a multiple files (transform all by default)`, () => {
+            const { sheets } = testStylableCore({
+                '/a.st.css': ``,
+                '/b.st.css': ``,
+            });
+
+            const a = sheets[`/a.st.css`];
+            const b = sheets[`/b.st.css`];
+
+            expect(CSSClass.get(a.meta, `root`), `a meta`).to.contain({ name: `root` });
+            expect(a.exports.classes.root, `a exports`).equal(`a__root`);
+            expect(CSSClass.get(b.meta, `root`), `b meta`).to.contain({ name: `root` });
+            expect(b.exports.classes.root, `b exports`).equal(`b__root`);
+        });
+        it(`should accept entries to transform`, () => {
+            const { sheets } = testStylableCore(
+                {
+                    '/entry.st.css': ``,
+                    '/a.st.css': ``,
+                    '/b.st.css': ``,
+                },
+                {
+                    entries: [`/a.st.css`, `/b.st.css`],
+                }
+            );
+
+            const entryNotProcessed = sheets[`/entry.st.css`];
+            const a = sheets[`/a.st.css`];
+            const b = sheets[`/b.st.css`];
+
+            expect(entryNotProcessed, `entry not processed`).to.equal(undefined);
+            expect(a.exports.classes.root, `b exports.classes`).to.equal(`a__root`);
+            expect(b.exports.classes.root, `b exports.classes`).to.equal(`b__root`);
+        });
+        it(`should throw on none absolute path entry`, () => {
+            expect(() =>
+                testStylableCore(
+                    {
+                        '/a.st.css': ``,
+                    },
+                    {
+                        entries: [`a.st.css`],
+                    }
+                )
+            ).to.throw(testStylableCore.errors.absoluteEntry(`a.st.css`));
+        });
+        it(`should inline test all files (even these that are not linked to entries)`, () => {
+            expect(() =>
+                testStylableCore({
+                    '/entry.st.css': `
+                        /* @rule .entry__part */
+                        .part {}
+                    `,
+                    '/other.st.css': `
+                        /* @rule .other__part */
+                        .part {}
+                    `,
+                })
+            ).to.not.throw();
+
+            expect(() =>
+                testStylableCore({
+                    '/entry.st.css': `
+                        /* @rule .entry__part */
+                        .part {}
+                    `,
+                    '/other.st.css': `
+                        /* @rule .fail__part */
+                        .part {}
+                    `,
+                })
+            ).to.throw();
+        });
+    });
 });

--- a/packages/core-test-kit/test/test-stylable-core.spec.ts
+++ b/packages/core-test-kit/test/test-stylable-core.spec.ts
@@ -1,0 +1,47 @@
+import { testStylableCore } from '@stylable/core-test-kit';
+import { CSSClass } from '@stylable/core/dist/features';
+import { expect } from 'chai';
+
+describe(`testStylableCore()`, () => {
+    it(`should accept a single "entry.st.css" and return transformed meta/exports`, () => {
+        const { sheets } = testStylableCore(``);
+
+        const { meta, exports } = sheets[`/entry.st.css`];
+
+        expect(CSSClass.get(meta, `root`), `meta`).to.contain({
+            _kind: `class`,
+            name: `root`,
+        });
+        expect(exports.classes.root, `exports.classes`).to.equal(`entry__root`);
+    });
+    it(`should inline test stylable content`, () => {
+        expect(() =>
+            testStylableCore(`
+                /* @rule .entry__pass */
+                .pass {}
+            `)
+        ).to.not.throw();
+
+        expect(() =>
+            testStylableCore(`
+                /* @rule .xxx__fail */
+                .fail {}
+            `)
+        ).to.throw();
+    });
+    it(`should expose stylable instance and filesystem`, () => {
+        const { stylable, fs } = testStylableCore(`.part {}`);
+
+        fs.writeFileSync(
+            `/new.st.css`,
+            `
+            @st-import [part] from './entry.st.css';
+            .part {}
+            `
+        );
+        const newMeta = stylable.process(`/new.st.css`);
+        stylable.transform(newMeta);
+
+        expect(newMeta.outputAst?.toString().trim()).to.equal(`.entry__part {}`);
+    });
+});


### PR DESCRIPTION
This PR adds a single test util `testStylableCore` to the `@stylable/core-test-kit` which provides a single function to test all cases. solves: #1987 .

## tasks
- [x] single entry input
- [x] inline test stylesheets
- [x] multiple file structure input 
- [x] return the processed stylesheets meta and exports
- [x] expose Stylable instance and filesystem
- [x] accept Stylable configuration
- [x] support default `requireModule` for JS
- [x] documentation
- [x] inline testing fixes and capabilities
  - add `@transform-remove` to test a node was removed in output
  - throw when transformation expectations are performed on removed nodes
  - fix parenthesis bug in `@rule` declaration expectation