### PR TITLE
Add StandWithUkraine banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://stand-with-ukraine.pp.ua)
+
 ![Stylable CSS for Components](./stylable.svg)
 
 [![Build Status](https://github.com/wix/stylable/workflows/tests/badge.svg)](https://github.com/wix/stylable/actions)


### PR DESCRIPTION
Adding a banner to support our colleagues from Kyiv, Dnipro, and Lviv. Detox, RN Navigation, and other Wix's OSS projects have already done that.