### PR TITLE
refactor: replace pseudo import syntax to st-import in Stylable fixtures

### DIFF
--- a/packages/custom-value/test/projects/st-border/src/index.st.css
+++ b/packages/custom-value/test/projects/st-border/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "@stylable/custom-value";
-    -st-named: stBorder;
-}
+@st-import [stBorder] from "@stylable/custom-value";
 
 :vars {
     myBorder: stBorder(1px, solid, green);

--- a/packages/experimental-loader/test/projects/basic-integration/foo.st.css
+++ b/packages/experimental-loader/test/projects/basic-integration/foo.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./formatter.js";
-    -st-named: echo;
-}
+@st-import [echo] from "./formatter.js";
 
 .hello {
   color: echo(red);

--- a/packages/experimental-loader/test/projects/two-components-dynamic-order/compB/b.st.css
+++ b/packages/experimental-loader/test/projects/two-components-dynamic-order/compB/b.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "../compA/a.st.css";
-    -st-default: A;
-}
+@st-import A from "../compA/a.st.css";
 
 .root {
     -st-extends: A;

--- a/packages/language-service/test/fixtures/server-cases/colors/color-presentation-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/colors/color-presentation-import.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: "./color-presentation.st.css";
-    -st-named: color1;
-}
+@st-import [color1] from "./color-presentation.st.css";

--- a/packages/language-service/test/fixtures/server-cases/colors/imported-color.st.css
+++ b/packages/language-service/test/fixtures/server-cases/colors/imported-color.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./single-var-color.st.css";
-    -st-named: color1;
-}
+@st-import [color1] from "./single-var-color.st.css";
 
 .root {
     color: value(color1);

--- a/packages/language-service/test/fixtures/server-cases/colors/substring-var-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/colors/substring-var-import.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./substring-var-top.st.css";
-    -st-named: colcol;
-}
+@st-import [colcol] from "./substring-var-top.st.css";
 
 .root {
     color: value(colcol);

--- a/packages/language-service/test/fixtures/server-cases/css-vars/css-vars.st.css
+++ b/packages/language-service/test/fixtures/server-cases/css-vars/css-vars.st.css
@@ -1,9 +1,6 @@
 @st-global-custom-property --y;
 
-:import {
-    -st-from: "./css-vars-level2.st.css";
-    -st-named: --x2, --y2;
-}
+@st-import [--x2, --y2] from "./css-vars-level2.st.css";
 
 .root {
     --x: red;

--- a/packages/language-service/test/fixtures/server-cases/custom-selectors/import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/custom-selectors/import.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: './top-import.st.css';
-    -st-default: Comp;
-}
+@st-import Comp from "./top-import.st.css";
 
 @custom-selector :--pongo div > Comp;
 

--- a/packages/language-service/test/fixtures/server-cases/custom-selectors/inside-selector-def.st.css
+++ b/packages/language-service/test/fixtures/server-cases/custom-selectors/inside-selector-def.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from:"./import.st.css";
-    -st-default:Comp;
-    -st-named:shlomo;
-}
+@st-import Comp, [shlomo] from "./import.st.css";
 
 @custom-selector :--popo div > Comp;
 

--- a/packages/language-service/test/fixtures/server-cases/custom-selectors/recursive-import-2.st.css
+++ b/packages/language-service/test/fixtures/server-cases/custom-selectors/recursive-import-2.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: './recursive-import-1.st.css';
-    -st-default: Comp;
-}
+@st-import Comp from "./recursive-import-1.st.css";
 
 @custom-selector :--bongo Comp .root;
 

--- a/packages/language-service/test/fixtures/server-cases/definitions/3rd-party-mixins-named-js.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/3rd-party-mixins-named-js.st.css
@@ -1,5 +1,2 @@
-:import {
-    -st-from: "fake-stylable-package/js-mixins.js";
-    -st-named: aM|ixin, aBareMixin, aFormatter;
-}
+@st-import [aM|ixin, aBareMixin, aFormatter] from "fake-stylable-package/js-mixins.js";
 

