### PR TITLE
feat: set specific source file path in the `dts` source-maps

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -110,7 +110,9 @@ export interface BuildOptions {
     minify?: boolean;
     /** should generate .d.ts definitions for every stylesheet */
     dts?: boolean;
-    /** should generate .d.ts.map files for every .d.ts mapping back to the source .st.css */
+    /** should generate .d.ts.map files for every .d.ts mapping back to the source .st.css.
+     * It will use the origin file path unless `outputSources` is true, then it will use the outputted file path as the source-map source.
+     */
     dtsSourceMap?: boolean;
     /** should emit diagnostics */
     diagnostics?: boolean;

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -175,7 +175,7 @@ export function buildSingleFile({
         // .d.ts.map
         // if not explicitly defined, assumed true with "--dts" parent scope
         if (dtsSourceMap !== false) {
-            const dtsMappingContent = generateDTSSourceMap(dtsContent, res.meta);
+            const dtsMappingContent = generateDTSSourceMap(dtsContent, res.meta, filePath);
             const dtsMapPath = outSrcPath + '.d.ts.map';
 
             generated.add(dtsMapPath);

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -175,7 +175,12 @@ export function buildSingleFile({
         // .d.ts.map
         // if not explicitly defined, assumed true with "--dts" parent scope
         if (dtsSourceMap !== false) {
-            const dtsMappingContent = generateDTSSourceMap(dtsContent, res.meta, filePath);
+            const dtsMappingContent = generateDTSSourceMap(
+                dtsContent,
+                res.meta,
+                relative(dirname(outSrcPath), filePath)
+            );
+
             const dtsMapPath = outSrcPath + '.d.ts.map';
 
             generated.add(dtsMapPath);

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -178,7 +178,7 @@ export function buildSingleFile({
             const dtsMappingContent = generateDTSSourceMap(
                 dtsContent,
                 res.meta,
-                relative(dirname(outSrcPath), filePath)
+                relative(dirname(outSrcPath), outputSources ? outSrcPath : filePath)
             );
 
             const dtsMapPath = outSrcPath + '.d.ts.map';

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -178,7 +178,7 @@ export function buildSingleFile({
             const dtsMappingContent = generateDTSSourceMap(
                 dtsContent,
                 res.meta,
-                relative(dirname(outSrcPath), outputSources ? outSrcPath : filePath)
+                relative(dirname(outSrcPath), dirname(outputSources ? outSrcPath : filePath))
             );
 
             const dtsMapPath = outSrcPath + '.d.ts.map';

--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -57,7 +57,7 @@ export function getCliArguments(): Arguments<CliArguments> {
         .option('dtsSourceMap', {
             type: 'boolean',
             description:
-                'output source maps for stylable definition files for sources (.st.css.d.ts.map)',
+                'output source maps for stylable definition files for sources (.st.css.d.ts.map). It will use the origin file path unless `--stcss` is set, then it will use the outputted file path as the source-map source',
             defaultDescription: 'true if "--dts" option is enabled, otherwise false',
         })
         .option('useNamespaceReference', {

--- a/packages/cli/test/build.spec.ts
+++ b/packages/cli/test/build.spec.ts
@@ -426,6 +426,6 @@ describe('build stand alone', () => {
         const dtsSourceMapContent = fs.readFileSync('/main.st.css.d.ts.map', 'utf8');
         expect(dtsSourceMapContent).to.contain(`"file": "main.st.css.d.ts",`);
         expect(dtsSourceMapContent).to.contain(`"sources": [`);
-        expect(dtsSourceMapContent).to.contain(`"/main.st.css"`);
+        expect(dtsSourceMapContent).to.contain(`"main.st.css"`);
     });
 });

--- a/packages/cli/test/build.spec.ts
+++ b/packages/cli/test/build.spec.ts
@@ -426,6 +426,6 @@ describe('build stand alone', () => {
         const dtsSourceMapContent = fs.readFileSync('/main.st.css.d.ts.map', 'utf8');
         expect(dtsSourceMapContent).to.contain(`"file": "main.st.css.d.ts",`);
         expect(dtsSourceMapContent).to.contain(`"sources": [`);
-        expect(dtsSourceMapContent).to.contain(`"main.st.css"`);
+        expect(dtsSourceMapContent).to.contain(`"/main.st.css"`);
     });
 });

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -180,7 +180,7 @@ describe('Stylable Cli', function () {
             dtsSourceMapContent.startsWith('{\n    "version": 3,\n    "file": "style.st.css.d.ts"')
         ).to.equal(true);
         expect(dtsSourceMapContent).to.contain(
-            `"sources": [\n        "${join('..', 'src', 'style.st.css')}"\n    ]`
+            `"sources": [\n        ${JSON.stringify(join('..', 'src', 'style.st.css'))}\n    ]`
         );
     });
 

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -189,7 +189,7 @@ describe('Stylable Cli', function () {
             dtsSourceMapContent.startsWith('{\n    "version": 3,\n    "file": "style.st.css.d.ts"')
         ).to.equal(true);
         expect(dtsSourceMapContent).to.contain(
-            `"sources": [\n        "../src/style.st.css"\n    ]`
+            `"sources": [\n        ${join('..', 'src', 'style.st.css')}\n    ]`
         );
     });
 

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -171,16 +171,7 @@ describe('Stylable Cli', function () {
             src: { 'style.st.css': srcContent },
         });
 
-        runCliSync([
-            '--rootDir',
-            tempDir.path,
-            '--srcDir',
-            './src',
-            '--outDir',
-            'dist',
-            '--stcss',
-            '--dts',
-        ]);
+        runCliSync(['--rootDir', tempDir.path, '--srcDir', './src', '--outDir', 'dist', '--dts']);
 
         const dirContent = loadDirSync(tempDir.path);
         const dtsSourceMapContent = dirContent['dist/style.st.css.d.ts.map'];
@@ -189,7 +180,7 @@ describe('Stylable Cli', function () {
             dtsSourceMapContent.startsWith('{\n    "version": 3,\n    "file": "style.st.css.d.ts"')
         ).to.equal(true);
         expect(dtsSourceMapContent).to.contain(
-            `"sources": [\n        ${join('..', 'src', 'style.st.css')}\n    ]`
+            `"sources": [\n        "${join('..', 'src', 'style.st.css')}"\n    ]`
         );
     });
 

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -193,6 +193,35 @@ describe('Stylable Cli', function () {
         );
     });
 
+    it('build .st.css.d.ts source-map and target the output source file path', () => {
+        const srcContent = '.root{color:red}';
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            src: { 'style.st.css': srcContent },
+            'stylable.config.js': `
+            exports.stcConfig = {
+                options: {
+                    outDir: './dist',
+                    srcDir: './src',
+                    outputSources: true,
+                    cjs: false,
+                    dts: true,
+                }
+            };
+        `,
+        });
+
+        runCliSync(['--rootDir', tempDir.path]);
+
+        const dirContent = loadDirSync(tempDir.path);
+        const dtsSourceMapContent = dirContent['dist/style.st.css.d.ts.map'];
+
+        expect(
+            dtsSourceMapContent.startsWith('{\n    "version": 3,\n    "file": "style.st.css.d.ts"')
+        ).to.equal(true);
+        expect(dtsSourceMapContent).to.contain(`"sources": [\n        "style.st.css"\n    ]`);
+    });
+
     it('build .st.css.d.ts alongside source files with source-maps on by default (config file)', () => {
         const srcContent = '.root{color:red}';
         populateDirectorySync(tempDir.path, {

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -164,6 +164,35 @@ describe('Stylable Cli', function () {
         ).to.equal(true);
     });
 
+    it('build .st.css.d.ts source-map and target the source file path relatively', () => {
+        const srcContent = '.root{color:red}';
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            src: { 'style.st.css': srcContent },
+        });
+
+        runCliSync([
+            '--rootDir',
+            tempDir.path,
+            '--srcDir',
+            './src',
+            '--outDir',
+            'dist',
+            '--stcss',
+            '--dts',
+        ]);
+
+        const dirContent = loadDirSync(tempDir.path);
+        const dtsSourceMapContent = dirContent['dist/style.st.css.d.ts.map'];
+
+        expect(
+            dtsSourceMapContent.startsWith('{\n    "version": 3,\n    "file": "style.st.css.d.ts"')
+        ).to.equal(true);
+        expect(dtsSourceMapContent).to.contain(
+            `"sources": [\n        "../src/style.st.css"\n    ]`
+        );
+    });
+
     it('build .st.css.d.ts alongside source files with source-maps on by default (config file)', () => {
         const srcContent = '.root{color:red}';
         populateDirectorySync(tempDir.path, {

--- a/packages/module-utils/src/generate-dts-sourcemaps.ts
+++ b/packages/module-utils/src/generate-dts-sourcemaps.ts
@@ -240,7 +240,11 @@ function getClassSourceName(targetName: string, classTokens: ClassesToken): stri
     return;
 }
 
-export function generateDTSSourceMap(dtsContent: string, meta: StylableMeta) {
+export function generateDTSSourceMap(
+    dtsContent: string,
+    meta: StylableMeta,
+    sourceFilePath?: string
+) {
     const tokens = tokenizeDTS(dtsContent);
     const mapping: Record<number, LineMapping> = {};
     const lines = dtsContent.split('\n');
@@ -312,7 +316,7 @@ export function generateDTSSourceMap(dtsContent: string, meta: StylableMeta) {
         {
             version: 3,
             file: `${stylesheetName}.d.ts`,
-            sources: [stylesheetName],
+            sources: [sourceFilePath ?? stylesheetName],
             names: [],
             mappings: Object.values(mapping)
                 .map((segment) => (segment.length ? segment.map((s) => encode(s)).join(',') : ''))

--- a/packages/module-utils/src/generate-dts-sourcemaps.ts
+++ b/packages/module-utils/src/generate-dts-sourcemaps.ts
@@ -1,4 +1,4 @@
-import { basename } from 'path';
+import { basename, join } from 'path';
 import { ClassSymbol, StylableMeta, valueMapping } from '@stylable/core';
 import { STSymbol, CSSKeyframes } from '@stylable/core/dist/features';
 import { processDeclarationFunctions } from '@stylable/core/dist/process-declaration-functions';
@@ -243,7 +243,7 @@ function getClassSourceName(targetName: string, classTokens: ClassesToken): stri
 export function generateDTSSourceMap(
     dtsContent: string,
     meta: StylableMeta,
-    sourceFilePath?: string
+    sourceDirPath?: string
 ) {
     const tokens = tokenizeDTS(dtsContent);
     const mapping: Record<number, LineMapping> = {};
@@ -316,7 +316,7 @@ export function generateDTSSourceMap(
         {
             version: 3,
             file: `${stylesheetName}.d.ts`,
-            sources: [sourceFilePath ?? stylesheetName],
+            sources: [sourceDirPath ? join(sourceDirPath, stylesheetName) : stylesheetName],
             names: [],
             mappings: Object.values(mapping)
                 .map((segment) => (segment.length ? segment.map((s) => encode(s)).join(',') : ''))

--- a/packages/module-utils/test/sourcemap.spec.ts
+++ b/packages/module-utils/test/sourcemap.spec.ts
@@ -2,6 +2,7 @@ import { generateStylableResult } from '@stylable/core-test-kit';
 import { generateDTSSourceMap, generateDTSContent } from '@stylable/module-utils';
 import { expect } from 'chai';
 import deindent from 'deindent';
+import { join } from 'path';
 import { SourceMapConsumer } from 'source-map';
 
 function getPosition(content: string, query: string) {
@@ -66,7 +67,7 @@ describe('.d.ts source-maps', () => {
         const dtsText = generateDTSContent(res);
         const sourcemapText = generateDTSSourceMap(dtsText, res.meta, 'src');
 
-        expect(JSON.parse(sourcemapText).sources).to.eql(['src/entry.st.css']);
+        expect(JSON.parse(sourcemapText).sources).to.eql([join('src', 'entry.st.css')]);
     });
 
     it('maps the "root" class in the ".d.ts" to its position in the original ".st.css" file', async () => {

--- a/packages/module-utils/test/sourcemap.spec.ts
+++ b/packages/module-utils/test/sourcemap.spec.ts
@@ -42,12 +42,31 @@ describe('.d.ts source-maps', () => {
         const dtsText = generateDTSContent(res);
         const sourcemapText = generateDTSSourceMap(dtsText, res.meta);
 
+        expect(JSON.parse(sourcemapText).sources).to.eql(['entry.st.css']);
+
         sourceMapConsumer = await new SourceMapConsumer(sourcemapText);
         const originalPosition = sourceMapConsumer.originalPositionFor(
             getPosition(dtsText, 'root":') // source mapping starts after the first double quote
         );
 
         expect(originalPosition).to.eql({ line: 1, column: 0, source: 'entry.st.css', name: null });
+    });
+
+    it('should generate source maps and set specific file path as the source file path', () => {
+        const res = generateStylableResult({
+            entry: `/entry.st.css`,
+            files: {
+                '/entry.st.css': {
+                    namespace: 'entry',
+                    content: ``,
+                },
+            },
+        });
+
+        const dtsText = generateDTSContent(res);
+        const sourcemapText = generateDTSSourceMap(dtsText, res.meta, 'src/entry.st.css');
+
+        expect(JSON.parse(sourcemapText).sources).to.eql(['src/entry.st.css']);
     });
 
     it('maps the "root" class in the ".d.ts" to its position in the original ".st.css" file', async () => {

--- a/packages/module-utils/test/sourcemap.spec.ts
+++ b/packages/module-utils/test/sourcemap.spec.ts
@@ -64,7 +64,7 @@ describe('.d.ts source-maps', () => {
         });
 
         const dtsText = generateDTSContent(res);
-        const sourcemapText = generateDTSSourceMap(dtsText, res.meta, 'src/entry.st.css');
+        const sourcemapText = generateDTSSourceMap(dtsText, res.meta, 'src');
 
         expect(JSON.parse(sourcemapText).sources).to.eql(['src/entry.st.css']);
     });


### PR DESCRIPTION
- [x] set the source path of the `source-maps` to be relative to the source file (fix).
- [x] set the source path of the `source-maps` to be the output `st.css` file path if it exists (feat).
- update docs
  - - [x] CLI README file.
  - - [x] CLI `help` output.