### PR TITLE
fix: cases with mixin moved compound selector

### DIFF
--- a/packages/core/src/features/st-symbol.ts
+++ b/packages/core/src/features/st-symbol.ts
@@ -184,9 +184,3 @@ export function reportRedeclare(context: FeatureContext) {
         }
     }
 }
-
-/* inheritSymbols are used for creating a copy meta with mixin root */
-export function inheritSymbols(originMeta: StylableMeta, targetMeta: StylableMeta) {
-    const originData = plugableRecord.getUnsafe(originMeta.data, dataKey);
-    plugableRecord.set(targetMeta.data, dataKey, createState(originData));
-}

--- a/packages/core/src/features/st-symbol.ts
+++ b/packages/core/src/features/st-symbol.ts
@@ -185,23 +185,8 @@ export function reportRedeclare(context: FeatureContext) {
     }
 }
 
-/* inheritSymbols/forceSetSymbol are used for creating a copy meta with mixin root */
+/* inheritSymbols are used for creating a copy meta with mixin root */
 export function inheritSymbols(originMeta: StylableMeta, targetMeta: StylableMeta) {
     const originData = plugableRecord.getUnsafe(originMeta.data, dataKey);
     plugableRecord.set(targetMeta.data, dataKey, createState(originData));
-}
-export function forceSetSymbol({
-    meta,
-    symbol,
-    localName,
-}: {
-    meta: StylableMeta;
-    symbol: filterSymbols<NamespaceToSymbolType['main']>;
-    localName?: string;
-}) {
-    const { byNS, byNSFlat, byType } = plugableRecord.getUnsafe(meta.data, dataKey);
-    const name = localName || symbol.name;
-    byNS.main.push({ name, symbol, safeRedeclare: false, ast: undefined });
-    byNSFlat.main[name] = symbol;
-    byType[symbol._kind][name] = symbol;
 }

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -64,7 +64,6 @@ export class StylableMeta {
     public mappedKeyframes: Record<string, KeyframesSymbol> = {};
     public customSelectors: Record<string, string> = {};
     public urls: string[] = [];
-    public parent?: StylableMeta;
     public transformDiagnostics: Diagnostics | null = null;
     public transformedScopes: Record<string, SelectorList> | null = null;
     public scopes: postcss.AtRule[] = [];

--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -234,7 +234,8 @@ function createMixinRootFromCSSResolve(
         undefined,
         resolvedArgs,
         path.concat(symbolName + ' from ' + meta.source),
-        true
+        true,
+        resolvedClass.symbol.name
     );
 
     fixRelativeUrls(mixinRoot, mixinMeta.source, meta.source);
@@ -338,21 +339,17 @@ function handleLocalClassMixin(
         undefined,
         resolvedArgs,
         path.concat(mix.mixin.type + ' from ' + meta.source),
-        true
+        true,
+        mix.ref.name
     );
     mergeRules(mixinRoot, rule);
 }
 
