### PR TITLE
fix(core-test-kit): inline expects skip comments between declarations

### DIFF
--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -230,7 +230,10 @@ function ruleTest(
             );
         }
         if (declarationCheck === `full`) {
-            const actualDecl = testNode.nodes.map((x) => x.toString()).join(`; `);
+            const actualDecl = testNode.nodes
+                .filter((x) => x.type !== `comment`)
+                .map((x) => x.toString())
+                .join(`; `);
             const expectedDecl = expectedDeclarations
                 .map(([prop, value]) => `${prop}: ${value}`)
                 .join(`; `);

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -173,6 +173,28 @@ describe('inline-expectations', () => {
                 ])
             );
         });
+        it('should ignore comments between declarations', () => {
+            const result = generateStylableResult({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'entry',
+                        content: `
+                            /* @rule .entry__root {first: 123; second: abc}*/
+                            .root {
+                                /* comment before */
+                                first: 123;
+                                /* comment between */
+                                second: abc;
+                                /* comment after */
+                            }
+                        `,
+                    },
+                },
+            });
+
+            expect(() => testInlineExpects(result)).to.not.throw();
+        });
         it('should throw for mismatch on nested rules', () => {
             const result = generateStylableResult({
                 entry: `/style.st.css`,


### PR DESCRIPTION
This PR fix a small issue in `core-test-kit` where comments between declarations were collected to compare against expectation declarations.

Before this PR, the following inline expectation would have failed because the comments are missing in the expectation:

```css
/* @rule .entry__root { prop: green; }*/
.root {
  /* comment before */
  prop: green;
  /* comment after*/
}
```