### PR TITLE
fix: export `StVar` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
     KeyFrameWithNode,
     ResolvedElement,
     StylableExports,
+    StVar,
     StylableResults,
     StylableTransformer,
     TransformHooks,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,7 +35,7 @@ export {
     KeyFrameWithNode,
     ResolvedElement,
     StylableExports,
-    StVar,
+    RuntimeStVar,
     StylableResults,
     StylableTransformer,
     TransformHooks,

--- a/packages/core/src/process-declaration-functions.ts
+++ b/packages/core/src/process-declaration-functions.ts
@@ -1,7 +1,7 @@
 import type { Declaration } from 'postcss';
 import { AnyValueNode, parseValues, stringifyValues } from 'css-selector-tokenizer';
 
-type OnFunction = (node: AnyValueNode, level: number) => void;
+export type OnFunction = (node: AnyValueNode, level: number) => void;
 
 export function processDeclarationFunctions(
     decl: Declaration,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -49,12 +49,12 @@ export interface KeyFrameWithNode {
     node: postcss.Node;
 }
 
-export type StVar = string | { [key: string]: StVar } | StVar[];
+export type RuntimeStVar = string | { [key: string]: RuntimeStVar } | RuntimeStVar[];
 
 export interface StylableExports {
     classes: Record<string, string>;
     vars: Record<string, string>;
-    stVars: Record<string, StVar>;
+    stVars: Record<string, RuntimeStVar>;
     keyframes: Record<string, string>;
 }
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -49,7 +49,7 @@ export interface KeyFrameWithNode {
     node: postcss.Node;
 }
 
-type StVar = string | { [key: string]: StVar } | StVar[];
+export type StVar = string | { [key: string]: StVar } | StVar[];
 
 export interface StylableExports {
     classes: Record<string, string>;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,5 +12,6 @@ export {
     StateMap,
     StateValue,
     StylableExports,
+    StVar,
 } from './types';
 export { DOMListRenderer, createDOMListRenderer } from './keyed-list-renderer';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,6 +12,6 @@ export {
     StateMap,
     StateValue,
     StylableExports,
-    StVar,
+    RuntimeStVar,
 } from './types';
 export { DOMListRenderer, createDOMListRenderer } from './keyed-list-renderer';

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -19,7 +19,7 @@ export interface InheritedAttributes {
     [props: string]: any;
 }
 
-type StVar = string | { [key: string]: StVar } | StVar[];
+export type StVar = string | { [key: string]: StVar } | StVar[];
 
 export interface StylableExports {
     classes: ClassesMap;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -19,12 +19,12 @@ export interface InheritedAttributes {
     [props: string]: any;
 }
 
-export type StVar = string | { [key: string]: StVar } | StVar[];
+export type RuntimeStVar = string | { [key: string]: RuntimeStVar } | RuntimeStVar[];
 
 export interface StylableExports {
     classes: ClassesMap;
     keyframes: Record<string, string>;
-    stVars: Record<string, StVar>;
+    stVars: Record<string, RuntimeStVar>;
     vars: Record<string, string>;
 }
 


### PR DESCRIPTION
Exporting `StVar` type since it's a public API