--- a/packages/language-service/test/fixtures/server-cases/definitions/3rd-party-var-named.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/3rd-party-var-named.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "fake-stylable-package/stylesheet.st.css";
-    -st-named: color|1;
-}
+@st-import [color|1] from "fake-stylable-package/stylesheet.st.css";
 
 .local {
     color: value(color1);

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-class-3rd-party.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-class-3rd-party.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "fake-stylable-package/stylesheet.st.css";
-    -st-named: part1;
-}
+@st-import [part1] from "fake-stylable-package/stylesheet.st.css";
 
 .local {
     -st-extends: par|t1;

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-class-extend.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-class-extend.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: momo;
-}
+@st-import [momo] from "./import.st.css";
 
 .local {
     -st-extends: m|omo;

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-class-named.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-class-named.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: mo|mo;
-}
+@st-import [mo|mo] from "./import.st.css";
 
 .local {
     -st-extends: momo;

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-class-pseudo-element.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-class-pseudo-element.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: momo;
-}
+@st-import [momo] from "./import.st.css";
 
 .local {
     -st-extends: momo;

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-default.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-default.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Co|mp;
-}
+@st-import Co|mp from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-named-js.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-named-js.st.css
@@ -1,8 +1,4 @@
-
-:import {
-    -st-from: "../mixins/js-mixins.js";
-    -st-named: aM|ixin, aBareMixin, aFormatter;
-}
+@st-import [aM|ixin, aBareMixin, aFormatter] from "../mixins/js-mixins.js";
 
 .local {
     color: notARealMixin();

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-named-ts.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-named-ts.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "../mixins/my-mixins.ts";
-    -st-named: paramlessMixin, param|fulMixin, notARealMixin;
-}
+@st-import [paramlessMixin, param|fulMixin, notARealMixin] from "../mixins/my-mixins.ts";
 
-:import {
-    -st-from: "../mixins/js-mixins.js";
-    -st-named: aMixin, aBareMixin, aFormatter;
-}
+@st-import [aMixin, aBareMixin, aFormatter] from "../mixins/js-mixins.js";
 
 .local {
     color: notARealMixin();

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-value-js.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-value-js.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "../mixins/my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin, notARealMixin;
-}
+@st-import [paramlessMixin, paramfulMixin, notARealMixin] from "../mixins/my-mixins.ts";
 
-:import {
-    -st-from: "../mixins/js-mixins.js";
-    -st-named: aMixin, aBareMixin, aFormatter;
-}
+@st-import [aMixin, aBareMixin, aFormatter] from "../mixins/js-mixins.js";
 
 .local {
     color: notARealMixin();

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-value-ts.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-mixins-value-ts.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "../mixins/my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin, paramlessFormatter;
-}
+@st-import [paramlessMixin, paramfulMixin, paramlessFormatter] from "../mixins/my-mixins.ts";
 
-:import {
-    -st-from: "../mixins/js-mixins.js";
-    -st-named: aMixin, aBareMixin, aFormatter;
-}
+@st-import [aMixin, aBareMixin, aFormatter] from "../mixins/js-mixins.js";
 
 .local {
     color: paramlessFormat|ter();

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-path.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-path.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: "./impo|rt.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./impo|rt.st.css";

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-var-named.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-var-named.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: bV|ar;
-}
+@st-import [bV|ar] from "./import.st.css";
 
 .local {
     color: value(bVar);

--- a/packages/language-service/test/fixtures/server-cases/definitions/imported-var-value.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/imported-var-value.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: bVar;
-}
+@st-import [bVar] from "./import.st.css";
 
 .local {
     color: value(b|Var);

--- a/packages/language-service/test/fixtures/server-cases/definitions/states-deep.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/states-deep.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./states-default.st.css";
-    -st-named: local;
-}
+@st-import [local] from "./states-default.st.css";
 
 .deep {
     -st-extends: local;

--- a/packages/language-service/test/fixtures/server-cases/definitions/states-default.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/states-default.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./states-import.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./states-import.st.css";
 
 .root Comp:rootState {}
 

--- a/packages/language-service/test/fixtures/server-cases/definitions/states-named.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/states-named.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./states-import.st.css";
-    -st-named: one, two;
-}
+@st-import [one, two] from "./states-import.st.css";
 
 .root .one:topState {}
 