-function createInheritedMeta({ meta, symbol }: CSSResolve) {
+function createInheritedMeta({ meta }: CSSResolve) {
     const mixinMeta: StylableMeta = Object.create(meta);
     mixinMeta.data = { ...meta.data };
     mixinMeta.parent = meta;
     STSymbol.inheritSymbols(meta, mixinMeta);
-    STSymbol.forceSetSymbol({
-        meta: mixinMeta,
-        symbol: STSymbol.getAll(mixinMeta)[symbol.name], // ToDo: check as an alternative: `symbol`;
-        localName: meta.root,
-    });
     return mixinMeta;
 }
 

--- a/packages/core/src/stylable-mixins.ts
+++ b/packages/core/src/stylable-mixins.ts
@@ -223,9 +223,7 @@ function createMixinRootFromCSSResolve(
         cssVarsMapping
     );
 
-    const mixinMeta: StylableMeta = isRootMixin
-        ? resolvedClass.meta
-        : createInheritedMeta(resolvedClass);
+    const mixinMeta: StylableMeta = resolvedClass.meta;
     const symbolName = isRootMixin ? 'default' : mix.mixin.type;
 
     transformer.transformAst(
@@ -335,7 +333,7 @@ function handleLocalClassMixin(
 
     transformer.transformAst(
         mixinRoot,
-        isRootMixin ? meta : createInheritedMeta({ meta, symbol: mix.ref, _kind: 'css' }),
+        meta,
         undefined,
         resolvedArgs,
         path.concat(mix.mixin.type + ' from ' + meta.source),
@@ -343,14 +341,6 @@ function handleLocalClassMixin(
         mix.ref.name
     );
     mergeRules(mixinRoot, rule);
-}
-
-function createInheritedMeta({ meta }: CSSResolve) {
-    const mixinMeta: StylableMeta = Object.create(meta);
-    mixinMeta.data = { ...meta.data };
-    mixinMeta.parent = meta;
-    STSymbol.inheritSymbols(meta, mixinMeta);
-    return mixinMeta;
 }
 
 function getMixinDeclaration(rule: postcss.Rule): postcss.Declaration | undefined {

--- a/packages/core/test/helpers/rule.spec.ts
+++ b/packages/core/test/helpers/rule.spec.ts
@@ -62,7 +62,7 @@ describe(`helpers/rule`, () => {
                 { selector: '& .y' },
                 { selector: '&:not(.x)' },
                 { selector: '& &.x:hover' },
-                { selector: '&.x.y' },
+                { selector: '&.y.x' },
                 { selector: '&&' }, // TODO: check if possible
                 { selector: '&' },
             ];

--- a/packages/core/test/mixins/css-mixins.spec.ts
+++ b/packages/core/test/mixins/css-mixins.spec.ts
@@ -7,10 +7,34 @@ import {
     matchAllRulesAndDeclarations,
     matchRuleAndDeclaration,
     testInlineExpects,
+    testStylableCore,
 } from '@stylable/core-test-kit';
 import { processorWarnings } from '@stylable/core';
 
 describe('CSS Mixins', () => {
+    it.only('apply simple class mixins declarations', () => {
+        testStylableCore({
+            '/mixin.st.css': `
+                .root {
+                    -st-states: x;
+                }
+                
+                .root:x.override {
+                    z-index: 1;
+                }
+            `,
+            'entry.st.css': `
+                @st-import [override] from "./mixin.st.css";
+
+                /* @rule[1] .entry__y.mixin__root.mixin--x  */
+                .y {
+                    -st-mixin: override;
+                }
+            `,
+        });
+
+    });
+
     it('apply simple class mixins declarations', () => {
         const result = generateStylableRoot({
             entry: `/entry.st.css`,

--- a/packages/core/test/mixins/css-mixins.spec.ts
+++ b/packages/core/test/mixins/css-mixins.spec.ts
@@ -8,33 +8,11 @@ import {
     matchRuleAndDeclaration,
     testInlineExpects,
     testStylableCore,
+    shouldReportNoDiagnostics,
 } from '@stylable/core-test-kit';
 import { processorWarnings } from '@stylable/core';
 
 describe('CSS Mixins', () => {
-    it.only('apply simple class mixins declarations', () => {
-        testStylableCore({
-            '/mixin.st.css': `
-                .root {
-                    -st-states: x;
-                }
-                
-                .root:x.override {
-                    z-index: 1;
-                }
-            `,
-            'entry.st.css': `
-                @st-import [override] from "./mixin.st.css";
-
-                /* @rule[1] .entry__y.mixin__root.mixin--x  */
-                .y {
-                    -st-mixin: override;
-                }
-            `,
-        });
-
-    });
-
     it('apply simple class mixins declarations', () => {
         const result = generateStylableRoot({
             entry: `/entry.st.css`,
@@ -206,6 +184,30 @@ describe('CSS Mixins', () => {
         });
 
         testInlineExpects(result);
+    });
+
+    it('should mix root state with mixed-in part', () => {
+        const { sheets } = testStylableCore({
+            '/mixin.st.css': `
+                .root {
+                    -st-states: x;
+                }
+                
+                .root:x.override {
+                    z-index: 1;
+                }
+            `,
+            'entry.st.css': `
+                @st-import [override] from "./mixin.st.css";
+
+                /* @rule[1] .entry__y.mixin__root.mixin--x  */
+                .y {
+                    -st-mixin: override;
+                }
+            `,
+        });
+
+        shouldReportNoDiagnostics(sheets[`/entry.st.css`].meta);
     });
 
     it.skip('mixin with multiple rules in keyframes', () => {

--- a/packages/core/test/mixins/css-mixins.spec.ts
+++ b/packages/core/test/mixins/css-mixins.spec.ts
@@ -186,27 +186,45 @@ describe('CSS Mixins', () => {
         testInlineExpects(result);
     });
 
-    it('should mix root state with mixed-in part', () => {
+    it('should reorder selector to context', () => {
         const { sheets } = testStylableCore({
             '/mixin.st.css': `
                 .root {
                     -st-states: x;
                 }
-                
-                .root:x.override {
+                .mixin {-st-states: mix-state;}
+                .root:x.mixin:mix-state {
                     z-index: 1;
                 }
+                .root:x.mixin:mix-state[attr].y {
+                    z-index: 1;
+                }
+                .mixin:is(.y.mixin:mix-state) {
+                    z-index: 1;
+                }
+                .x.mixin[a] .y.mixin[b] {
+                    z-index: 1;
+                } 
+                :is(.x.mixin:is(.y.mixin)) {
+                    z-index: 1;
+                }
+
             `,
             'entry.st.css': `
-                @st-import [override] from "./mixin.st.css";
+                @st-import [mixin] from "./mixin.st.css";
 
-                /* @rule[1] .entry__y.mixin__root.mixin--x  */
+                /* 
+                    @rule[1] .entry__y.mixin--mix-state.mixin__root.mixin--x  
+                    @rule[2] .entry__y.mixin--mix-state[attr].mixin__y.mixin__root.mixin--x    
+                    @rule[3] .entry__y:is(.entry__y.mixin--mix-state.mixin__y)
+                    @rule[4] .entry__y[a].mixin__x .entry__y[b].mixin__y
+                */
                 .y {
-                    -st-mixin: override;
+                    -st-mixin: mixin;
                 }
             `,
         });
-
+        //@TODO-rule[5] :is(.entry__y:is(.entry__y.mixin__y).mixin__x)
         shouldReportNoDiagnostics(sheets[`/entry.st.css`].meta);
     });
 


### PR DESCRIPTION
This PR fixes 2 issues:

## 1) ambiguity of a mixed-in CSS class and root class 

The issue happens when a mixed class is compounded with `.root:state` (root class with `custom-pseudo-class`). The issue is that there is a bug in the process of mixin that loses the actual root symbol when a stylesheet class other then root is mixed:

**mixin.st.css:**
```
.root {
    -st-mixin: x;
}
.root:x.mix {
    color: green;
}
```
**entry.st.css:**
```
@st-import [mix] from "./mixin.st.css";

/* @rule[1] .entry__c.mixin__root.mixin--x */
.c {
    -st-mixin: mix;
}
```

valid selector: `.entry__c.mixin__root.mixin--x`
error selector: `.entry__c.mixin__root:x` // root symbol is "wrongly" replaced with mix class and `:x` custom-pseudo-state is unresolved

## 2) multiple compound selectors after mixin

When compound selectors are connected after mixin class, they need to move to the beginning of the selector with the mixin if it is moved:

**mixin.st.css:**
```
.root {
    -st-mixin: x;
}
.root.mix:mix-state {
    color: green;
}
```
**entry.st.css:**
```
@st-import [mix] from "./mixin.st.css";

/* @rule[1] .entry__c.mixin--mix-state.mixin__root */
.c {
    -st-mixin: mix;
}
```

valid selector: `.entry__c.mixin--mix-state.mixin__root`
error selector: `.entry__c.mixin__root:mix-state` // mix-state is not moved/transformed