### PR TITLE
feat(cli): preserve watch output

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,7 +7,13 @@ import { createLogger } from './logger';
 async function main() {
     const argv = getCliArguments();
     const { resolve } = fs;
-    const { watch, require: requires, log: shouldLog, namespaceResolver } = argv;
+    const {
+        watch,
+        require: requires,
+        log: shouldLog,
+        namespaceResolver,
+        preserveWatchOutput,
+    } = argv;
     const { resolveNamespace } = require(namespaceResolver);
     const rootDir = resolve(argv.rootDir);
 
@@ -19,7 +25,7 @@ async function main() {
                 console.log('[Stylable]', `[${currentTime}]`, ...messages);
             }
         },
-        () => !shouldLog && console.clear()
+        () => !shouldLog && !preserveWatchOutput && console.clear()
     );
 
     // execute all require hooks before running the CLI build

--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -148,6 +148,12 @@ export function getCliArguments(): Arguments<CliArguments> {
             description: 'enable watch mode',
             default: false,
         })
+        .option('preserveWatchOutput', {
+            type: 'boolean',
+            description:
+                'Should keep the console output in watch mode instead of clearing the screen whenever a change has occurred',
+            default: false,
+        })
         .alias('h', 'help')
         .alias('v', 'version')
         .help()

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -105,6 +105,7 @@ export interface CliArguments {
     diagnostics: boolean | undefined;
     diagnosticsMode: string | undefined;
     watch: boolean;
+    preserveWatchOutput: boolean;
 }
 
 export interface BuildOptions {


### PR DESCRIPTION
Our CLI clears the terminal in watch mode update a file update ([depending on the OS](https://nodejs.org/api/console.html#consoleclear)), one may want to keep the log for a variety of reasons.
This PR introduces a flag for the CLI to preserve the output.