--- a/packages/language-service/test/fixtures/server-cases/definitions/states-very-deep.st.css
+++ b/packages/language-service/test/fixtures/server-cases/definitions/states-very-deep.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./states-deep.st.css";
-    -st-named: deep;
-}
+@st-import [deep] from "./states-deep.st.css";
 
 .veryDeep {
     -st-extends: deep;

--- a/packages/language-service/test/fixtures/server-cases/general/missing-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/general/missing-import.st.css
@@ -1,6 +1,3 @@
-:import {
-    -st-from: "./missing-import.st.css";
-    -st-named: btn;
-}
+@st-import [btn] from "./missing-import.st.css";
 
 .btn:|

--- a/packages/language-service/test/fixtures/server-cases/imports/from-package/st-extends.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/from-package/st-extends.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from: 'fake-stylable-package/stylesheet.st.css';
-    -st-default: Comp;
-    -st-named: part1, color1;
-}
+@st-import Comp, [part1, color1] from "fake-stylable-package/stylesheet.st.css";
 
 .gaga{
     -st-extends:|

--- a/packages/language-service/test/fixtures/server-cases/imports/from-package/value.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/from-package/value.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "fake-stylable-package/stylesheet.st.css";
-    -st-named: color1;
-}
+@st-import [color1] from "fake-stylable-package/stylesheet.st.css";
 
 .root {
     color: value(|);

--- a/packages/language-service/test/fixtures/server-cases/imports/st-extends-mixins.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/st-extends-mixins.st.css
@@ -1,19 +1,8 @@
-:import{
-    -st-from:"./import-from-here.st.css";
-    -st-default:Comp;
-    -st-named: shlomo, oneVar, twoVar;
-}
+@st-import Comp, [shlomo, oneVar, twoVar] from "./import-from-here.st.css";
 
-:import {
-    -st-from: "../mixins/my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin, notARealMixin;
-    -st-default: mixin;
-}
+@st-import mixin, [paramlessMixin, paramfulMixin, notARealMixin] from "../mixins/my-mixins.ts";
 
-:import {
-    -st-from: "../mixins/js-mixins.js";
-    -st-named: aMixin, aBareMixin, aFormatter;
-}
+@st-import [aMixin, aBareMixin, aFormatter] from "../mixins/js-mixins.js";
 
 .gaga{
     -st-extends:|

--- a/packages/language-service/test/fixtures/server-cases/imports/st-extends-with-semicolon.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/st-extends-with-semicolon.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from:"./import-from-here.st.css";
-    -st-default:Comp;
-    -st-named:shlomo;
-}
+@st-import Comp, [shlomo] from "./import-from-here.st.css";
 
 .gaga{
     -st-extends:|   ;

--- a/packages/language-service/test/fixtures/server-cases/imports/st-extends.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/st-extends.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from:"./import-from-here.st.css";
-    -st-default:Comp;
-    -st-named: shlomo
-}
+@st-import Comp, [shlomo] from "./import-from-here.st.css";
 
 .gaga{
     -st-extends:|

--- a/packages/language-service/test/fixtures/server-cases/imports/st-from.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/st-from.st.css
@@ -1,3 +1,1 @@
-:import{
-    -st-from:|
-}
+@st-import  from "|";

--- a/packages/language-service/test/fixtures/server-cases/imports/top-level-import-exists.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/top-level-import-exists.st.css
@@ -1,9 +1,6 @@
 @namespace "moshe";
 
-:import {
-    -st-from: "./import-from-here.st.css";
-    -st-named: shlomo;
-}
+@st-import [shlomo] from "./import-from-here.st.css";
 
 :vars {
     color1: red;

--- a/packages/language-service/test/fixtures/server-cases/mixins/3rd-party-css-mixin.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/3rd-party-css-mixin.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "fake-stylable-package/stylesheet.st.css";
-    -st-named: part1;
-}
+@st-import [part1] from "fake-stylable-package/stylesheet.st.css";
 
 .root {
     -st-mixin:|

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-formatters-single-value.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-formatters-single-value.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessFormatter, formatterWithParams;
-}
+@st-import [paramlessFormatter, formatterWithParams] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./js-mixins.js";
-    -st-named: aFormatter, aFormatterWithParams;
-}
+@st-import [aFormatter, aFormatterWithParams] from "./js-mixins.js";
 
 .myClass {
     color: aFormatterWithParams('25','aaa','a'), |

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-formatters.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-formatters.st.css
@@ -1,13 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin, paramlessFormatter, formatterWithParams;
-    -st-default: mixin;
-}
+@st-import mixin, [paramlessMixin, paramfulMixin, paramlessFormatter, formatterWithParams] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./js-mixins.js";
-    -st-named: aMixin, aBareMixin, aFormatter, aFormatterWithParams;
-}
+@st-import [aMixin, aBareMixin, aFormatter, aFormatterWithParams] from "./js-mixins.js";
 
 .myClass {
     color: |

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-default-paramful-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-default-paramful-signature.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-default: mixin;
-}
+@st-import mixin from "./my-mixins.ts";
 
