### PR TITLE
fix(webpack-plugin): crash with webpack@5.66.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "ts-expect": "^1.3.0",
         "typescript": "~4.5.4",
         "url-loader": "^4.1.1",
-        "webpack": "^5.65.0"
+        "webpack": "^5.66.0"
       },
       "engines": {
         "node": ">=12"
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@types/eslint-scope": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.2.tgz",
-      "integrity": "sha512-TzgYCWoPiTeRg6RQYgtuW7iODtVoKu3RVL72k3WohqhjfaOLK5Mg2T4Tg1o2bSfu0vPkoI48wdQFv5b/Xe04wQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.27",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz",
-      "integrity": "sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001298",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -2307,9 +2307,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.39",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.39.tgz",
-      "integrity": "sha512-bFH3gdRq/l7WlzSleiO6dwpZH3RhiJ8vlMq0tOJMfT+5nb+x397eJn2RHF6Ho/9GCKv+BkimNlUMHl9+Yh+Qcg=="
+      "version": "1.4.43",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.43.tgz",
+      "integrity": "sha512-PO3kEfcxPrti/4STbXvCkNIF4fgWvCKl2508e6UI7KomCDffpIfeBZLXsh5DK/XGsjUw3kwq6WEsi0MJTlGAdg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5465,9 +5465,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "version": "3.1.32",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz",
+      "integrity": "sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6909,9 +6909,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.65.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.65.0.tgz",
-      "integrity": "sha512-Q5or2o6EKs7+oKmJo7LaqZaMOlDWQse9Tm5l1WAfU/ujLGN5Pb0SqGeVkN/4bpPmEqEP5RnVhiqsOtWtUVwGRw==",
+      "version": "5.66.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
+      "integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -6927,7 +6927,7 @@
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
@@ -7031,9 +7031,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
-      "integrity": "sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "engines": {
         "node": ">=10.13.0"
       }
@@ -8175,9 +8175,9 @@
       }
     },
     "@types/eslint-scope": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.2.tgz",
-      "integrity": "sha512-TzgYCWoPiTeRg6RQYgtuW7iODtVoKu3RVL72k3WohqhjfaOLK5Mg2T4Tg1o2bSfu0vPkoI48wdQFv5b/Xe04wQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
       "requires": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -8201,9 +8201,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.27",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz",
-      "integrity": "sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -9113,9 +9113,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001298",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ=="
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw=="
     },
     "chai": {
       "version": "4.3.4",
@@ -9654,9 +9654,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.4.39",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.39.tgz",
-      "integrity": "sha512-bFH3gdRq/l7WlzSleiO6dwpZH3RhiJ8vlMq0tOJMfT+5nb+x397eJn2RHF6Ho/9GCKv+BkimNlUMHl9+Yh+Qcg=="
+      "version": "1.4.43",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.43.tgz",
+      "integrity": "sha512-PO3kEfcxPrti/4STbXvCkNIF4fgWvCKl2508e6UI7KomCDffpIfeBZLXsh5DK/XGsjUw3kwq6WEsi0MJTlGAdg=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -11877,9 +11877,9 @@
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.1.30",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-          "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+          "version": "3.1.32",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz",
+          "integrity": "sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw=="
         }
       }
     },
@@ -13004,9 +13004,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.65.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.65.0.tgz",
-      "integrity": "sha512-Q5or2o6EKs7+oKmJo7LaqZaMOlDWQse9Tm5l1WAfU/ujLGN5Pb0SqGeVkN/4bpPmEqEP5RnVhiqsOtWtUVwGRw==",
+      "version": "5.66.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
+      "integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -13022,7 +13022,7 @@
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
@@ -13096,9 +13096,9 @@
       }
     },
     "webpack-sources": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
-      "integrity": "sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
     },
     "whatwg-encoding": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ts-expect": "^1.3.0",
     "typescript": "~4.5.4",
     "url-loader": "^4.1.1",
-    "webpack": "^5.65.0"
+    "webpack": "^5.66.0"
   },
   "engines": {
     "node": ">=12"

--- a/packages/webpack-plugin/src/plugin-utils.ts
+++ b/packages/webpack-plugin/src/plugin-utils.ts
@@ -108,6 +108,7 @@ export function replaceMappedCSSAssetPlaceholders({
             if (isLoadedWithKnownAssetLoader(assetModule)) {
                 return extractFilenameFromAssetModule(assetModule, publicPath);
             } else {
+                const data = new Map<string, unknown>();
                 const assetModuleSource = assetModule.generator.generate(assetModule, {
                     chunkGraph,
                     moduleGraph,
@@ -116,12 +117,16 @@ export function replaceMappedCSSAssetPlaceholders({
                     runtimeTemplate,
                     dependencyTemplates,
                     type: 'asset/resource',
+                    getData: () => data,
                 });
 
                 if (assetModule.buildInfo.dataUrl) {
-                    return extractDataUrlFromAssetModuleSource(
-                        assetModuleSource.source().toString()
-                    );
+                    const dataUrl = data.get('url');
+                    return typeof dataUrl === 'string'
+                        ? dataUrl
+                        : extractDataUrlFromAssetModuleSource(
+                              assetModuleSource.source().toString()
+                          );
                 }
 
                 return publicPath + assetModule.buildInfo.filename;

--- a/packages/webpack-plugin/src/plugin-utils.ts
+++ b/packages/webpack-plugin/src/plugin-utils.ts
@@ -121,12 +121,10 @@ export function replaceMappedCSSAssetPlaceholders({
                 });
 
                 if (assetModule.buildInfo.dataUrl) {
-                    const dataUrl = data.get('url');
-                    return typeof dataUrl === 'string'
-                        ? dataUrl
-                        : extractDataUrlFromAssetModuleSource(
-                              assetModuleSource.source().toString()
-                          );
+                    // Investigate using the data map from getData currently there is an unknown in term from escaping keeping extractDataUrlFromAssetModuleSource
+                    return extractDataUrlFromAssetModuleSource(
+                        assetModuleSource.source().toString()
+                    );
                 }
 
                 return publicPath + assetModule.buildInfo.filename;


### PR DESCRIPTION
while the interface of GeneratorContext clearly states that getData is optional, webpack's new version uses it as it was required. this is one of the downsides of them using ts-in-js with less strictness.

fix is to provide it with an actual map and extract the data uri from there when it's available. kept regex-matching fallback for older versions.