### PR TITLE
feat(cli): use file services resolver in build stylable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,11 @@
         "@file-services/types": "^5.7.1"
       }
     },
+    "node_modules/@file-services/resolve": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@file-services/resolve/-/resolve-5.7.1.tgz",
+      "integrity": "sha512-dIS0PWkdy6qS7swu8mIAN9i9mb7N+N83cDwsr2J/2YaOTJNslX4GHsqqB4X3eNo6AfixAbjcUPsZn88jG77zUg=="
+    },
     "node_modules/@file-services/types": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@file-services/types/-/types-5.7.1.tgz",
@@ -7262,6 +7267,7 @@
       "license": "MIT",
       "dependencies": {
         "@file-services/node": "^5.7.1",
+        "@file-services/resolve": "^5.7.1",
         "@file-services/types": "^5.7.1",
         "@stylable/build-tools": "^4.10.3",
         "@stylable/code-formatter": "^4.10.3",
@@ -7697,6 +7703,11 @@
         "@file-services/types": "^5.7.1"
       }
     },
+    "@file-services/resolve": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@file-services/resolve/-/resolve-5.7.1.tgz",
+      "integrity": "sha512-dIS0PWkdy6qS7swu8mIAN9i9mb7N+N83cDwsr2J/2YaOTJNslX4GHsqqB4X3eNo6AfixAbjcUPsZn88jG77zUg=="
+    },
     "@file-services/types": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@file-services/types/-/types-5.7.1.tgz",
@@ -7799,6 +7810,7 @@
       "version": "file:packages/cli",
       "requires": {
         "@file-services/node": "^5.7.1",
+        "@file-services/resolve": "^5.7.1",
         "@file-services/types": "^5.7.1",
         "@stylable/build-tools": "^4.10.3",
         "@stylable/code-formatter": "^4.10.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "test": "mocha \"./dist/test/**/*.spec.js\" --timeout 25000"
   },
   "dependencies": {
+    "@file-services/resolve": "^5.7.1",
     "@file-services/node": "^5.7.1",
     "@file-services/types": "^5.7.1",
     "@stylable/build-tools": "^4.10.3",

--- a/packages/cli/src/build-stylable.ts
+++ b/packages/cli/src/build-stylable.ts
@@ -9,12 +9,13 @@ import {
 } from './config/resolve-options';
 import { DiagnosticsManager } from './diagnostics-manager';
 import { createDefaultLogger } from './logger';
+import { createDefaultResolveModule } from './resolve-module';
 import type { BuildContext, BuildOptions } from './types';
 import { WatchHandler } from './watch-handler';
 
 export interface BuildStylableContext
     extends Partial<Pick<BuildContext, 'fs' | 'watch' | 'log'>>,
-        Partial<Pick<StylableConfig, 'resolveNamespace' | 'requireModule'>> {
+        Partial<Pick<StylableConfig, 'resolveNamespace' | 'requireModule' | 'resolveModule'>> {
     resolverCache?: StylableResolverCache;
     fileProcessorCache?: StylableConfig['fileProcessorCache'];
     diagnosticsManager?: DiagnosticsManager;
@@ -44,6 +45,7 @@ export async function buildStylable(
         outputFiles = new Map(),
         requireModule = require,
         resolveNamespace = requireModule(NAMESPACE_RESOLVER_MODULE_REQUEST).resolveNamespace,
+        resolveModule = createDefaultResolveModule(fileSystem),
     }: BuildStylableContext = {}
 ) {
     const projects = await projectsConfig(rootDir, overrideBuildOptions, defaultOptions);
@@ -75,6 +77,7 @@ export async function buildStylable(
                 resolveNamespace,
                 resolverCache,
                 fileProcessorCache,
+                resolveModule,
             });
 
             const { service } = await build(buildOptions, {

--- a/packages/cli/src/resolve-module.ts
+++ b/packages/cli/src/resolve-module.ts
@@ -1,0 +1,21 @@
+import type { IFileSystem } from '@file-services/types';
+import { createRequestResolver } from '@file-services/resolve';
+import type { StylableConfig } from '@stylable/core';
+
+export function createDefaultResolveModule(fs: IFileSystem): StylableConfig['resolveModule'] {
+    const moduleResolver = createRequestResolver({ fs });
+
+    return (context, request) => {
+        const { resolvedFile } = moduleResolver(context, request);
+
+        if (resolvedFile === false) {
+            throw new Error(
+                `Stylable CLI does not support browser field 'false' values. "${request}" resolved to 'false' from "${context}"`
+            );
+        } else if (resolvedFile === undefined) {
+            throw new Error(`Stylable CLI cannot resolve request: "${request}"`);
+        }
+
+        return resolvedFile;
+    };
+}

--- a/packages/cli/src/resolve-module.ts
+++ b/packages/cli/src/resolve-module.ts
@@ -1,8 +1,9 @@
-import type { IFileSystem } from '@file-services/types';
-import { createRequestResolver } from '@file-services/resolve';
+import { createRequestResolver, IResolutionFileSystem } from '@file-services/resolve';
 import type { StylableConfig } from '@stylable/core';
 
-export function createDefaultResolveModule(fs: IFileSystem): StylableConfig['resolveModule'] {
+export function createDefaultResolveModule(
+    fs: IResolutionFileSystem
+): StylableConfig['resolveModule'] {
     const moduleResolver = createRequestResolver({ fs });
 
     return (context, request) => {


### PR DESCRIPTION
Has mentioned [here](https://github.com/wixplosives/file-services/issues/24#issuecomment-1014338289), this gives us a boost in terms of performance which we like in our CLI for big projects that are going to use our [integrations (e.g., webpack, rollup) with `stc`](https://github.com/wix/stylable/pull/2342).
The downside is that the resolver has missing features, but they are very advanced, and most modern tools still do not support them as well.