-:import {
-    -st-from: "./my-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./my-mixins.js";
 
 .myClass {
     -st-mixin: mixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-dts-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-dts-signature.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./transpiled-mixins.js";
-    -st-named: paramfulMixin, paramlessMixin;
-}
+@st-import [paramfulMixin, paramlessMixin] from "./transpiled-mixins.js";
 
 .myClass {
     -st-mixin: paramfulMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-js-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-js-signature.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./js-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./js-mixins.js";
 
 .myClass {
     -st-mixin: aMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-signature-outside-1.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-signature-outside-1.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./my-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./my-mixins.js";
 
 .myClass {
     -st-mixin: paramfulMixin()|,

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-signature-outside-2.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-signature-outside-2.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./my-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./my-mixins.js";
 
 .myClass {
     -st-mixin: paramful|Mixin()

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramful-signature.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./my-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./my-mixins.js";
 
 .myClass {
     -st-mixin: paramfulMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramless-dts-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramless-dts-signature.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./transpiled-mixins.js";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./transpiled-mixins.js";
 
 .myClass {
     -st-mixin: paramlessMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramless-js-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramless-js-signature.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./js-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./js-mixins.js";
 
 .myClass {
     -st-mixin: aBareMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramless-signature.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-paramless-signature.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./my-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./my-mixins.js";
 
 .myClass {
     -st-mixin: paramlessMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-single-value.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-single-value.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin;
-}
+@st-import [paramlessMixin, paramfulMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./js-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "./js-mixins.js";
 
 .myClass {
     -st-mixin: paramfulMixin('25','aaa','a'), |

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-third-party.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins-third-party.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "fake-stylable-package/js-mixins.js";
-    -st-named: aMixin, aBareMixin;
-}
+@st-import [aMixin, aBareMixin] from "fake-stylable-package/js-mixins.js";
 
 .myClass {
     -st-mixin: aMixin(|)

--- a/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins.st.css
+++ b/packages/language-service/test/fixtures/server-cases/mixins/imported-mixins.st.css
@@ -1,13 +1,6 @@
-:import {
-    -st-from: "./my-mixins.ts";
-    -st-named: paramlessMixin, paramfulMixin, notARealMixin;
-    -st-default: mixin;
-}
+@st-import mixin, [paramlessMixin, paramfulMixin, notARealMixin] from "./my-mixins.ts";
 
-:import {
-    -st-from: "./js-mixins.js";
-    -st-named: aMixin, aBareMixin, aFormatter;
-}
+@st-import [aMixin, aBareMixin, aFormatter] from "./js-mixins.js";
 
 .myClass {
     -st-mixin: |

--- a/packages/language-service/test/fixtures/server-cases/named/st-named-mixin.st.css
+++ b/packages/language-service/test/fixtures/server-cases/named/st-named-mixin.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: '../mixins/js-mixins.js';
-    -st-named: |
-}
+@st-import [|] from "../mixins/js-mixins.js";

--- a/packages/language-service/test/fixtures/server-cases/named/st-named-multi-line.st.css
+++ b/packages/language-service/test/fixtures/server-cases/named/st-named-multi-line.st.css
@@ -1,5 +1,1 @@
-:import {
-    -st-from: './import.st.css';
-    -st-named: shlomo, poopy,
-    |
-}
+@st-import [shlomo, poopy, |] from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/named/st-named-multi-values.st.css
+++ b/packages/language-service/test/fixtures/server-cases/named/st-named-multi-values.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: './import.st.css';
-    -st-named: shlomo, poopy,|
-}
+@st-import [shlomo, poopy, |] from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/named/st-named-single-value.st.css
+++ b/packages/language-service/test/fixtures/server-cases/named/st-named-single-value.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: './import.st.css';
-    -st-named: shlomo,|
-}
+@st-import [shlomo, |] from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/named/st-named.st.css
+++ b/packages/language-service/test/fixtures/server-cases/named/st-named.st.css
@@ -1,4 +1,1 @@
-:import {
-    -st-from: './import.st.css';
-    -st-named: |
-}
+@st-import [|] from "./import.st.css";

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/custom-selector-local.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/custom-selector-local.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from:"./import.st.css";
-    -st-default:Comp;
-    -st-named:shlomo;
-}
+@st-import Comp, [shlomo] from "./import.st.css";
 
 @custom-selector :--popo div > Comp;
 

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-as-tag-css-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-as-tag-css-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
- }
+@st-import Comp from "./import.st.css";
 
 Comp {
     -st-states: localState;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-as-tag-imported-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-as-tag-imported-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
- }
+@st-import Comp from "./import.st.css";
 
 Comp {
     -st-states: localState;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-as-tag-local-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-as-tag-local-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
- }
+@st-import Comp from "./import.st.css";
 
 Comp {
     -st-states: localState;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-extended-css-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-extended-css-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./import.st.css";
 
 .local {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-extended-imported-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-extended-imported-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./import.st.css";
 
 .local {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-extended-local-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-extended-local-state.st.css
@@ -1,8 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: shlomo, momo;
-    -st-default: Comp;
-}
+@st-import Comp, [shlomo, momo] from "./import.st.css";
 
 .gaga {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-with-native-class.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/default-import-with-native-class.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./import.st.css";
 
 .local {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/mid-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/mid-import.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./import.st.css";
 
 .bobo {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/multiple-states.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/multiple-states.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./import.st.css";
 
 .local {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/named-import-extended-css-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/named-import-extended-css-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./mid-import.st.css";
-    -st-named: bobo;
-}
+@st-import [bobo] from "./mid-import.st.css";
 
 .gaga {
     -st-extends: bobo;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/named-import-extended-imported-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/named-import-extended-imported-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./mid-import.st.css";
-    -st-named: bobo;
-}
+@st-import [bobo] from "./mid-import.st.css";
 
 .gaga {
     -st-extends: bobo;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/named-import-extended-local-state.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/named-import-extended-local-state.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./mid-import.st.css";
-    -st-named: bobo;
-}
+@st-import [bobo] from "./mid-import.st.css";
 
 .gaga {
     -st-extends: bobo;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/other-mid-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/other-mid-import.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: momo;
-}
+@st-import [momo] from "./import.st.css";
 
 .bobo {
     -st-extends: momo;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-1.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-1.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./recursive-import-0.st.css";
-    -st-default: Compi;
-}
+@st-import Compi from "./recursive-import-0.st.css";
 
 .shlomo {
     color: black;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-2.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-2.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./recursive-import-1.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./recursive-import-1.st.css";
 
 .bobo {
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-3-mixin-multiple-values.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-3-mixin-multiple-values.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./recursive-import-2.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./recursive-import-2.st.css";
 
-:import {
-    -st-from: "./recursive-import-1.st.css";
-    -st-named: momo, shlomo;
-}
+@st-import [momo, shlomo] from "./recursive-import-1.st.css";
 
 .local {
     color: fuchsia;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-3-mixin-single-value.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-3-mixin-single-value.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./recursive-import-2.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./recursive-import-2.st.css";
 
-:import {
-    -st-from: "./recursive-import-1.st.css";
-    -st-named: momo, shlomo;
-}
+@st-import [momo, shlomo] from "./recursive-import-1.st.css";
 
 .local {
     color: fuchsia;

--- a/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-3-mixin.st.css
+++ b/packages/language-service/test/fixtures/server-cases/pseudo-elements/recursive-import-3-mixin.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./recursive-import-2.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./recursive-import-2.st.css";
 
-:import {
-    -st-from: "./recursive-import-1.st.css";
-    -st-named: momo, shlomo;
-}
+@st-import [momo, shlomo] from "./recursive-import-1.st.css";
 
 .local {
     color: fuchsia;

--- a/packages/language-service/test/fixtures/server-cases/references/classes-import-default.st.css
+++ b/packages/language-service/test/fixtures/server-cases/references/classes-import-default.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./classes-top.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./classes-top.st.css";
 
 .root Comp {}
 

--- a/packages/language-service/test/fixtures/server-cases/references/classes-import-named.st.css
+++ b/packages/language-service/test/fixtures/server-cases/references/classes-import-named.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./classes-top.st.css";
-    -st-named: aaa,bbb,ccc;
-}
+@st-import [aaa, bbb, ccc] from "./classes-top.st.css";
 
 .root .aaa .bbb .ccc {
 

--- a/packages/language-service/test/fixtures/server-cases/references/vars.st.css
+++ b/packages/language-service/test/fixtures/server-cases/references/vars.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./var-import.st.css";
-    -st-named: someVar;
-}
+@st-import [someVar] from "./var-import.st.css";
 
 .local {
     color: value(someVar);

--- a/packages/language-service/test/fixtures/server-cases/states/locally-imported-component-with-states.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/locally-imported-component-with-states.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from: "./comp-to-import.st.css";
-    -st-default: Comp;
-
-}
+@st-import Comp from "./comp-to-import.st.css";
 
 .gaga{
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/states/locally-imported-component.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/locally-imported-component.st.css
@@ -1,8 +1,4 @@
-:import{
-    -st-from: "./comp-to-import.st.css";
-    -st-default: Comp;
-
-}
+@st-import Comp from "./comp-to-import.st.css";
 
 .gaga{
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/states/mid-level-import.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/mid-level-import.st.css
@@ -1,7 +1,4 @@
-:import{
-    -st-from: "./comp-to-import.st.css";
-    -st-default: Zag;
-}
+@st-import Zag from "./comp-to-import.st.css";
 .root{
     -st-extends:Zag;
     -st-states:hoover;

--- a/packages/language-service/test/fixtures/server-cases/states/with-param/enum/imported-state-with-enum-middle.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/with-param/enum/imported-state-with-enum-middle.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./state-with-enum.st.css";
-    -st-default: Enum;
-}
+@st-import Enum from "./state-with-enum.st.css";
 
 .blah {
     -st-extends: Enum;

--- a/packages/language-service/test/fixtures/server-cases/states/with-param/enum/imported-state-with-enum-start.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/with-param/enum/imported-state-with-enum-start.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./state-with-enum.st.css";
-    -st-default: Enum;
-}
+@st-import Enum from "./state-with-enum.st.css";
 
 .blah {
     -st-extends: Enum;

--- a/packages/language-service/test/fixtures/server-cases/states/with-param/imported-state-param-and-validators-suggestion.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/with-param/imported-state-param-and-validators-suggestion.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./comp-to-import-with-param-and-validators.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./comp-to-import-with-param-and-validators.st.css";
 
 .gaga{
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/states/with-param/imported-state-param-suggestion.st.css
+++ b/packages/language-service/test/fixtures/server-cases/states/with-param/imported-state-param-suggestion.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./comp-to-import-with-param.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./comp-to-import-with-param.st.css";
 
 .gaga{
     -st-extends: Comp;

--- a/packages/language-service/test/fixtures/server-cases/variables/complex-selector.st.css
+++ b/packages/language-service/test/fixtures/server-cases/variables/complex-selector.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: './import.st.css';
-    -st-default: Comp;
-}
+@st-import Comp from "./import.st.css";
 
 :vars {
     color1: red;

--- a/packages/language-service/test/fixtures/server-cases/variables/inside-value-defined-var.st.css
+++ b/packages/language-service/test/fixtures/server-cases/variables/inside-value-defined-var.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: color1, color2;
-}
+@st-import [color1, color2] from "./import.st.css";
 
 .local {
     localVar: value(|)

--- a/packages/language-service/test/fixtures/server-cases/variables/inside-value-imported-vars.st.css
+++ b/packages/language-service/test/fixtures/server-cases/variables/inside-value-imported-vars.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./import.st.css";
-    -st-named: color1, color2;
-}
+@st-import [color1, color2] from "./import.st.css";
 
 .local {
     color: value(), value( | )

--- a/packages/webpack-extensions/test/e2e/projects/manifest-plugin/Button.comp.st.css
+++ b/packages/webpack-extensions/test/e2e/projects/manifest-plugin/Button.comp.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./common.st.css";
-    -st-named: myColor;
-}
+@st-import [myColor] from "./common.st.css";
 
 .root {
     --myColor: red;

--- a/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/index.st.css
+++ b/packages/webpack-extensions/test/e2e/projects/metadata-loader-case/index.st.css
@@ -1,8 +1,5 @@
 @st-import CompX from "./comp-x.st.css";
-:import {
-    -st-from: "./comp.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "./comp.st.css";
 
 .root {
     -st-extends: Comp;

--- a/packages/webpack-extensions/test/e2e/projects/metadata-plugin-project/src/index.st.css
+++ b/packages/webpack-extensions/test/e2e/projects/metadata-plugin-project/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button, Gallery;
-}
+@st-import [Button, Gallery] from "test-components/index.st.css";
 
 .root Button {}
 .root Gallery {}

--- a/packages/webpack-plugin/test/e2e/projects/3rd-party-standalone/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/3rd-party-standalone/src/index.st.css
@@ -1,9 +1,6 @@
 @namespace "SRCIndex";
 
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 Button {
     font-size: 2em;

--- a/packages/webpack-plugin/test/e2e/projects/3rd-party/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/3rd-party/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 Button {
     font-size: 2em;

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/src/index.st.css
@@ -1,9 +1,6 @@
 @namespace "mainIndex";
 
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 .root {
     -st-mixin: Button;

--- a/packages/webpack-plugin/test/e2e/projects/bad-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/bad-project/src/index.st.css
@@ -1,8 +1,4 @@
-
-:import {
-    -st-from: "./comp.st.css";
-    -st-named: unknown;
-}
+@st-import [unknown] from "./comp.st.css";
 
 .root {
     background-color: value(xxx); 

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/src/app.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/src/app.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 Button {
     font-size: 35px;

--- a/packages/webpack-plugin/test/e2e/projects/dev-mode-warnings-project/src/comp.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/dev-mode-warnings-project/src/comp.st.css
@@ -1,12 +1,6 @@
-:import {
-    -st-from: "./other.st.css";
-    -st-default: Other;
-}
+@st-import Other from "./other.st.css";
 
-:import {
-    -st-from: "./not-direct.st.css";
-    -st-named: Other as NotDirect;
-}
+@st-import [Other as NotDirect] from "./not-direct.st.css";
 
 .root {
     -st-extends: Other;

--- a/packages/webpack-plugin/test/e2e/projects/dev-mode-warnings-project/src/not-direct.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/dev-mode-warnings-project/src/not-direct.st.css
@@ -1,6 +1,3 @@
-:import {
-    -st-from: "./other.st.css";
-    -st-default: Other;
-}
+@st-import Other from "./other.st.css";
 
 .root Other {}

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-chunk-3rd-party-split-project/src/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-chunk-3rd-party-split-project/src/button.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 .root {
     -st-extends: Button;

--- a/packages/webpack-plugin/test/e2e/projects/dynamic-chunk-3rd-party-split-project/src/gallery.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/dynamic-chunk-3rd-party-split-project/src/gallery.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Label;
-}
+@st-import [Label] from "test-components/index.st.css";
 
 .root {
     background-color: red;

--- a/packages/webpack-plugin/test/e2e/projects/errors-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/errors-project/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./test.st.css";
-    -st-named: NotFound;
-}
+@st-import [NotFound] from "./test.st.css";
 
 .root {
     -st-extends: NotFound;

--- a/packages/webpack-plugin/test/e2e/projects/inclusion-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/inclusion-project/src/index.st.css
@@ -1,22 +1,10 @@
-:import {
-    -st-from: "./not-included.st.css";
-    -st-named: x;
-}
+@st-import [x] from "./not-included.st.css";
 
-:import {
-    -st-from: "./included-via-compse.st.css";
-    -st-named: x as x1;
-}
+@st-import [x as x1] from "./included-via-compse.st.css";
 
-:import {
-    -st-from: "./not-included-explicit-global.st.css";
-    -st-default: WithGlobals;
-}
+@st-import WithGlobals from "./not-included-explicit-global.st.css";
 
-:import {
-    -st-from: "./included-via-keyframes.st.css";
-    -st-named: keyframes(x);
-}
+@st-import [keyframes(x)] from "./included-via-keyframes.st.css";
 
 WithGlobals {}
 

--- a/packages/webpack-plugin/test/e2e/projects/mixins-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/mixins-project/src/index.st.css
@@ -1,17 +1,8 @@
-:import {
-    -st-from: "./mixin";
-    -st-named: Mixin;
-}
+@st-import [Mixin] from "./mixin";
 
-:import {
-    -st-from: "./mixin2";
-    -st-named: Mixin as Mixin2;
-}
+@st-import [Mixin as Mixin2] from "./mixin2";
 
-:import {
-    -st-from: "./functions.js";
-    -st-named: add;
-}
+@st-import [add] from "./functions.js";
 
 .root {
     -st-mixin: Mixin(1, "2"), Mixin2(1px solid rgb(255, 0, 0));

--- a/packages/webpack-plugin/test/e2e/projects/multiple-chunks-split/src/commons/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/multiple-chunks-split/src/commons/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./c.st.css";
-    -st-default: C;
-}
+@st-import C from "./c.st.css";
 
 .root {
     color: chocolate;

--- a/packages/webpack-plugin/test/e2e/projects/namespace-generation-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/namespace-generation-project/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-package/index.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "test-package/index.st.css";
 
 .root { background-color: red; }
 .Comp { background-color: red; }

--- a/packages/webpack-plugin/test/e2e/projects/optimizations/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/optimizations/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 :vars {
     myValue: red;

--- a/packages/webpack-plugin/test/e2e/projects/project-with-3rd-party-mixin-assets/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/project-with-3rd-party-mixin-assets/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/mix.st.css";
-    -st-default: Comp;
-}
+@st-import Comp from "test-components/mix.st.css";
 
 .css {
     -st-mixin: Comp;

--- a/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/resolve-js-with-context/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test1/comp.st.css";
-    -st-named: x;
-}
+@st-import [x] from "test1/comp.st.css";
 
 .root {
     -st-mixin: x;

--- a/packages/webpack-plugin/test/e2e/projects/split-chunks/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/split-chunks/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "lib/index.st.css";
-    -st-default: Lib;
-}
+@st-import Lib from "lib/index.st.css";
 .root {
     -st-extends: Lib;
     background-color: red; 

--- a/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/tsconfig-resolver-plugin/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "test-components/index.st.css";
-    -st-named: Button;
-}
+@st-import [Button] from "test-components/index.st.css";
 
 Button {
     font-size: 2em;

--- a/packages/webpack-plugin/test/e2e/projects/unsafe-mute-diagnostics/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/unsafe-mute-diagnostics/src/index.st.css
@@ -1,9 +1,3 @@
-:import {
-    -st-from: "lib1/index.st.css";
-    -st-default: Lib1;
-}
-:import {
-    -st-from: "lib2/index.st.css";
-    -st-default: Lib2;
-}
+@st-import Lib1 from "lib1/index.st.css";
+@st-import Lib2 from "lib2/index.st.css";
 .root {}

--- a/packages/webpack-plugin/test/e2e/projects/watched-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/watched-project/src/index.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./mixin-a.st.css";
-    -st-named: a;
-}
+@st-import [a] from "./mixin-a.st.css";
 
 .root {
     -st-mixin: a;

--- a/packages/webpack-plugin/test/e2e/projects/watched-project/src/mixin-a.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/watched-project/src/mixin-a.st.css
@@ -1,7 +1,4 @@
-:import {
-    -st-from: "./mixin-b.st.css";
-    -st-named: b;
-}
+@st-import [b] from "./mixin-b.st.css";
 
 .a {
     -st-mixin: b;


### PR DESCRIPTION
As part of the Unify Stylable API #2002 issue, we want to switch all the old pseudo import syntax to the new st-import syntax.