### PR TITLE
refactor(module-utils): 10x speed-up for generate dts tests

### DIFF
--- a/packages/e2e-test-kit/src/dts-kit.ts
+++ b/packages/e2e-test-kit/src/dts-kit.ts
@@ -51,7 +51,7 @@ export class DTSKit {
                 target: ScriptTarget.ES2020,
                 strict: true,
                 types: [],
-                lib: ['lib.dom.d.ts', 'lib.es2020.d.ts'],
+                noLib: true,
             },
             rootNames: [filePath],
         });

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -303,7 +303,7 @@ describe('Generate DTS', function () {
                 "Type 'string' is not assignable to type 'boolean | undefined'"
             );
             expect(diagnostics).to.include(
-                "Type 'true' is not assignable to type 'string | undefined'"
+                "Type 'boolean' is not assignable to type 'string | undefined'"
             );
         });
 
@@ -336,7 +336,7 @@ describe('Generate DTS', function () {
                 });
 
                 expect(tk.typecheck('test.ts')).to.include(
-                    `Type 'true' is not assignable to type 'string | undefined'`
+                    `Type 'boolean' is not assignable to type 'string | undefined'`
                 );
             });
 


### PR DESCRIPTION
use `noLib:true` since we don't use anything from the outside world in the generate `d.ts` tests