### PR TITLE
feat(core): get `st-vars` computed values

### DIFF
--- a/packages/core-test-kit/src/test-stylable-core.ts
+++ b/packages/core-test-kit/src/test-stylable-core.ts
@@ -76,6 +76,10 @@ testStylableCore.errors = {
 // copied from memory-minimal
 function createJavascriptRequireModule(fs: IFileSystem) {
     const requireModule = (id: string): any => {
+        if (id === '@stylable/core') {
+            return require('@stylable/core');
+        }
+
         const _module = {
             id,
             exports: {},

--- a/packages/core-test-kit/src/test-stylable-core.ts
+++ b/packages/core-test-kit/src/test-stylable-core.ts
@@ -77,7 +77,7 @@ testStylableCore.errors = {
 function createJavascriptRequireModule(fs: IFileSystem) {
     const requireModule = (id: string): any => {
         if (id === '@stylable/core') {
-            return require('@stylable/core');
+            return require(id);
         }
 
         const _module = {

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -339,22 +339,26 @@ function createUniqID(source: string, varName: string) {
 }
 
 export function getComputed(stylable: Stylable, meta: StylableMeta) {
-    const diagnostics = new Diagnostics();
+    const topLevelDiagnostics = new Diagnostics();
     const evaluator = new StylableEvaluator();
-    const getResolvedSymbols = createSymbolResolverWithCache(stylable.resolver, diagnostics);
+    const getResolvedSymbols = createSymbolResolverWithCache(
+        stylable.resolver,
+        topLevelDiagnostics
+    );
+
     const { var: stVars, customValues } = getResolvedSymbols(meta);
 
     const computed: ComputedStVars = {};
 
     for (const [localName, resolvedVar] of Object.entries(stVars)) {
-        const variableDiagnostics = new Diagnostics();
+        const diagnostics = new Diagnostics();
         const { outputValue, topLevelType } = evaluator.evaluateValue(
             {
                 getResolvedSymbols,
                 resolver: stylable.resolver,
                 evaluator,
                 meta,
-                diagnostics: variableDiagnostics,
+                diagnostics,
             },
             {
                 meta: resolvedVar.meta,
@@ -369,7 +373,7 @@ export function getComputed(stylable: Stylable, meta: StylableMeta) {
              * In case of custom value that could be flat, we will use the "outputValue" which is a flat value.
              */
             value: topLevelType && !customValue?.flattenValue ? unbox(topLevelType) : outputValue,
-            diagnostics: variableDiagnostics,
+            diagnostics,
         };
 
         if (customValue?.flattenValue) {

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -366,7 +366,7 @@ export function getComputed(stylable: Stylable, meta: StylableMeta) {
         const customValue = customValues[topLevelType?.type];
         const computedStVar: ComputedStVar = {
             /**
-             * In case of custom value that could be flat we will use the "outputValue" which is flat value.
+             * In case of custom value that could be flat, we will use the "outputValue" which is a flat value.
              */
             value: topLevelType && !customValue?.flattenValue ? unbox(topLevelType) : outputValue,
             diagnostics: variableDiagnostics,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export type {
 } from './features';
 export { reservedKeyFrames } from './features/css-keyframes';
 export { scopeCSSVar } from './features/css-custom-property';
-export type { ComputedStVar, ComputedStVars } from './features/st-var';
+export type { ComputedStVar } from './features/st-var';
 export {
     StylableProcessor,
     createEmptyMeta,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export type {
 } from './features';
 export { reservedKeyFrames } from './features/css-keyframes';
 export { scopeCSSVar } from './features/css-custom-property';
+export type { ComputedStVar, ComputedStVars } from './features/st-var';
 export {
     StylableProcessor,
     createEmptyMeta,

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -18,6 +18,7 @@ import type { StylableTransformer } from './stylable-transformer';
 import { valueMapping } from './stylable-value-parsers';
 import { findRule } from './helpers/rule';
 import type { ModuleResolver } from './types';
+import { CustomValueExtension, isCustomValue, stTypes } from './custom-values';
 
 export type JsModule = {
     default?: unknown;
@@ -66,6 +67,7 @@ export interface MetaResolvedSymbols {
     element: Record<string, Array<CSSResolve<ClassSymbol | ElementSymbol>>>;
     var: Record<string, CSSResolve<VarSymbol>>;
     js: Record<string, JSResolve>;
+    customValues: Record<string, CustomValueExtension<any>>;
     cssVar: Record<string, CSSResolve<CSSVarSymbol>>;
     keyframes: Record<string, CSSResolve<KeyframesSymbol>>;
     import: Record<string, CSSResolve<ImportSymbol>>;
@@ -261,6 +263,7 @@ export class StylableResolver {
             element: {},
             var: {},
             js: {},
+            customValues: { ...stTypes },
             keyframes: {},
             cssVar: {},
             import: {},
@@ -277,6 +280,12 @@ export class StylableResolver {
                 } else if (deepResolved?._kind === `js`) {
                     resolvedSymbols.js[name] = deepResolved;
                     resolvedSymbols.mainNamespace[name] = `js`;
+
+                    const customValueSymbol = deepResolved.symbol;
+                    if (isCustomValue(customValueSymbol)) {
+                        resolvedSymbols.customValues[name] = customValueSymbol.register(name);
+                    }
+
                     continue;
                 } else if (
                     symbol._kind !== `cssVar` &&

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -14,6 +14,7 @@ import {
 import type { IStylableOptimizer, ModuleResolver } from './types';
 import { createDefaultResolver } from './module-resolver';
 import { warnOnce } from './helpers/deprecation';
+import { STVar } from './features';
 
 export interface StylableConfig {
     projectRoot: string;
@@ -100,6 +101,9 @@ export class Stylable {
         });
 
         this.resolver = this.createResolver();
+    }
+    public getComputedStVars(meta: StylableMeta) {
+        return STVar.getComputed(this, meta);
     }
     public initCache({ filter }: InitCacheParams = {}) {
         if (filter && this.resolverCache) {

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -74,6 +74,7 @@ export class Stylable {
     }
     public fileProcessor: FileProcessor<StylableMeta>;
     public resolver: StylableResolver;
+    public stVar = new STVar.StylablePublicApi(this);
     constructor(
         public projectRoot: string,
         protected fileSystem: MinimalFS,
@@ -101,9 +102,6 @@ export class Stylable {
         });
 
         this.resolver = this.createResolver();
-    }
-    public getComputedStVars(meta: StylableMeta) {
-        return STVar.getComputed(this, meta);
     }
     public initCache({ filter }: InitCacheParams = {}) {
         if (filter && this.resolverCache) {

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -1258,8 +1258,6 @@ describe(`features/st-var`, () => {
             );
         });
     });
-    it.skip(`should provide valid var path introspection - value(var, ...path)`);
-
     describe('introspection', () => {
         it('should get computed st-vars', () => {
             const { stylable, sheets } = testStylableCore(`
@@ -1271,20 +1269,24 @@ describe(`features/st-var`, () => {
             `);
 
             const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.getComputedStVars(meta);
+            const computedVars = stylable.stVar.getComputed(meta);
 
             expect(Object.keys(computedVars)).to.eql(['a', 'b', 'c']);
-
-            expect(
-                Object.values(computedVars).every(
-                    ({ diagnostics }) => diagnostics.reports.length === 0
-                ),
-                'should not have any diagnostics'
-            ).to.be.true;
-
-            expect(computedVars.a.value).to.eql('red');
-            expect(computedVars.b.value).to.eql('blue');
-            expect(computedVars.c.value).to.eql(['red', 'gold']);
+            expect(computedVars.a).to.containSubset({
+                value: 'red',
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
+            expect(computedVars.b).to.containSubset({
+                value: 'blue',
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
+            expect(computedVars.c).to.containSubset({
+                value: ['red', 'gold'],
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
         });
 
         it('should get computed custom value st-var', () => {
@@ -1324,22 +1326,17 @@ describe(`features/st-var`, () => {
             });
 
             const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.getComputedStVars(meta);
+            const computedVars = stylable.stVar.getComputed(meta);
 
             expect(Object.keys(computedVars)).to.eql(['border']);
-
-            expect(
-                Object.values(computedVars).every(
-                    ({ diagnostics }) => diagnostics.reports.length === 0
-                ),
-                'should not have any diagnostics'
-            ).to.be.true;
-
-            expect(computedVars.border.value).to.eql('1px solid red');
-            expect(computedVars.border.rawValue).to.eql({
-                color: 'red',
-                size: '1px',
-                style: 'solid',
+            expect(computedVars.border).to.containSubset({
+                value: '1px solid red',
+                input: {
+                    color: 'red',
+                    size: '1px',
+                    style: 'solid',
+                },
+                diagnostics: { reports: [] },
             });
         });
 
@@ -1361,20 +1358,24 @@ describe(`features/st-var`, () => {
             });
 
             const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.getComputedStVars(meta);
+            const computedVars = stylable.stVar.getComputed(meta);
 
             expect(Object.keys(computedVars)).to.eql(['imported', 'a', 'b']);
-
-            expect(
-                Object.values(computedVars).every(
-                    ({ diagnostics }) => diagnostics.reports.length === 0
-                ),
-                'should not have any diagnostics'
-            ).to.be.true;
-
-            expect(computedVars['imported'].value).to.eql('red');
-            expect(computedVars.a.value).to.eql('red');
-            expect(computedVars.b.value).to.eql({ a: 'red' });
+            expect(computedVars.imported).to.containSubset({
+                value: 'red',
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
+            expect(computedVars.a).to.containSubset({
+                value: 'red',
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
+            expect(computedVars.b).to.containSubset({
+                value: { a: 'red' },
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
         });
 
         it('should emit diagnostics only on invalid computed st-vars', () => {
@@ -1390,13 +1391,30 @@ describe(`features/st-var`, () => {
 
             const { meta } = sheets['/entry.st.css'];
 
-            const computedVars = stylable.getComputedStVars(meta);
+            const computedVars = stylable.stVar.getComputed(meta);
 
-            expect(computedVars.validBefore.diagnostics.reports.length).to.eql(0);
-            expect(computedVars.validAfter.diagnostics.reports.length).to.eql(0);
-            expect(computedVars.invalid.diagnostics.reports[0]).to.containSubset({
-                message: functionWarnings.UNKNOWN_FORMATTER('invalid-func'),
-                type: 'warning',
+            expect(Object.keys(computedVars)).to.eql(['validBefore', 'invalid', 'validAfter']);
+            expect(computedVars.validBefore).to.containSubset({
+                value: 'red',
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
+            expect(computedVars.validAfter).to.containSubset({
+                value: 'green',
+                input: undefined,
+                diagnostics: { reports: [] },
+            });
+            expect(computedVars.invalid).to.containSubset({
+                value: 'invalid-func(imported)',
+                input: undefined,
+                diagnostics: {
+                    reports: [
+                        {
+                            message: functionWarnings.UNKNOWN_FORMATTER('invalid-func'),
+                            type: 'warning',
+                        },
+                    ],
+                },
             });
         });
     });


### PR DESCRIPTION
New public API to get the computed Stylable vars for a given style sheet.

### Internals
* Add the ability to require Stylable core package from the `core-test-kit`.
* Expose `flattenValue` from `CustomValueExtension` to indicate that the custom value can be flat.
* Move custom values resolution from each function evaluation to the resolver.
