### PR TITLE
fix(core): complex selectors inside nested pseudo-classes

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -449,6 +449,9 @@ export class StylableTransformer {
         }
         const outputAst = splitCompoundSelectors(selectorList);
         context.additionalSelectors.forEach((addSelector) => outputAst.push(addSelector()));
+        for (let i = 0; i < outputAst.length; i++) {
+            selectorAst[i] = outputAst[i];
+        }
         return outputAst;
     }
     private handleCompoundNode(context: Required<ScopeContext>) {
@@ -586,10 +589,7 @@ export class StylableTransformer {
                             : node.nodes
                     ) as Selector[];
                     const nestedContext = context.createNestedContext(innerSelectors);
-                    const transformedSelectors = this.scopeSelectorAst(nestedContext);
-                    for (let i = 0; i < transformedSelectors.length; i++) {
-                        innerSelectors[i] = transformedSelectors[i];
-                    }
+                    this.scopeSelectorAst(nestedContext);
                     /**
                      * ToDo: remove once elements is deprecated!
                      * support deprecated elements.

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
-import { generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
+import { testStylableCore, generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
 import { createWarningRule } from '@stylable/core/dist/helpers/rule';
 
 describe('Stylable postcss transform (Scoping)', () => {
@@ -36,46 +36,26 @@ describe('Stylable postcss transform (Scoping)', () => {
             testInlineExpects(result);
         });
         it('should transform pseudo-element chain inside nested pseudo-classes', () => {
-            const result = generateStylableRoot({
-                entry: `/style.st.css`,
-                files: {
-                    '/style.st.css': {
-                        namespace: 'style',
-                        content: `
-                        @st-import Btn from "./button.st.css";
+            testStylableCore({
+                '/style.st.css': `
+                    @st-import Btn from "./button.st.css";
 
-                        /* @check :is(.button__root .button__label) */
-                        :is(Btn::label) {}
-                        `,
-                    },
-                    '/button.st.css': {
-                        namespace: 'button',
-                        content: `
-                        .label {}
-                        .icon {}
-                        `,
-                    },
-                },
+                    /* @rule :is(.button__root .button__label) */
+                    :is(Btn::label) {}
+                `,
+                '/button.st.css': `
+                    .label {}
+                    .icon {}
+                `,
             });
-
-            testInlineExpects(result);
         });
         it('should transform custom element with multiple selector inside nested pseudo-classes', () => {
-            const result = generateStylableRoot({
-                entry: `/entry.st.css`,
-                files: {
-                    '/entry.st.css': {
-                        namespace: 'entry',
-                        content: `
-                            @custom-selector :--part .partA, .partB;
-                            /* @check .entry__root:not(.entry__partA,.entry__partB) */
-                            .root:not(::part) {}
-                        `,
-                    },
-                },
-            });
+            testStylableCore(`
+                @custom-selector :--part .partA, .partB;
 
-            testInlineExpects(result);
+                /* @rule .entry__root:not(.entry__partA,.entry__partB) */
+                .root:not(::part) {}
+            `);
         });
     });
 

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -40,8 +40,14 @@ describe('Stylable postcss transform (Scoping)', () => {
                 '/style.st.css': `
                     @st-import Btn from "./button.st.css";
 
-                    /* @rule :is(.button__root .button__label) */
+                    /* @rule(single) :is(.button__root .button__label) */
                     :is(Btn::label) {}
+
+                    /* @rule(multi) :is(.button__root .button__label, .button__root .button__icon) */
+                    :is(Btn::label, Btn::icon) {}
+
+                    /* @rule(nested) :is(:where(.button__root .button__label)) */
+                    :is(:where(Btn::label)) {}
                 `,
                 '/button.st.css': `
                     .label {}
@@ -52,9 +58,23 @@ describe('Stylable postcss transform (Scoping)', () => {
         it('should transform custom element with multiple selector inside nested pseudo-classes', () => {
             testStylableCore(`
                 @custom-selector :--part .partA, .partB;
+                @custom-selector :--nestedPart ::part, .partC;
 
-                /* @rule .entry__root:not(.entry__partA,.entry__partB) */
+                /* @rule(1 level) .entry__root:not(.entry__partA,.entry__partB) */
                 .root:not(::part) {}
+
+                /* 
+                    notice: partB is pushed at the end because of how custom selectors are
+                    processed atm.
+
+                    @rule(2 levels) .entry__root:not(.entry__partA,.entry__partC,.entry__partB) 
+                */
+                .root:not(::nestedPart) {}
+
+                /* @rule(custom-selector syntax) 
+                        .entry__root:not(.entry__partA), .entry__root:not(.entry__partB)
+                */
+                .root:not(:--part) {}
             `);
         });
     });

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -35,6 +35,48 @@ describe('Stylable postcss transform (Scoping)', () => {
 
             testInlineExpects(result);
         });
+        it('should transform pseudo-element chain inside nested pseudo-classes', () => {
+            const result = generateStylableRoot({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'style',
+                        content: `
+                        @st-import Btn from "./button.st.css";
+
+                        /* @check :is(.button__root .button__label) */
+                        :is(Btn::label) {}
+                        `,
+                    },
+                    '/button.st.css': {
+                        namespace: 'button',
+                        content: `
+                        .label {}
+                        .icon {}
+                        `,
+                    },
+                },
+            });
+
+            testInlineExpects(result);
+        });
+        it('should transform custom element with multiple selector inside nested pseudo-classes', () => {
+            const result = generateStylableRoot({
+                entry: `/entry.st.css`,
+                files: {
+                    '/entry.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            @custom-selector :--part .partA, .partB;
+                            /* @check .entry__root:not(.entry__partA,.entry__partB) */
+                            .root:not(::part) {}
+                        `,
+                    },
+                },
+            });
+
+            testInlineExpects(result);
+        });
     });
 
     describe('scoped pseudo-elements', () => {


### PR DESCRIPTION
Calling `scopeSelectorAst` is mutative to the input AST. The new selector parser refactor introduced a flaw that we missed - the original input nodes are still mutated, but any addition AST is not inserted into the original input.

This has caused a regression that misses the space added before most pseudo-elements. for example:
`:is(Btn::label)` should be `:is(.btn .label)` and not `:is(.btn.label)`

This PR changes the behavior to be fully mutative, so that any inner changes or additions will now change the original input.

In addition this PR also removes an unwanted space before nested selector: 
`:is(::part)` is now transformed to `:is(.part)` instead of `:is( .part)`



