### PR TITLE
infra(ci): pin npm to 8.3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm i -g npm@8
+      - run: npm i -g npm@8.3
       - run: npm ci
       - run: npm run build
       - run: npm run lint


### PR DESCRIPTION
installing 8.4.0 is broken on Windows, apparently. reported upstream