### PR TITLE
fix(rollup-plugin): use the correct base directory as `projectRoot`

### DIFF
--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -36,6 +36,7 @@ interface StylableRollupPluginOptions {
     fileName?: string;
     diagnosticsMode?: 'auto' | 'strict' | 'loose';
     resolveNamespace?: (namespace: string, source: string) => string;
+    projectRoot?: string; // default is process.cwd()
 }
 ```
 

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -32,6 +32,7 @@ export interface StylableRollupPluginOptions {
     mode?: 'development' | 'production';
     diagnosticsMode?: DiagnosticsMode;
     resolveNamespace?: typeof resolveNamespaceNode;
+    projectRoot?: string;
 }
 
 const requireModuleCache = new Set<string>();
@@ -56,6 +57,7 @@ export function stylableRollupPlugin({
     diagnosticsMode = 'strict',
     mode = getDefaultMode(),
     resolveNamespace = resolveNamespaceNode,
+    projectRoot = process.cwd(),
 }: StylableRollupPluginOptions = {}): Plugin {
     let stylable!: Stylable;
     let extracted!: Map<any, any>;
@@ -64,7 +66,7 @@ export function stylableRollupPlugin({
 
     return {
         name: 'Stylable',
-        buildStart(rollupOptions) {
+        buildStart() {
             extracted = extracted || new Map();
             emittedAssets = emittedAssets || new Map();
             if (stylable) {
@@ -73,7 +75,7 @@ export function stylableRollupPlugin({
             } else {
                 stylable = Stylable.create({
                     fileSystem: fs,
-                    projectRoot: rollupOptions.context,
+                    projectRoot,
                     mode,
                     resolveNamespace,
                     optimizer: new StylableOptimizer(),


### PR DESCRIPTION
Apparently, rollup doesn't have `rootDir` like other bundlers (webpack, vite, etc...) and the context is referring to something else.

In this fix, we expose a way to set `projectRoot` and we default to `process.cwd()`

Relevant issues:
https://github.com/rollup/rollup/issues/4435