### PR TITLE
chore(deps): upgrade rollup to latest stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",
-        "rollup": "^2.68.0",
+        "rollup": "^2.70.0",
         "source-map": "^0.7.3",
         "source-map-loader": "^3.0.1",
         "style-loader": "^3.3.1",
@@ -5866,9 +5866,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
-      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12193,9 +12193,9 @@
       }
     },
     "rollup": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
-      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "requires": {
         "fsevents": "~2.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",
-    "rollup": "^2.68.0",
+    "rollup": "^2.70.0",
     "source-map": "^0.7.3",
     "source-map-loader": "^3.0.1",
     "style-loader": "^3.3.1",

--- a/packages/rollup-plugin/test/test-kit/rollup-runner.ts
+++ b/packages/rollup-plugin/test/test-kit/rollup-runner.ts
@@ -55,12 +55,7 @@ export function rollupRunner({
     });
     const ready = waitForWatcherFinish(watcher);
 
-    const disposables: Array<() => Promise<void> | void> = [
-        removeProject,
-        () => {
-            watcher.close();
-        },
-    ];
+    const disposables: Array<() => Promise<void> | void> = [removeProject, () => watcher.close()];
 
     async function dispose() {
         for (const dispose of disposables.reverse()) {


### PR DESCRIPTION
Rollup introduced a [fix](https://github.com/rollup/rollup/releases/tag/v2.70.0) to an issue we had while trying to add a feature to the Stylable rollup plugin (#2342)