### PR TITLE
refactor: resolve/cache all symbols together in transformation

### DIFF
--- a/packages/core/src/custom-values.ts
+++ b/packages/core/src/custom-values.ts
@@ -1,6 +1,6 @@
 import cloneDeepWith from 'lodash.clonedeepwith';
 import postcssValueParser from 'postcss-value-parser';
-import type { MetaParts } from './stylable-resolver';
+import type { MetaResolvedSymbols } from './stylable-resolver';
 import { getFormatterArgs, getNamedArgs, getStringValue } from './helpers/value';
 import type { ParsedValue } from './types';
 
@@ -156,7 +156,7 @@ interface ExtensionApi<Value, Args> {
     };
 }
 
-export function resolveCustomValues(resolvedSymbols: MetaParts) {
+export function resolveCustomValues(resolvedSymbols: MetaResolvedSymbols) {
     const customValues = { ...stTypes };
     for (const [symbolName, jsRef] of Object.entries(resolvedSymbols.js)) {
         if (isCustomValue(jsRef.symbol)) {

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -75,9 +75,9 @@ export const hooks = createFeature<{
         addClass(context, node.value, rule);
     },
     transformResolve({ context }) {
-        const metaParts = context.getResolvedSymbols(context.meta);
+        const resolvedSymbols = context.getResolvedSymbols(context.meta);
         const locals: Record<string, string> = {};
-        for (const [localName, resolved] of Object.entries(metaParts.class)) {
+        for (const [localName, resolved] of Object.entries(resolvedSymbols.class)) {
             const exportedClasses = [];
             let first = true;
             // collect list of css classes for exports
@@ -123,7 +123,8 @@ export const hooks = createFeature<{
     },
     transformSelectorNode({ context, selectorContext, node }) {
         const { originMeta, resolver } = selectorContext;
-        const resolved = selectorContext.metaParts.class[node.value] || [
+        const resolvedSymbols = context.getResolvedSymbols(context.meta);
+        const resolved = resolvedSymbols.class[node.value] || [
             // used to namespace classes from js mixins since js mixins
             // are scoped in the context of the mixed-in stylesheet
             // which might not have a definition for the mixed-in class

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -74,7 +74,8 @@ export const hooks = createFeature<{
         }
         addClass(context, node.value, rule);
     },
-    transformResolve({ metaParts }) {
+    transformResolve({ context }) {
+        const metaParts = context.getResolvedSymbols(context.meta);
         const locals: Record<string, string> = {};
         for (const [localName, resolved] of Object.entries(metaParts.class)) {
             const exportedClasses = [];

--- a/packages/core/src/features/css-custom-property.ts
+++ b/packages/core/src/features/css-custom-property.ts
@@ -124,32 +124,19 @@ export const hooks = createFeature<{
             analyzeDeclValueVarCalls(context, decl);
         }
     },
-    transformResolve({ context: { meta, resolver } }) {
+    transformResolve({ context: { meta, getResolvedSymbols } }) {
         const customPropsMapping: Record<string, string> = {};
-        for (const [localVarName, cssVar] of Object.entries(
+        const resolvedSymbols = getResolvedSymbols(meta);
+        for (const [localVarName, localSymbol] of Object.entries(
             STSymbol.getAllByType(meta, `cssVar`)
         )) {
-            if (cssVar.alias) {
-                const resolved = resolver.deepResolve(cssVar.alias);
-                const unresolved =
-                    !resolved || resolved._kind !== `css` || resolved.symbol?._kind !== `cssVar`;
+            const resolve = resolvedSymbols.cssVar[localVarName] || {
                 // fallback to local namespace
-                customPropsMapping[localVarName] = getTransformedName(
-                    unresolved
-                        ? {
-                              _kind: `css`,
-                              symbol: cssVar,
-                              meta,
-                          }
-                        : (resolved as CSSResolve<CSSVarSymbol>)
-                );
-            } else {
-                customPropsMapping[localVarName] = getTransformedName({
-                    _kind: `css`,
-                    symbol: cssVar,
-                    meta,
-                });
-            }
+                _kind: `css`,
+                symbol: localSymbol,
+                meta,
+            };
+            customPropsMapping[localVarName] = getTransformedName(resolve);
         }
 
         return customPropsMapping;

--- a/packages/core/src/features/css-keyframes.ts
+++ b/packages/core/src/features/css-keyframes.ts
@@ -3,7 +3,6 @@ import * as STSymbol from './st-symbol';
 import * as STImport from './st-import';
 import type { Imported } from './st-import';
 import type { StylableMeta } from '../stylable-meta';
-import type { StylableResolver } from '../stylable-resolver';
 import { plugableRecord } from '../helpers/plugable-record';
 import { ignoreDeprecationWarn } from '../helpers/deprecation';
 import { isInConditionalGroup } from '../helpers/rule';
@@ -285,30 +284,6 @@ function addKeyframesDeclaration(
         imports.push(name);
     }
     return isFirstInPath && !isImportedBefore;
-}
-
-export function resolveKeyframes(
-    meta: StylableMeta,
-    symbol: KeyframesSymbol,
-    resolver: StylableResolver
-) {
-    const current = { meta, symbol };
-    while (current.symbol?.import) {
-        const res = resolver.resolveImported(
-            current.symbol.import,
-            current.symbol.name,
-            'mappedKeyframes' // ToDo: refactor out of resolver
-        );
-        if (res?._kind === 'css' && res.symbol?._kind === 'keyframes') {
-            ({ meta: current.meta, symbol: current.symbol } = res);
-        } else {
-            return undefined;
-        }
-    }
-    if (current.symbol) {
-        return current;
-    }
-    return undefined;
 }
 
 function getTransformedName({ symbol, meta }: KeyframesResolve) {

--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -52,7 +52,8 @@ export const hooks = createFeature<{
         addType(context, node.value, rule);
     },
     transformSelectorNode({ context, node, selectorContext }): void {
-        const resolved = selectorContext.metaParts.element[node.value] || [
+        const resolvedSymbols = context.getResolvedSymbols(context.meta);
+        const resolved = resolvedSymbols.element[node.value] || [
             // provides resolution for native elements
             // that are not collected by parts
             // or elements that are added by js mixin

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -20,6 +20,7 @@ export interface FeatureContext {
 export interface FeatureTransformContext extends FeatureContext {
     resolver: StylableResolver;
     evaluator: StylableEvaluator;
+    getResolvedSymbols: (meta: StylableMeta) => MetaParts;
 }
 
 export interface NodeTypes {
@@ -46,10 +47,7 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
     }) => SelectorWalkReturn;
     analyzeDeclaration: (options: { context: FeatureContext; decl: postcss.Declaration }) => void;
     transformInit: (options: { context: FeatureTransformContext }) => void;
-    transformResolve: (options: {
-        context: FeatureTransformContext;
-        metaParts: MetaParts;
-    }) => T['RESOLVED'];
+    transformResolve: (options: { context: FeatureTransformContext }) => T['RESOLVED'];
     transformAtRuleNode: (options: {
         context: FeatureTransformContext;
         atRule: postcss.AtRule;

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -1,6 +1,6 @@
 import type { StylableMeta } from '../stylable-meta';
 import type { ScopeContext, StylableExports } from '../stylable-transformer';
-import type { StylableResolver, MetaParts } from '../stylable-resolver';
+import type { StylableResolver, MetaResolvedSymbols } from '../stylable-resolver';
 import type { StylableEvaluator, EvalValueData } from '../functions';
 import type * as postcss from 'postcss';
 import type { ImmutableSelectorNode } from '@tokey/css-selector-parser';
@@ -20,7 +20,7 @@ export interface FeatureContext {
 export interface FeatureTransformContext extends FeatureContext {
     resolver: StylableResolver;
     evaluator: StylableEvaluator;
-    getResolvedSymbols: (meta: StylableMeta) => MetaParts;
+    getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols;
 }
 
 export interface NodeTypes {

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -211,17 +211,17 @@ function evaluateValueCall(
         // resolve
         const resolvedSymbols = context.getResolvedSymbols(data.meta);
         const resolvedVar = resolvedSymbols.var[varName];
-        const resolvedSymbol = resolvedVar?.symbol;
+        const resolvedVarSymbol = resolvedVar?.symbol;
         const possibleNonSTVarSymbol = STSymbol.get(context.meta, varName);
-        if (resolvedSymbol && resolvedSymbol._kind === `var`) {
+        if (resolvedVarSymbol) {
             const { outputValue, topLevelType, typeError } = context.evaluator.evaluateValue(
                 context,
                 {
                     ...data,
                     passedThrough: passedThrough.concat(refUniqID),
-                    value: stripQuotation(resolvedSymbol.text),
+                    value: stripQuotation(resolvedVarSymbol.text),
                     args: restArgs,
-                    node: resolvedSymbol.node,
+                    node: resolvedVarSymbol.node,
                     meta: resolvedVar.meta,
                 }
             );
@@ -244,7 +244,7 @@ function evaluateValueCall(
         } else if (possibleNonSTVarSymbol) {
             const type = resolvedSymbols.mainNamespace[varName];
             if (type === `js`) {
-                const deepResolve = resolvedSymbols[type][varName];
+                const deepResolve = resolvedSymbols.js[varName];
                 const importedType = typeof deepResolve.symbol;
                 if (importedType === 'string') {
                     parsedNode.resolvedValue = data.valueHook

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -218,7 +218,6 @@ export function processDeclarationValue(
                 });
             }
         }
-        return;
     }, true);
 
     let outputValue = '';

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -11,7 +11,7 @@ import {
     JSResolve,
     StylableResolver,
     createSymbolResolverWithCache,
-    MetaParts,
+    MetaResolvedSymbols,
 } from './stylable-resolver';
 import type { replaceValueHook, StylableTransformer } from './stylable-transformer';
 import { getFormatterArgs, getStringValue, stringifyFunction } from './helpers/value';
@@ -103,7 +103,7 @@ export function resolveArgumentsValue(
 
 export function processDeclarationValue(
     resolver: StylableResolver,
-    getResolvedSymbols: (meta: StylableMeta) => MetaParts,
+    getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols,
     value: string,
     meta: StylableMeta,
     node?: postcss.Node,
@@ -266,7 +266,7 @@ export function evalDeclarationValue(
     passedThrough: string[] = [],
     cssVarsMapping?: Record<string, string>,
     args: string[] = [],
-    getResolvedSymbols: (meta: StylableMeta) => MetaParts = createSymbolResolverWithCache(
+    getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols = createSymbolResolverWithCache(
         resolver,
         diagnostics || new Diagnostics()
     )

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -115,7 +115,7 @@ export function processDeclarationValue(
     args: string[] = []
 ): EvalValueResult {
     const evaluator = new StylableEvaluator({ tsVarOverride: variableOverride });
-    const customValues = resolveCustomValues(meta, resolver);
+    const customValues = resolveCustomValues(getResolvedSymbols(meta));
     const parsedValue: any = postcssValueParser(value);
     parsedValue.walk((parsedNode: ParsedValue) => {
         const { type, value } = parsedNode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,7 +125,6 @@ export {
     ValueFormatter,
     evalDeclarationValue,
     functionWarnings,
-    processDeclarationValue,
     resolveArgumentsValue,
 } from './functions';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,7 +108,7 @@ export {
     StateParsedValue,
     StateTypeValidator,
 } from './types';
-export { appendMixin, appendMixins, mixinWarnings } from './stylable-mixins';
+export { mixinWarnings } from './stylable-mixins';
 export {
     OnUrlCallback,
     UrlNode,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,7 +138,6 @@ export {
     createCustomValue,
     getBoxValue,
     isCustomValue,
-    resolveCustomValues,
     stTypes,
     unbox,
 } from './custom-values';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,7 +108,6 @@ export {
     StateParsedValue,
     StateTypeValidator,
 } from './types';
-export { mixinWarnings } from './stylable-mixins';
 export {
     OnUrlCallback,
     UrlNode,

--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -80,7 +80,7 @@ export function appendMixin(
         );
     } else {
         const resolvedSymbols = context.getResolvedSymbols(meta);
-        const symbolName = mix.mixin.type; //valueNode.value
+        const symbolName = mix.mixin.type;
         const resolvedType = resolvedSymbols.mainNamespace[symbolName];
         if (resolvedType === `class`) {
             const resolveChain = resolvedSymbols.class[symbolName];

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -309,9 +309,8 @@ export class StylableResolver {
             import: {},
         };
         for (const [name, symbol] of Object.entries(meta.getAllSymbols())) {
-            // let targetSymbol: StylableSymbol = symbol;
             let deepResolved: CSSResolve | JSResolve | null;
-            if (symbol._kind === `import`) {
+            if (symbol._kind === `import` || (symbol._kind === `cssVar` && symbol.alias)) {
                 deepResolved = this.deepResolve(symbol);
                 if (!deepResolved || !deepResolved.symbol) {
                     // ToDo: handle...
@@ -322,8 +321,9 @@ export class StylableResolver {
                     continue;
                 } else {
                     if (
-                        deepResolved.symbol._kind === `class` ||
-                        deepResolved.symbol._kind === `element`
+                        symbol._kind !== `cssVar` &&
+                        (deepResolved.symbol._kind === `class` ||
+                            deepResolved.symbol._kind === `element`)
                     ) {
                         // virtual alias
                         deepResolved = {
@@ -355,6 +355,9 @@ export class StylableResolver {
                     break;
                 case `var`:
                     resolvedSymbols.var[name] = deepResolved as CSSResolve<VarSymbol>;
+                    break;
+                case `cssVar`:
+                    resolvedSymbols.cssVar[name] = deepResolved as CSSResolve<CSSVarSymbol>;
                     break;
             }
             resolvedSymbols.mainNamespace[name] = deepResolved.symbol._kind;

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -60,7 +60,7 @@ export interface JSResolve {
     meta: null;
 }
 
-export interface MetaParts {
+export interface MetaResolvedSymbols {
     mainNamespace: Record<string, StylableSymbol['_kind'] | 'js'>;
     class: Record<string, Array<CSSResolve<ClassSymbol | ElementSymbol>>>;
     element: Record<string, Array<CSSResolve<ClassSymbol | ElementSymbol>>>;
@@ -299,7 +299,7 @@ export class StylableResolver {
     }
 
     public resolveSymbols(meta: StylableMeta, diagnostics: Diagnostics) {
-        const resolvedSymbols: MetaParts = {
+        const resolvedSymbols: MetaResolvedSymbols = {
             mainNamespace: {},
             class: {},
             element: {},
@@ -501,8 +501,8 @@ export function createSymbolResolverWithCache(
     resolver: StylableResolver,
     diagnostics: Diagnostics
 ) {
-    const cache = new Map<StylableMeta, MetaParts>();
-    return (meta: StylableMeta): MetaParts => {
+    const cache = new Map<StylableMeta, MetaResolvedSymbols>();
+    return (meta: StylableMeta): MetaResolvedSymbols => {
         let symbols = cache.get(meta);
         if (!symbols) {
             symbols = resolver.resolveSymbols(meta, diagnostics);

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -253,50 +253,6 @@ export class StylableResolver {
         }
         return null;
     }
-    public resolveClass(meta: StylableMeta, symbol: StylableSymbol) {
-        return this.resolveName(meta, symbol, false);
-    }
-
-    public resolveName(
-        meta: StylableMeta,
-        symbol: StylableSymbol,
-        isElement: boolean
-    ): CSSResolve<ClassSymbol | ElementSymbol> | null {
-        const type = isElement ? 'element' : 'class';
-        let finalSymbol;
-        let finalMeta;
-        if (symbol._kind === type) {
-            finalSymbol = symbol;
-            finalMeta = meta;
-        } else if (symbol._kind === 'import') {
-            const resolved = this.deepResolve(symbol);
-            if (resolved && resolved._kind === 'css' && resolved.symbol) {
-                if (resolved.symbol._kind === 'class' || resolved.symbol._kind === 'element') {
-                    finalSymbol = resolved.symbol;
-                    finalMeta = resolved.meta;
-                } else {
-                    // TODO: warn
-                }
-            } else {
-                // TODO: warn
-            }
-        } else {
-            // TODO: warn
-        }
-
-        if (finalMeta && finalSymbol) {
-            return {
-                _kind: 'css',
-                symbol: finalSymbol,
-                meta: finalMeta,
-            };
-        } else {
-            return null;
-        }
-    }
-    public resolveElement(meta: StylableMeta, symbol: StylableSymbol) {
-        return this.resolveName(meta, symbol, true);
-    }
 
     public resolveSymbols(meta: StylableMeta, diagnostics: Diagnostics) {
         const resolvedSymbols: MetaResolvedSymbols = {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -12,6 +12,7 @@ import {
     VarSymbol,
     CSSVarSymbol,
     KeyframesSymbol,
+    CSSKeyframes,
 } from './features';
 import type { StylableTransformer } from './stylable-transformer';
 import { valueMapping } from './stylable-value-parsers';
@@ -308,6 +309,7 @@ export class StylableResolver {
             cssVar: {},
             import: {},
         };
+        // resolve main namespace
         for (const [name, symbol] of Object.entries(meta.getAllSymbols())) {
             let deepResolved: CSSResolve | JSResolve | null;
             if (symbol._kind === `import` || (symbol._kind === `cssVar` && symbol.alias)) {
@@ -361,6 +363,17 @@ export class StylableResolver {
                     break;
             }
             resolvedSymbols.mainNamespace[name] = deepResolved.symbol._kind;
+        }
+        // resolve keyframes
+        for (const [name, symbol] of Object.entries(CSSKeyframes.getAll(meta))) {
+            const result = CSSKeyframes.resolveKeyframes(meta, symbol, this);
+            if (result) {
+                resolvedSymbols.keyframes[name] = {
+                    _kind: `css`,
+                    meta: result.meta,
+                    symbol: result.symbol,
+                };
+            }
         }
         return resolvedSymbols;
     }

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -456,7 +456,7 @@ export function createSymbolResolverWithCache(
     resolver: StylableResolver,
     diagnostics: Diagnostics
 ) {
-    const cache = new Map<StylableMeta, MetaResolvedSymbols>();
+    const cache = new WeakMap<StylableMeta, MetaResolvedSymbols>();
     return (meta: StylableMeta): MetaResolvedSymbols => {
         let symbols = cache.get(meta);
         if (!symbols) {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -315,7 +315,8 @@ export class StylableResolver {
             if (symbol._kind === `import` || (symbol._kind === `cssVar` && symbol.alias)) {
                 deepResolved = this.deepResolve(symbol);
                 if (!deepResolved || !deepResolved.symbol) {
-                    // ToDo: handle...
+                    // diagnostics for unresolved imports are reported
+                    // as part of st-import validateImports
                     continue;
                 } else if (deepResolved?._kind === `js`) {
                     resolvedSymbols.js[name] = deepResolved;

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -257,7 +257,15 @@ export class StylableTransformer {
             this.addDevRules(meta);
         }
         ast.walkRules((rule) =>
-            appendMixins(this, rule as SRule, meta, tsVarOverride || {}, cssVarsMapping, path)
+            appendMixins(
+                transformContext,
+                this,
+                rule as SRule,
+                meta,
+                tsVarOverride || {},
+                cssVarsMapping,
+                path
+            )
         );
 
         if (metaExports) {

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -497,7 +497,9 @@ describe('diagnostics: warnings and errors', () => {
                         },
                         '/imported.js': {
                             content: `
-
+                                module.exports = {
+                                    myMixin: "not a function",
+                                }
                             `,
                         },
                     },

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -5,13 +5,13 @@ import {
     findTestLocations,
 } from '@stylable/core-test-kit';
 import {
-    mixinWarnings,
     valueMapping,
     processorWarnings,
     transformerWarnings,
     nativePseudoElements,
     valueParserWarnings,
 } from '@stylable/core';
+import { mixinWarnings } from '@stylable/core/dist/stylable-mixins';
 import { valueDiagnostics } from '@stylable/core/dist/helpers/value';
 import { STImport, CSSClass, CSSType, STVar } from '@stylable/core/dist/features';
 import { generalDiagnostics } from '@stylable/core/dist/features/diagnostics';

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -380,7 +380,7 @@ describe(`features/css-class`, () => {
             // JS exports
             expect(exports.classes.before, `before JS export`).to.eql(`classes__before`);
             expect(exports.classes.after, `after JS export`).to.eql(`classes__after`);
-            expect(exports.classes.unused, `unused JS export`).to.eql(undefined);
+            expect(exports.classes.unused, `unused JS export`).to.eql(`classes__unused`);
         });
         it(`should handle unknown imported class`, () => {
             const { sheets } = testStylableCore({
@@ -586,7 +586,9 @@ describe(`features/css-class`, () => {
             expect(exports.classes.class, `class compose JS export`).to.eql(
                 `entry__class classes__imported`
             );
-            expect(exports.classes.imported, `no imported JS export`).to.eql(undefined);
+            expect(exports.classes.imported, `used only by extends JS export`).to.eql(
+                `classes__imported`
+            );
         });
         it(`should handle -st-extends of imported root `, () => {
             const { sheets } = testStylableCore({

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -852,7 +852,7 @@ describe(`features/st-var`, () => {
 
                         /* 
                             @decl(unknown) prop: value(unknown)
-                            @transform-error(unknown) word(unknown) ${STVar.diagnostics.CANNOT_FIND_IMPORTED_VAR(
+                            @transform-error(unknown) word(unknown) ${STVar.diagnostics.UNKNOWN_VAR(
                                 `unknown`
                             )} 
                         */

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -861,6 +861,7 @@ describe(`features/st-var`, () => {
                         /* 
                             @decl(JS number) prop: value(jsNum)
                             @transform-warn(JS number) word(jsNum) ${STVar.diagnostics.CANNOT_USE_JS_AS_VALUE(
+                                `number`,
                                 `jsNum`
                             )} 
                         */
@@ -869,6 +870,7 @@ describe(`features/st-var`, () => {
                         /* 
                             @decl(JS function) prop: value(jsFunc)
                             @transform-warn(JS function) word(jsFunc) ${STVar.diagnostics.CANNOT_USE_JS_AS_VALUE(
+                                `function`,
                                 `jsFunc`
                             )} 
                         */

--- a/packages/core/test/stylable-transformer/exports.spec.ts
+++ b/packages/core/test/stylable-transformer/exports.spec.ts
@@ -63,6 +63,7 @@ describe('Exports to js', () => {
             });
             expect(cssExports.classes).to.eql({
                 root: 'entry__root',
+                x: 'middle__x',
                 z: 'entry__z',
             });
         });


### PR DESCRIPTION
This PR moves the resolvement of stylesheet symbols to be cached and resolved at a single place. In the future the cache can be moved out of transformation and invalidated on content / dependency change.

- [x] refactor `metaParts` to include other symbols (before it only included `class` and `type`)
- [x] pass `getResolvedSymbols` as part of the transform context
- use `getResolvedSymbols` with all symbols
  - [x] css class
  - [x] css type
  - [x] st var
  - [x] js value / function
  - [x] css keyframes
  - [x] css property
- [x] fix output JS exports of unused class