### PR TITLE
feat(core): implement `-st-extends` parser 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -355,6 +355,14 @@
         "@tokey/core": "^1.2.1"
       }
     },
+    "node_modules/@tokey/css-value-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tokey/css-value-parser/-/css-value-parser-0.0.2.tgz",
+      "integrity": "sha512-w7vIiAbB9UGFD8fTpHpFOjcDg+23Ish2nP2rQxYa7JEXMbDfaxref+SGbhgn4ABGQWNYCUMIVxh8coVEcubiWA==",
+      "dependencies": {
+        "@tokey/core": "^1.2.1"
+      }
+    },
     "node_modules/@tokey/imports-parser": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@tokey/imports-parser/-/imports-parser-0.0.2.tgz",
@@ -7294,6 +7302,7 @@
       "license": "MIT",
       "dependencies": {
         "@tokey/css-selector-parser": "^0.5.1",
+        "@tokey/css-value-parser": "^0.0.2",
         "@tokey/imports-parser": "^0.0.2",
         "balanced-match": "^2.0.0",
         "css-selector-tokenizer": "^0.8.0",
@@ -7823,6 +7832,7 @@
       "version": "file:packages/core",
       "requires": {
         "@tokey/css-selector-parser": "^0.5.1",
+        "@tokey/css-value-parser": "^0.0.2",
         "@tokey/imports-parser": "^0.0.2",
         "balanced-match": "^2.0.0",
         "css-selector-tokenizer": "^0.8.0",
@@ -8012,6 +8022,14 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@tokey/css-selector-parser/-/css-selector-parser-0.5.1.tgz",
       "integrity": "sha512-wNqvEgxghpkdHEG7QAKISbWR+jbojS900ZnzDcOe5YIZQlvMiyH0tqsxmwc7lbnWE47VGf9FmddP5rqL69rCqA==",
+      "requires": {
+        "@tokey/core": "^1.2.1"
+      }
+    },
+    "@tokey/css-value-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tokey/css-value-parser/-/css-value-parser-0.0.2.tgz",
+      "integrity": "sha512-w7vIiAbB9UGFD8fTpHpFOjcDg+23Ish2nP2rQxYa7JEXMbDfaxref+SGbhgn4ABGQWNYCUMIVxh8coVEcubiWA==",
       "requires": {
         "@tokey/core": "^1.2.1"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tokey/css-selector-parser": "^0.5.1",
+    "@tokey/css-value-parser": "^0.0.2",
     "@tokey/imports-parser": "^0.0.2",
     "balanced-match": "^2.0.0",
     "css-selector-tokenizer": "^0.8.0",

--- a/packages/core/src/parsers/st-extends-parser.ts
+++ b/packages/core/src/parsers/st-extends-parser.ts
@@ -1,0 +1,163 @@
+import type { PseudoElement } from '@tokey/css-selector-parser';
+import type { ClassSymbol, ElementSymbol } from '../features';
+import type { StylableMeta } from '../stylable-meta';
+import type { StylableResolver } from '../stylable-resolver';
+import { parseCSSValue } from '@tokey/css-value-parser';
+
+type ParsedNodes = ReturnType<typeof parseCSSValue>[number];
+
+export class ExpNode<T = string> {
+    constructor(
+        public left?: T | ExpNode<T>,
+        public right?: T | ExpNode<T>,
+        public op?: '&' | '|'
+    ) {}
+    clone() {
+        return new ExpNode<T>(this.left, this.right, this.op);
+    }
+    toString() {
+        const op = this.op === '&' ? `and` : 'or';
+        return `${op}(${this.left}, ${this.right})`;
+    }
+}
+
+export function stExtendsParser(stExtends: string) {
+    const ast = parseCSSValue(stExtends);
+    const outputTree = new ExpNode();
+    const stack: ExpNode[] = [outputTree];
+    for (const node of ast) {
+        handleNode(stack, node);
+    }
+    if (stack.length !== 1) {
+        throw new Error('unclosed parenthesis');
+    }
+    optimizeTree(outputTree);
+    return outputTree;
+}
+
+function handleNode(stack: ExpNode[], node: ParsedNodes) {
+    const currentNode = stack[stack.length - 1];
+    if (node.type === '<custom-ident>') {
+        if (!handleConnectedCustomIdent(stack, node)) {
+            if (currentNode.op) {
+                currentNode.right = node.value;
+            } else {
+                currentNode.left = node.value;
+            }
+        }
+    } else if (node.type === 'literal' && node.value === '&') {
+        if (currentNode.op) {
+            pushRight(currentNode, node.value, stack);
+        } else {
+            if (!currentNode.left) {
+                throw new Error(`missing expression left side before ${node.value} operator`);
+            }
+            currentNode.op = node.value;
+        }
+    } else if (node.type === 'literal' && node.value === '|') {
+        if (currentNode.op === '&') {
+            pullLeft(currentNode, node.value);
+        } else if (currentNode.op === '|') {
+            pushRight(currentNode, node.value, stack);
+        } else {
+            if (!currentNode.left) {
+                throw new Error(`missing expression left side before ${node.value} operator`);
+            }
+            currentNode.op = node.value;
+        }
+    } else if (node.type === 'literal' && node.value === '(') {
+        currentNode[currentNode.op ? 'right' : 'left'] = pushStack(stack);
+    } else if (node.type === 'literal' && node.value === ')') {
+        if (currentNode.op && currentNode.right === undefined) {
+            throw new Error(`missing expression right side after ${currentNode.op} operator`);
+        } else if (currentNode.left === undefined) {
+            throw new Error('empty parenthesis');
+        } else {
+            stack.pop();
+        }
+    } else if (node.type !== 'space' && node.type !== 'comment') {
+        throw new Error(`invalid node type ${node.type} with value ${node.value}`);
+    }
+}
+
+function pushStack(stack: ExpNode[]) {
+    const newNode = new ExpNode();
+    stack.push(newNode);
+    return newNode;
+}
+
+function pullLeft(currentNode: ExpNode, op: '&' | '|') {
+    if (!currentNode.right) {
+        throw new Error(`missing value between ${currentNode.op} and ${op} operators`);
+    }
+    currentNode.left = currentNode.clone();
+    currentNode.right = undefined;
+    currentNode.op = op;
+}
+
+function pushRight(currentNode: ExpNode, op: '&' | '|', stack: ExpNode[]) {
+    if (!currentNode.right) {
+        throw new Error(`missing value between ${currentNode.op} and ${op} operators`);
+    }
+    const newNode = new ExpNode(currentNode.right, undefined, op);
+    currentNode.right = newNode;
+    stack.length--;
+    stack.push(newNode);
+}
+
+function optimizeTree(stNode: string | ExpNode, parent?: ExpNode) {
+    if (typeof stNode === 'string') {
+        return;
+    }
+    if (stNode.left) {
+        optimizeTree(stNode.left, stNode);
+    }
+    if (stNode.right) {
+        optimizeTree(stNode.right, stNode);
+    }
+    if (!parent) {
+        return;
+    }
+    if (parent.op === stNode.op || parent.op === undefined) {
+        if (!stNode.right) {
+            if (parent.left === stNode) {
+                parent.left = stNode.left;
+            } else if (parent.right === stNode) {
+                parent.right = stNode.left;
+            }
+        } else if (!parent.right) {
+            parent.left = stNode.left;
+            parent.right = stNode.right;
+            parent.op = stNode.op;
+        }
+    }
+}
+
+function handleConnectedCustomIdent(stack: ExpNode[], node: ParsedNodes) {
+    const parts = node.value.split(/(?=|)|(?=&)/gm);
+    if (parts.length > 1) {
+        let offset = 0;
+        for (const part of parts) {
+            handleNode(stack, {
+                type: part === '|' || part === '&' ? 'literal' : '<custom-ident>',
+                value: part,
+                start: node.start + offset,
+                end: node.start + offset + part.length,
+                before: '',
+                after: '',
+            });
+            offset += part.length;
+        }
+        return true;
+    }
+    return false;
+}
+
+export function resolveType(
+    resolved: { meta: StylableMeta; symbol?: ClassSymbol | ElementSymbol }[],
+    innerPart: null | PseudoElement,
+    resolver: StylableResolver
+): { errors: string[]; resolved: { meta: StylableMeta; symbol?: ClassSymbol | ElementSymbol }[] } {
+    /** */
+    return { resolved, innerPart, resolver } as any;
+}

--- a/packages/core/test/parse-st-extends.spec.ts
+++ b/packages/core/test/parse-st-extends.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { parseCSSValue } from '@tokey/css-value-parser';
 
+type ParsedNodes = ReturnType<typeof parseCSSValue>[number];
+
 class stNode {
     constructor(
         public left?: string | stNode,
@@ -15,49 +17,65 @@ class stNode {
         return `${op}(${this.left}, ${this.right})`;
     }
 }
+// TODO: fix case `a|`
 
 function stExtendsParser(stExtends: string) {
     const ast = parseCSSValue(stExtends);
     const outputTree = new stNode();
     const stack: stNode[] = [outputTree];
     for (const node of ast) {
-        const currentNode = stack[stack.length - 1];
-        if (node.type === '<custom-ident>') {
+        handleNode(stack, node);
+    }
+    if (stack.length !== 1) {
+        throw new Error('unclosed parenthesis');
+    }
+    optimizeTree(outputTree);
+    return outputTree;
+}
+
+function handleNode(stack: stNode[], node: ParsedNodes) {
+    const currentNode = stack[stack.length - 1];
+    if (node.type === '<custom-ident>') {
+        if (!handleConnectedCustomIdent(stack, node)) {
             if (currentNode.op) {
                 currentNode.right = node.value;
             } else {
                 currentNode.left = node.value;
             }
-        } else if (node.type === 'literal' && node.value === '&') {
-            if (currentNode.op) {
-                pushRight(currentNode, node.value, stack);
-            } else {
-                currentNode.op = node.value;
-            }
-        } else if (node.type === 'literal' && node.value === '|') {
-            if (currentNode.op === '&') {
-                pullLeft(currentNode, node.value);
-            } else if (currentNode.op === '|') {
-                pushRight(currentNode, node.value, stack);
-            } else {
-                currentNode.op = node.value;
-            }
-        } else if (node.type === 'literal' && node.value === '(') {
-            currentNode[currentNode.op ? 'right' : 'left'] = pushStack(stack);
-        } else if (node.type === 'literal' && node.value === ')') {
-            if (currentNode.op && currentNode.right === undefined) {
-                throw new Error('Invalid ST Extends');
-            } else if (currentNode.left === undefined) {
-                throw new Error('Invalid ST Extends');
-            } else {
-                stack.pop();
-            }
-        } else if (node.type !== 'space' && node.type !== 'comment') {
-            throw new Error('Invalid ST Extends');
         }
+    } else if (node.type === 'literal' && node.value === '&') {
+        if (currentNode.op) {
+            pushRight(currentNode, node.value, stack);
+        } else {
+            if (!currentNode.left) {
+                throw new Error(`missing expression left side before ${node.value} operator`);
+            }
+            currentNode.op = node.value;
+        }
+    } else if (node.type === 'literal' && node.value === '|') {
+        if (currentNode.op === '&') {
+            pullLeft(currentNode, node.value);
+        } else if (currentNode.op === '|') {
+            pushRight(currentNode, node.value, stack);
+        } else {
+            if (!currentNode.left) {
+                throw new Error(`missing expression left side before ${node.value} operator`);
+            }
+            currentNode.op = node.value;
+        }
+    } else if (node.type === 'literal' && node.value === '(') {
+        currentNode[currentNode.op ? 'right' : 'left'] = pushStack(stack);
+    } else if (node.type === 'literal' && node.value === ')') {
+        if (currentNode.op && currentNode.right === undefined) {
+            throw new Error(`missing expression right side after ${currentNode.op} operator`);
+        } else if (currentNode.left === undefined) {
+            throw new Error('empty parenthesis');
+        } else {
+            stack.pop();
+        }
+    } else if (node.type !== 'space' && node.type !== 'comment') {
+        throw new Error(`invalid node type ${node.type} with value ${node.value}`);
     }
-    optimizeTree(outputTree);
-    return outputTree;
 }
 
 function pushStack(stack: stNode[]) {
@@ -68,7 +86,7 @@ function pushStack(stack: stNode[]) {
 
 function pullLeft(currentNode: stNode, op: '&' | '|') {
     if (!currentNode.right) {
-        throw new Error('Invalid ST Extends');
+        throw new Error(`missing value between ${currentNode.op} and ${op} operators`);
     }
     currentNode.left = currentNode.clone();
     currentNode.right = undefined;
@@ -77,7 +95,7 @@ function pullLeft(currentNode: stNode, op: '&' | '|') {
 
 function pushRight(currentNode: stNode, op: '&' | '|', stack: stNode[]) {
     if (!currentNode.right) {
-        throw new Error('Invalid ST Extends');
+        throw new Error(`missing value between ${currentNode.op} and ${op} operators`);
     }
     const newNode = new stNode(currentNode.right, undefined, op);
     currentNode.right = newNode;
@@ -113,14 +131,37 @@ function optimizeTree(stNode: string | stNode, parent?: stNode) {
     }
 }
 
+function handleConnectedCustomIdent(stack: stNode[], node: ParsedNodes) {
+    const parts = node.value.split(/(?=|)|(?=&)/gm);
+    if (parts.length > 1) {
+        let offset = 0;
+        for (const part of parts) {
+            handleNode(stack, {
+                type: part === '|' || part === '&' ? 'literal' : '<custom-ident>',
+                value: part,
+                start: node.start + offset,
+                end: node.start + offset + part.length,
+                before: '',
+                after: '',
+            });
+            offset += part.length;
+        }
+        return true;
+    }
+    return false;
+}
+
 describe('-st-extends parser', () => {
     it('parse single', () => {
         const ast = stExtendsParser('a');
         expect(ast).to.eql(new stNode('a'));
     });
+
     it('parse single |', () => {
         const ast = stExtendsParser('a | b');
         expect(ast).to.eql(new stNode('a', 'b', '|'));
+        const ast2 = stExtendsParser('a|b');
+        expect(ast2).to.eql(new stNode('a', 'b', '|'));
     });
 
     it('parse multi |', () => {
@@ -131,6 +172,8 @@ describe('-st-extends parser', () => {
     it('parse single &', () => {
         const ast = stExtendsParser('a & b');
         expect(ast).to.eql(new stNode('a', 'b', '&'));
+        const ast2 = stExtendsParser('a&b');
+        expect(ast2).to.eql(new stNode('a', 'b', '&'));
     });
 
     it('parse multi &', () => {
@@ -171,5 +214,91 @@ describe('-st-extends parser', () => {
     it('unwrap single expression', () => {
         const ast = stExtendsParser('(((a)))');
         expect(ast).to.eql(new stNode('a'));
+    });
+
+    describe('errors', () => {
+        it('unclosed parenthesis', () => {
+            expect(() => {
+                stExtendsParser('(');
+            }).to.throw('unclosed parenthesis');
+        });
+
+        it('empty parenthesis', () => {
+            expect(() => {
+                stExtendsParser('()');
+            }).to.throw('empty parenthesis');
+        });
+
+        it('missing expression right side |', () => {
+            expect(() => {
+                stExtendsParser('(a|)');
+            }).to.throw('missing expression right side after | operator');
+        });
+
+        it('missing expression right side &', () => {
+            expect(() => {
+                stExtendsParser('(a&)');
+            }).to.throw('missing expression right side after & operator');
+        });
+
+        it('missing expression left side |', () => {
+            expect(() => {
+                stExtendsParser('(|a)');
+            }).to.throw('missing expression left side before | operator');
+            expect(() => {
+                stExtendsParser('|a');
+            }).to.throw('missing expression left side before | operator');
+        });
+
+        it('missing expression left side &', () => {
+            expect(() => {
+                stExtendsParser('(&a)');
+            }).to.throw('missing expression left side before & operator');
+            expect(() => {
+                stExtendsParser('&a');
+            }).to.throw('missing expression left side before & operator');
+        });
+
+        it('consecutive | operators (no space)', () => {
+            expect(() => {
+                stExtendsParser('||');
+            }).to.throw(`invalid node type literal with value ||`);
+        });
+
+        it('consecutive & operators (no space)', () => {
+            expect(() => {
+                stExtendsParser('&&');
+            }).to.throw(`invalid node type literal with value &&`);
+        });
+
+        it('consecutive &| operators (no space)', () => {
+            expect(() => {
+                stExtendsParser('&|');
+            }).to.throw(`invalid node type literal with value &|`);
+        });
+
+        it('consecutive |& operators (no space)', () => {
+            expect(() => {
+                stExtendsParser('|&');
+            }).to.throw(`invalid node type literal with value |&`);
+        });
+
+        it('missing value with | first', () => {
+            expect(() => {
+                stExtendsParser('a | |');
+            }).to.throw(`missing value between | and | operators`);
+            expect(() => {
+                stExtendsParser('a | &');
+            }).to.throw(`missing value between | and & operators`);
+        });
+
+        it('missing value with & first', () => {
+            expect(() => {
+                stExtendsParser('a & |');
+            }).to.throw(`missing value between & and | operators`);
+            expect(() => {
+                stExtendsParser('a & &');
+            }).to.throw(`missing value between & and & operators`);
+        });
     });
 });

--- a/packages/core/test/parse-st-extends.spec.ts
+++ b/packages/core/test/parse-st-extends.spec.ts
@@ -1,0 +1,175 @@
+import { expect } from 'chai';
+import { parseCSSValue } from '@tokey/css-value-parser';
+
+class stNode {
+    constructor(
+        public left?: string | stNode,
+        public right?: string | stNode,
+        public op?: '&' | '|'
+    ) {}
+    clone() {
+        return new stNode(this.left, this.right, this.op);
+    }
+    toString() {
+        const op = this.op === '&' ? `and` : 'or';
+        return `${op}(${this.left}, ${this.right})`;
+    }
+}
+
+function stExtendsParser(stExtends: string) {
+    const ast = parseCSSValue(stExtends);
+    const outputTree = new stNode();
+    const stack: stNode[] = [outputTree];
+    for (const node of ast) {
+        const currentNode = stack[stack.length - 1];
+        if (node.type === '<custom-ident>') {
+            if (currentNode.op) {
+                currentNode.right = node.value;
+            } else {
+                currentNode.left = node.value;
+            }
+        } else if (node.type === 'literal' && node.value === '&') {
+            if (currentNode.op) {
+                pushRight(currentNode, node.value, stack);
+            } else {
+                currentNode.op = node.value;
+            }
+        } else if (node.type === 'literal' && node.value === '|') {
+            if (currentNode.op === '&') {
+                pullLeft(currentNode, node.value);
+            } else if (currentNode.op === '|') {
+                pushRight(currentNode, node.value, stack);
+            } else {
+                currentNode.op = node.value;
+            }
+        } else if (node.type === 'literal' && node.value === '(') {
+            currentNode[currentNode.op ? 'right' : 'left'] = pushStack(stack);
+        } else if (node.type === 'literal' && node.value === ')') {
+            if (currentNode.op && currentNode.right === undefined) {
+                throw new Error('Invalid ST Extends');
+            } else if (currentNode.left === undefined) {
+                throw new Error('Invalid ST Extends');
+            } else {
+                stack.pop();
+            }
+        } else if (node.type !== 'space' && node.type !== 'comment') {
+            throw new Error('Invalid ST Extends');
+        }
+    }
+    optimizeTree(outputTree);
+    return outputTree;
+}
+
+function pushStack(stack: stNode[]) {
+    const newNode = new stNode();
+    stack.push(newNode);
+    return newNode;
+}
+
+function pullLeft(currentNode: stNode, op: '&' | '|') {
+    if (!currentNode.right) {
+        throw new Error('Invalid ST Extends');
+    }
+    currentNode.left = currentNode.clone();
+    currentNode.right = undefined;
+    currentNode.op = op;
+}
+
+function pushRight(currentNode: stNode, op: '&' | '|', stack: stNode[]) {
+    if (!currentNode.right) {
+        throw new Error('Invalid ST Extends');
+    }
+    const newNode = new stNode(currentNode.right, undefined, op);
+    currentNode.right = newNode;
+    stack.length--;
+    stack.push(newNode);
+}
+
+function optimizeTree(stNode: string | stNode, parent?: stNode) {
+    if (typeof stNode === 'string') {
+        return;
+    }
+    if (stNode.left) {
+        optimizeTree(stNode.left, stNode);
+    }
+    if (stNode.right) {
+        optimizeTree(stNode.right, stNode);
+    }
+    if (!parent) {
+        return;
+    }
+    if (parent.op === stNode.op || parent.op === undefined) {
+        if (!stNode.right) {
+            if (parent.left === stNode) {
+                parent.left = stNode.left;
+            } else if (parent.right === stNode) {
+                parent.right = stNode.left;
+            }
+        } else if (!parent.right) {
+            parent.left = stNode.left;
+            parent.right = stNode.right;
+            parent.op = stNode.op;
+        }
+    }
+}
+
+describe('-st-extends parser', () => {
+    it('parse single', () => {
+        const ast = stExtendsParser('a');
+        expect(ast).to.eql(new stNode('a'));
+    });
+    it('parse single |', () => {
+        const ast = stExtendsParser('a | b');
+        expect(ast).to.eql(new stNode('a', 'b', '|'));
+    });
+
+    it('parse multi |', () => {
+        const ast = stExtendsParser('a | b | c');
+        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '|'), '|'));
+    });
+
+    it('parse single &', () => {
+        const ast = stExtendsParser('a & b');
+        expect(ast).to.eql(new stNode('a', 'b', '&'));
+    });
+
+    it('parse multi &', () => {
+        const ast = stExtendsParser('a & b & c');
+        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '&'), '&'));
+    });
+
+    it('parse operator order |&', () => {
+        const ast = stExtendsParser('a | b & c');
+        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '&'), '|'));
+    });
+
+    it('parse operator order &|', () => {
+        const ast = stExtendsParser('a & b | c');
+        expect(ast).to.eql(new stNode(new stNode('a', 'b', '&'), 'c', '|'));
+    });
+
+    it('parse single | with parens', () => {
+        const ast = stExtendsParser('(a | b)');
+        expect(ast).to.eql(new stNode('a', 'b', '|'));
+    });
+
+    it('parse operator order parens |&', () => {
+        const ast = stExtendsParser('(a | b) & c');
+        expect(ast).to.eql(new stNode(new stNode('a', 'b', '|'), 'c', '&'));
+    });
+
+    it('parse operator order parens &|', () => {
+        const ast = stExtendsParser('a & (b | c)');
+        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '|'), '&'));
+    });
+
+    it('unwrap complex expression', () => {
+        const ast = stExtendsParser('(((a | b) | c))');
+        expect(ast).to.eql(new stNode(new stNode('a', 'b', '|'), 'c', '|'));
+    });
+
+    it('unwrap single expression', () => {
+        const ast = stExtendsParser('(((a)))');
+        expect(ast).to.eql(new stNode('a'));
+    });
+});

--- a/packages/core/test/parse-st-extends.spec.ts
+++ b/packages/core/test/parse-st-extends.spec.ts
@@ -1,218 +1,292 @@
 import { expect } from 'chai';
-import { parseCSSValue } from '@tokey/css-value-parser';
+import { testStylableCore } from '@stylable/core-test-kit';
+import { parseCssSelector, PseudoElement } from '@tokey/css-selector-parser';
+import {
+    stExtendsParser,
+    resolveType,
+    ExpNode,
+} from '@stylable/core/dist/parsers/st-extends-parser';
 
-type ParsedNodes = ReturnType<typeof parseCSSValue>[number];
+describe.skip('resolveType', () => {
+    it('two roots intersection', () => {
+        const { sheets, stylable } = testStylableCore({
+            'a.st.css': ``,
+            'b.st.css': ``,
+            'c.st.css': `
+                @st-import A from "./a.st.css";
+                @st-import B from "./b.st.css";
+                /* @rule .c__root */
+                .root {
+                    -st-extends: A & B;
+                }
+            `,
+        });
 
-class stNode {
-    constructor(
-        public left?: string | stNode,
-        public right?: string | stNode,
-        public op?: '&' | '|'
-    ) {}
-    clone() {
-        return new stNode(this.left, this.right, this.op);
-    }
-    toString() {
-        const op = this.op === '&' ? `and` : 'or';
-        return `${op}(${this.left}, ${this.right})`;
-    }
-}
+        const entry = sheets['c.st.css'].meta;
 
-function stExtendsParser(stExtends: string) {
-    const ast = parseCSSValue(stExtends);
-    const outputTree = new stNode();
-    const stack: stNode[] = [outputTree];
-    for (const node of ast) {
-        handleNode(stack, node);
-    }
-    if (stack.length !== 1) {
-        throw new Error('unclosed parenthesis');
-    }
-    optimizeTree(outputTree);
-    return outputTree;
-}
+        const resolved = resolveType(
+            [{ meta: entry, symbol: entry.getClass('root') }],
+            null,
+            stylable.resolver
+        );
 
-function handleNode(stack: stNode[], node: ParsedNodes) {
-    const currentNode = stack[stack.length - 1];
-    if (node.type === '<custom-ident>') {
-        if (!handleConnectedCustomIdent(stack, node)) {
-            if (currentNode.op) {
-                currentNode.right = node.value;
-            } else {
-                currentNode.left = node.value;
-            }
-        }
-    } else if (node.type === 'literal' && node.value === '&') {
-        if (currentNode.op) {
-            pushRight(currentNode, node.value, stack);
-        } else {
-            if (!currentNode.left) {
-                throw new Error(`missing expression left side before ${node.value} operator`);
-            }
-            currentNode.op = node.value;
-        }
-    } else if (node.type === 'literal' && node.value === '|') {
-        if (currentNode.op === '&') {
-            pullLeft(currentNode, node.value);
-        } else if (currentNode.op === '|') {
-            pushRight(currentNode, node.value, stack);
-        } else {
-            if (!currentNode.left) {
-                throw new Error(`missing expression left side before ${node.value} operator`);
-            }
-            currentNode.op = node.value;
-        }
-    } else if (node.type === 'literal' && node.value === '(') {
-        currentNode[currentNode.op ? 'right' : 'left'] = pushStack(stack);
-    } else if (node.type === 'literal' && node.value === ')') {
-        if (currentNode.op && currentNode.right === undefined) {
-            throw new Error(`missing expression right side after ${currentNode.op} operator`);
-        } else if (currentNode.left === undefined) {
-            throw new Error('empty parenthesis');
-        } else {
-            stack.pop();
-        }
-    } else if (node.type !== 'space' && node.type !== 'comment') {
-        throw new Error(`invalid node type ${node.type} with value ${node.value}`);
-    }
-}
+        expect(resolved).to.eql({
+            errors: [],
+            resolved: [{ meta: entry, symbol: entry.getClass('root') }],
+        });
+    });
 
-function pushStack(stack: stNode[]) {
-    const newNode = new stNode();
-    stack.push(newNode);
-    return newNode;
-}
+    it('two roots intersection inner part resolved to never', () => {
+        const { sheets, stylable } = testStylableCore({
+            'a.st.css': `.part{}`,
+            'b.st.css': `.part{}`,
+            'c.st.css': `
+                @st-import A from "./a.st.css";
+                @st-import B from "./b.st.css";
+                /* @rule .c__root */
+                .root {
+                    -st-extends: A & B;
+                }
 
-function pullLeft(currentNode: stNode, op: '&' | '|') {
-    if (!currentNode.right) {
-        throw new Error(`missing value between ${currentNode.op} and ${op} operators`);
-    }
-    currentNode.left = currentNode.clone();
-    currentNode.right = undefined;
-    currentNode.op = op;
-}
+                /* 
+                    @transform-error .part in A & B does reference the same part.
+                    @rule .c__root::part
+                */
+                .root::part {
 
-function pushRight(currentNode: stNode, op: '&' | '|', stack: stNode[]) {
-    if (!currentNode.right) {
-        throw new Error(`missing value between ${currentNode.op} and ${op} operators`);
-    }
-    const newNode = new stNode(currentNode.right, undefined, op);
-    currentNode.right = newNode;
-    stack.length--;
-    stack.push(newNode);
-}
+                }
+            `,
+        });
 
-function optimizeTree(stNode: string | stNode, parent?: stNode) {
-    if (typeof stNode === 'string') {
-        return;
-    }
-    if (stNode.left) {
-        optimizeTree(stNode.left, stNode);
-    }
-    if (stNode.right) {
-        optimizeTree(stNode.right, stNode);
-    }
-    if (!parent) {
-        return;
-    }
-    if (parent.op === stNode.op || parent.op === undefined) {
-        if (!stNode.right) {
-            if (parent.left === stNode) {
-                parent.left = stNode.left;
-            } else if (parent.right === stNode) {
-                parent.right = stNode.left;
-            }
-        } else if (!parent.right) {
-            parent.left = stNode.left;
-            parent.right = stNode.right;
-            parent.op = stNode.op;
-        }
-    }
-}
+        // const metaA = sheets['a.st.css'].meta;
+        // const metaB = sheets['b.st.css'].meta;
+        const entry = sheets['c.st.css'].meta;
 
-function handleConnectedCustomIdent(stack: stNode[], node: ParsedNodes) {
-    const parts = node.value.split(/(?=|)|(?=&)/gm);
-    if (parts.length > 1) {
-        let offset = 0;
-        for (const part of parts) {
-            handleNode(stack, {
-                type: part === '|' || part === '&' ? 'literal' : '<custom-ident>',
-                value: part,
-                start: node.start + offset,
-                end: node.start + offset + part.length,
-                before: '',
-                after: '',
-            });
-            offset += part.length;
-        }
-        return true;
-    }
-    return false;
-}
+        const partNode = parseCssSelector('::part')[0].nodes[0] as PseudoElement;
+
+        const resolved = resolveType(
+            [{ meta: entry, symbol: entry.getClass('root') }],
+            partNode,
+            stylable.resolver
+        );
+
+        expect(resolved).to.eql({
+            errors: ['.part in A & B does reference the same part.'],
+            resolved: [],
+        });
+    });
+
+    it('two roots intersection common inner part', () => {
+        const { sheets, stylable } = testStylableCore({
+            'common.st.css': `.part{}`,
+            'a.st.css': `@st-import [part] from "./common.st.css"; .part{}`,
+            'b.st.css': `@st-import [part] from "./common.st.css"; .part{}`,
+            'c.st.css': `
+                @st-import A from "./a.st.css";
+                @st-import B from "./b.st.css";
+                /* @rule .c__root */
+                .root {
+                    -st-extends: A & B;
+                }
+
+                /* 
+                    @rule .c__root .common__part
+                */
+                .root::part {
+
+                }
+            `,
+        });
+
+        const metaCommon = sheets['common.st.css'].meta;
+        const entry = sheets['c.st.css'].meta;
+
+        const partNode = parseCssSelector('::part')[0].nodes[0] as PseudoElement;
+
+        const resolved = resolveType(
+            [{ meta: entry, symbol: entry.getClass('root') }],
+            partNode,
+            stylable.resolver
+        );
+
+        expect(resolved).to.eql({
+            errors: [],
+            resolved: [{ meta: metaCommon, symbol: metaCommon.getClass('part') }],
+        });
+    });
+
+    it('two roots union with inner parts and common part', () => {
+        const { sheets, stylable } = testStylableCore({
+            'common.st.css': `.commonPart{}`,
+            'a.st.css': ` @st-import Common from "./common.st.css"; .part{-st-extends: Common;}`,
+            'b.st.css': ` @st-import Common from "./common.st.css"; .part{-st-extends: Common;}`,
+            'c.st.css': `
+                @st-import A from "./a.st.css";
+                @st-import B from "./b.st.css";
+                
+                /* @rule .c__root */
+                .root {
+                    -st-extends: A | B;
+                }
+
+                /* @rule .c__root :is(.a__part, .b__part) */
+                .root::part {}
+
+                /* @rule .c__root :is(.a__part, .b__part) .common__commonPart */
+                .root::part::commonPart {}
+            `,
+        });
+
+        const entry = sheets['c.st.css'].meta;
+        const common = sheets['common.st.css'].meta;
+        const metaA = sheets['a.st.css'].meta;
+        const metaB = sheets['b.st.css'].meta;
+
+        const resolved = resolveType(
+            [{ meta: entry, symbol: entry.getClass('root') }],
+            null,
+            stylable.resolver
+        );
+
+        expect(resolved).to.eql({
+            errors: [],
+            resolved: [{ meta: entry, symbol: entry.getClass('root') }],
+        });
+
+        const partNode = parseCssSelector('::part')[0].nodes[0] as PseudoElement;
+        const resolvedPart = resolveType(
+            [{ meta: entry, symbol: entry.getClass('root') }],
+            partNode,
+            stylable.resolver
+        );
+
+        expect(resolvedPart).to.eql({
+            errors: [],
+            resolved: [
+                { meta: metaA, symbol: metaA.getClass('part') },
+                { meta: metaB, symbol: metaB.getClass('part') },
+            ],
+        });
+
+        const commonPartNode = parseCssSelector('::common')[0].nodes[0] as PseudoElement;
+
+        const resolvedInnerCommonPart = resolveType(
+            resolvedPart.resolved,
+            commonPartNode,
+            stylable.resolver
+        );
+
+        expect(resolvedInnerCommonPart).to.eql({
+            errors: [],
+            resolved: [{ meta: common, symbol: common.getClass('commonPart') }],
+        });
+    });
+
+    it('intersection and union', () => {
+        const { sheets, stylable } = testStylableCore({
+            'a.st.css': `.part{}`,
+            'b.st.css': `.part{}`,
+            'c.st.css': `.part{}`,
+            'entry.st.css': `
+                @st-import A from "./a.st.css";
+                @st-import B from "./b.st.css";
+                @st-import C from "./b.st.css";
+                
+                /* @rule .c__root */
+                .root {
+                    -st-extends: (A & B) | C;
+                }
+
+                /* 
+                    @rule .c__root .common__part
+                */
+                .root::part {
+
+                }
+            `,
+        });
+
+        const metaCommon = sheets['common.st.css'].meta;
+        const entry = sheets['c.st.css'].meta;
+
+        const partNode = parseCssSelector('::part')[0].nodes[0] as PseudoElement;
+
+        const resolved = resolveType(
+            [{ meta: entry, symbol: entry.getClass('root') }],
+            partNode,
+            stylable.resolver
+        );
+
+        expect(resolved).to.eql({
+            errors: [],
+            resolved: [{ meta: metaCommon, symbol: metaCommon.getClass('part') }],
+        });
+    });
+});
 
 describe('-st-extends parser', () => {
     it('parse single', () => {
         const ast = stExtendsParser('a');
-        expect(ast).to.eql(new stNode('a'));
+        expect(ast).to.eql(new ExpNode('a'));
     });
 
     it('parse single |', () => {
         const ast = stExtendsParser('a | b');
-        expect(ast).to.eql(new stNode('a', 'b', '|'));
+        expect(ast).to.eql(new ExpNode('a', 'b', '|'));
         const ast2 = stExtendsParser('a|b');
-        expect(ast2).to.eql(new stNode('a', 'b', '|'));
+        expect(ast2).to.eql(new ExpNode('a', 'b', '|'));
     });
 
     it('parse multi |', () => {
         const ast = stExtendsParser('a | b | c');
-        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '|'), '|'));
+        expect(ast).to.eql(new ExpNode('a', new ExpNode('b', 'c', '|'), '|'));
     });
 
     it('parse single &', () => {
         const ast = stExtendsParser('a & b');
-        expect(ast).to.eql(new stNode('a', 'b', '&'));
+        expect(ast).to.eql(new ExpNode('a', 'b', '&'));
         const ast2 = stExtendsParser('a&b');
-        expect(ast2).to.eql(new stNode('a', 'b', '&'));
+        expect(ast2).to.eql(new ExpNode('a', 'b', '&'));
     });
 
     it('parse multi &', () => {
         const ast = stExtendsParser('a & b & c');
-        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '&'), '&'));
+        expect(ast).to.eql(new ExpNode('a', new ExpNode('b', 'c', '&'), '&'));
     });
 
     it('parse operator order |&', () => {
         const ast = stExtendsParser('a | b & c');
-        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '&'), '|'));
+        expect(ast).to.eql(new ExpNode('a', new ExpNode('b', 'c', '&'), '|'));
     });
 
     it('parse operator order &|', () => {
         const ast = stExtendsParser('a & b | c');
-        expect(ast).to.eql(new stNode(new stNode('a', 'b', '&'), 'c', '|'));
+        expect(ast).to.eql(new ExpNode(new ExpNode('a', 'b', '&'), 'c', '|'));
     });
 
     it('parse single | with parens', () => {
         const ast = stExtendsParser('(a | b)');
-        expect(ast).to.eql(new stNode('a', 'b', '|'));
+        expect(ast).to.eql(new ExpNode('a', 'b', '|'));
     });
 
     it('parse operator order parens |&', () => {
         const ast = stExtendsParser('(a | b) & c');
-        expect(ast).to.eql(new stNode(new stNode('a', 'b', '|'), 'c', '&'));
+        expect(ast).to.eql(new ExpNode(new ExpNode('a', 'b', '|'), 'c', '&'));
     });
 
     it('parse operator order parens &|', () => {
         const ast = stExtendsParser('a & (b | c)');
-        expect(ast).to.eql(new stNode('a', new stNode('b', 'c', '|'), '&'));
+        expect(ast).to.eql(new ExpNode('a', new ExpNode('b', 'c', '|'), '&'));
     });
 
     it('unwrap complex expression', () => {
         const ast = stExtendsParser('(((a | b) | c))');
-        expect(ast).to.eql(new stNode(new stNode('a', 'b', '|'), 'c', '|'));
+        expect(ast).to.eql(new ExpNode(new ExpNode('a', 'b', '|'), 'c', '|'));
     });
 
     it('unwrap single expression', () => {
         const ast = stExtendsParser('(((a)))');
-        expect(ast).to.eql(new stNode('a'));
+        expect(ast).to.eql(new ExpNode('a'));
     });
 
     describe('errors', () => {

--- a/packages/core/test/parse-st-extends.spec.ts
+++ b/packages/core/test/parse-st-extends.spec.ts
@@ -17,7 +17,6 @@ class stNode {
         return `${op}(${this.left}, ${this.right})`;
     }
 }
-// TODO: fix case `a|`
 
 function stExtendsParser(stExtends: string) {
     const ast = parseCSSValue(stExtends);


### PR DESCRIPTION
Just a starting point for the new `-st-extend` parsing:
- [x] basic tree structure parsing  
- [x] union and intersection syntax
- [x] operator precedence 
- [x] parens elimination 
- [ ] good errors
- [x] basic cases tests
- [x] error cases tests
- [ ] weird cases tests
- [ ] move code from tests

* This PR is for early feedback collection