### PR TITLE
feat(core): flatten st-vars

### DIFF
--- a/packages/core/src/custom-values.ts
+++ b/packages/core/src/custom-values.ts
@@ -34,7 +34,7 @@ export function unbox<B extends Box<string, unknown>>(
     node?: ParsedValue
 ): any {
     if (typeof boxed === 'string') {
-        return unboxPrimitives ? boxed : box('string', boxed);
+        return unboxPrimitives ? boxed : box('string', boxed, boxed);
     } else if (typeof boxed === 'object' && boxed !== null) {
         const customValue = customValues?.[boxed.type];
         let value = boxed.value;

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -154,17 +154,15 @@ export class StylablePublicApi {
                 }
             );
 
-            const customValue = customValues[topLevelType?.type];
             const computedStVar: ComputedStVar = {
                 /**
                  * In case of custom value that could be flat, we will use the "outputValue" which is a flat value.
                  */
-                value:
-                    topLevelType && !customValue?.flattenValue ? unbox(topLevelType) : outputValue,
+                value: topLevelType ? unbox(topLevelType, customValues) : outputValue,
                 diagnostics,
             };
 
-            if (customValue?.flattenValue) {
+            if (topLevelType) {
                 computedStVar.input = unbox(topLevelType);
             }
 

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -1,5 +1,5 @@
 import { createFeature, FeatureContext, FeatureTransformContext } from './feature';
-import { deprecatedStFunctions } from '../custom-values';
+import { Box, deprecatedStFunctions } from '../custom-values';
 import { generalDiagnostics } from './diagnostics';
 import * as STSymbol from './st-symbol';
 import type { StylableMeta } from '../stylable-meta';
@@ -28,10 +28,12 @@ export interface VarSymbol {
     node: postcss.Node;
 }
 
+type Input = Box<string, Input | Record<string, Input | string> | Array<Input | string>>;
+
 export interface ComputedStVar {
     value: RuntimeStVar;
     diagnostics: Diagnostics;
-    input?: any;
+    input?: Input;
 }
 
 export const diagnostics = {
@@ -163,7 +165,7 @@ export class StylablePublicApi {
             };
 
             if (topLevelType) {
-                computedStVar.input = unbox(topLevelType);
+                computedStVar.input = topLevelType;
             }
 
             computed[localName] = computedStVar;

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -12,11 +12,12 @@ import {
     createSymbolResolverWithCache,
     MetaResolvedSymbols,
 } from './stylable-resolver';
-import type { replaceValueHook, StylableTransformer } from './stylable-transformer';
+import type { replaceValueHook, RuntimeStVar, StylableTransformer } from './stylable-transformer';
 import { getFormatterArgs, getStringValue, stringifyFunction } from './helpers/value';
 import type { ParsedValue } from './types';
 import type { FeatureTransformContext } from './features/feature';
 import { CSSCustomProperty, STVar } from './features';
+import { unbox, ValueError } from './custom-values';
 
 export type ValueFormatter = (name: string) => string;
 export type ResolvedFormatter = Record<string, JSResolve | CSSResolve | ValueFormatter | null>;
@@ -30,10 +31,13 @@ export interface EvalValueData {
     tsVarOverride?: Record<string, string> | null;
     cssVarsMapping?: Record<string, string>;
     args?: string[];
+    rootArgument?: string;
+    evaluatorNode?: postcss.Node;
 }
 
 export interface EvalValueResult {
     topLevelType: any;
+    runtimeValue: RuntimeStVar;
     outputValue: string;
     typeError?: Error;
 }
@@ -58,7 +62,9 @@ export class StylableEvaluator {
             context.diagnostics,
             data.passedThrough,
             data.cssVarsMapping,
-            data.args
+            data.args,
+            data.rootArgument,
+            data.evaluatorNode
         );
     }
 }
@@ -111,7 +117,9 @@ export function processDeclarationValue(
     diagnostics: Diagnostics = new Diagnostics(),
     passedThrough: string[] = [],
     cssVarsMapping: Record<string, string> = {},
-    args: string[] = []
+    args: string[] = [],
+    rootArgument?: string,
+    evaluatorNode?: postcss.Node
 ): EvalValueResult {
     const evaluator = new StylableEvaluator({ tsVarOverride: variableOverride });
     const resolvedSymbols = getResolvedSymbols(meta);
@@ -137,6 +145,8 @@ export function processDeclarationValue(
                         tsVarOverride: variableOverride,
                         cssVarsMapping,
                         args,
+                        rootArgument,
+                        evaluatorNode,
                     },
                     node: parsedNode,
                 });
@@ -204,6 +214,8 @@ export function processDeclarationValue(
                         tsVarOverride: variableOverride,
                         cssVarsMapping,
                         args,
+                        rootArgument,
+                        evaluatorNode,
                     },
                     node: parsedNode,
                 });
@@ -220,23 +232,46 @@ export function processDeclarationValue(
 
     let outputValue = '';
     let topLevelType = null;
+    let runtimeValue = null;
     let typeError: Error | undefined = undefined;
     for (const n of parsedValue.nodes) {
         if (n.type === 'function') {
             const matchingType = resolvedSymbols.customValues[n.value];
 
             if (matchingType) {
-                topLevelType = matchingType.evalVarAst(n, resolvedSymbols.customValues);
                 try {
-                    outputValue += matchingType.getValue(
-                        args,
-                        topLevelType,
-                        n,
-                        resolvedSymbols.customValues
-                    );
+                    topLevelType = matchingType.evalVarAst(n, resolvedSymbols.customValues, true);
+                    runtimeValue = unbox(topLevelType, true, resolvedSymbols.customValues, n);
+                    try {
+                        outputValue += matchingType.getValue(
+                            args,
+                            topLevelType,
+                            n,
+                            resolvedSymbols.customValues
+                        );
+                    } catch (error) {
+                        if (error instanceof ValueError) {
+                            outputValue += error.fallbackValue;
+                        } else {
+                            throw error;
+                        }
+                    }
                 } catch (e) {
                     typeError = e as Error;
-                    // catch broken variable resolutions
+
+                    const invalidNode = evaluatorNode || node;
+
+                    if (invalidNode) {
+                        diagnostics.warn(
+                            invalidNode,
+                            STVar.diagnostics.COULD_NOT_RESOLVE_VALUE(
+                                [...(rootArgument ? [rootArgument] : []), ...args].join(', ')
+                            ),
+                            { word: value }
+                        );
+                    } else {
+                        // TODO: catch broken variable resolutions without a node
+                    }
                 }
             } else {
                 outputValue += getStringValue([n]);
@@ -245,7 +280,7 @@ export function processDeclarationValue(
             outputValue += getStringValue([n]);
         }
     }
-    return { outputValue, topLevelType, typeError };
+    return { outputValue, topLevelType, typeError, runtimeValue };
 }
 
 export function evalDeclarationValue(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export type {
 } from './features';
 export { reservedKeyFrames } from './features/css-keyframes';
 export { scopeCSSVar } from './features/css-custom-property';
-export type { ComputedStVar } from './features/st-var';
+export type { ComputedStVar, FlatComputedStVar } from './features/st-var';
 export {
     StylableProcessor,
     createEmptyMeta,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -204,6 +204,7 @@ export class StylableTransformer {
                     node: atRule,
                     valueHook: this.replaceValueHook,
                     passedThrough: path.slice(),
+                    evaluatorNode: atRule,
                 }).outputValue;
             } else if (name === 'property') {
                 CSSCustomProperty.hooks.transformAtRuleNode({

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -1299,19 +1299,38 @@ describe(`features/st-var`, () => {
             expect(Object.keys(computedVars)).to.eql(['a', 'b', 'c']);
             expect(computedVars.a).to.containSubset({
                 value: 'red',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'red',
+                },
                 diagnostics: { reports: [] },
             });
             expect(computedVars.b).to.containSubset({
                 value: 'blue',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'blue',
+                },
                 diagnostics: { reports: [] },
             });
             expect(computedVars.c).to.containSubset({
                 value: ['red', 'gold'],
                 input: {
                     type: 'st-array',
-                    value: ['red', 'gold'],
+                    value: [
+                        {
+                            flatValue: undefined,
+                            type: 'string',
+                            value: 'red',
+                        },
+                        {
+                            flatValue: undefined,
+                            type: 'string',
+                            value: 'gold',
+                        },
+                    ],
                 },
                 diagnostics: { reports: [] },
             });
@@ -1328,24 +1347,28 @@ describe(`features/st-var`, () => {
             const computedVars = stylable.stVar.getComputed(meta);
 
             expect(Object.keys(computedVars)).to.eql(['map']);
-            expect(computedVars.map).to.containSubset({
+            expect(computedVars.map.diagnostics.reports.length).to.eql(0);
+            expect(computedVars.map.value).to.eql({
+                a: {
+                    b: 'red',
+                },
+            });
+            expect(computedVars.map.input).to.eql({
+                type: 'st-map',
+                flatValue: undefined,
                 value: {
                     a: {
-                        b: 'red',
-                    },
-                },
-                input: {
-                    type: 'st-map',
-                    value: {
-                        a: {
-                            type: 'st-map',
-                            value: {
-                                b: 'red',
+                        type: 'st-map',
+                        flatValue: undefined,
+                        value: {
+                            b: {
+                                flatValue: undefined,
+                                type: 'string',
+                                value: 'red',
                             },
                         },
                     },
                 },
-                diagnostics: { reports: [] },
             });
         });
 
@@ -1369,7 +1392,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.border).to.containSubset({
                 value: '1px solid red',
                 input: {
-                    type: 'stBorder',
+                    type: 'createBorder',
                     flatValue: '1px solid red',
                     value: {
                         color: 'red',
@@ -1387,8 +1410,12 @@ describe(`features/st-var`, () => {
                 @st-import [stBorder] from './st-border.js';
 
                 :vars {
-                    array: st-array(red, stBorder(1px, solid, blue));
-                    map: st-map(border stBorder(1px, solid, value(array, 0)));
+                    array: st-array(blue, stBorder(1px, solid, blue));
+                    map: st-map(
+                            border stBorder(value(array, 1, size), 
+                            solid, 
+                            value(array, 0))
+                        );
                 }
                 `,
                 // Stylable custom value
@@ -1400,12 +1427,16 @@ describe(`features/st-var`, () => {
 
             expect(Object.keys(computedVars)).to.eql(['array', 'map']);
             expect(computedVars.array).to.containSubset({
-                value: ['red', '1px solid blue'],
+                value: ['blue', '1px solid blue'],
                 input: {
                     type: 'st-array',
                     flatValue: undefined,
                     value: [
-                        'red',
+                        {
+                            flatValue: undefined,
+                            type: 'string',
+                            value: 'blue',
+                        },
                         {
                             type: 'stBorder',
                             flatValue: '1px solid blue',
@@ -1421,7 +1452,7 @@ describe(`features/st-var`, () => {
             });
             expect(computedVars.map).to.containSubset({
                 value: {
-                    border: '1px solid red',
+                    border: '1px solid blue',
                 },
                 input: {
                     type: 'st-map',
@@ -1429,9 +1460,9 @@ describe(`features/st-var`, () => {
                     value: {
                         border: {
                             type: 'stBorder',
-                            flatValue: '1px solid red',
+                            flatValue: '1px solid blue',
                             value: {
-                                color: 'red',
+                                color: 'blue',
                                 size: '1px',
                                 style: 'solid',
                             },
@@ -1465,12 +1496,20 @@ describe(`features/st-var`, () => {
             expect(Object.keys(computedVars)).to.eql(['imported', 'a', 'b']);
             expect(computedVars.imported).to.containSubset({
                 value: 'red',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'red',
+                },
                 diagnostics: { reports: [] },
             });
             expect(computedVars.a).to.containSubset({
                 value: 'red',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'red',
+                },
                 diagnostics: { reports: [] },
             });
             expect(computedVars.b).to.containSubset({
@@ -1503,21 +1542,68 @@ describe(`features/st-var`, () => {
             expect(Object.keys(computedVars)).to.eql(['validBefore', 'invalid', 'validAfter']);
             expect(computedVars.validBefore).to.containSubset({
                 value: 'red',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'red',
+                },
                 diagnostics: { reports: [] },
             });
             expect(computedVars.validAfter).to.containSubset({
                 value: 'green',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'green',
+                },
                 diagnostics: { reports: [] },
             });
             expect(computedVars.invalid).to.containSubset({
                 value: 'invalid-func(imported)',
-                input: undefined,
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: 'invalid-func(imported)',
+                },
                 diagnostics: {
                     reports: [
                         {
                             message: functionWarnings.UNKNOWN_FORMATTER('invalid-func'),
+                            type: 'warning',
+                        },
+                    ],
+                },
+            });
+        });
+
+        it('should emit diagnostics only on invalid custom st-vars', () => {
+            const { stylable, sheets } = testStylableCore({
+                '/entry.st.css': `
+                    @st-import [stBorder] from './st-border.js';
+
+                    :vars {
+                        border: stBorder(st-array(1px, 2px), solid, red);
+                    }
+                `,
+                // Stylable custom value
+                '/st-border.js': stBorderDefinitionMock,
+            });
+
+            const { meta } = sheets['/entry.st.css'];
+
+            const computedVars = stylable.stVar.getComputed(meta);
+
+            expect(computedVars.border).to.containSubset({
+                value: '',
+                input: {
+                    flatValue: undefined,
+                    type: 'string',
+                    value: '',
+                },
+                diagnostics: {
+                    reports: [
+                        {
+                            message: STVar.diagnostics.COULD_NOT_RESOLVE_VALUE(),
                             type: 'warning',
                         },
                     ],

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -1300,7 +1300,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.a).to.containSubset({
                 value: 'red',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'red',
                     type: 'string',
                     value: 'red',
                 },
@@ -1309,7 +1309,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.b).to.containSubset({
                 value: 'blue',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'blue',
                     type: 'string',
                     value: 'blue',
                 },
@@ -1321,12 +1321,12 @@ describe(`features/st-var`, () => {
                     type: 'st-array',
                     value: [
                         {
-                            flatValue: undefined,
+                            flatValue: 'red',
                             type: 'string',
                             value: 'red',
                         },
                         {
-                            flatValue: undefined,
+                            flatValue: 'gold',
                             type: 'string',
                             value: 'gold',
                         },
@@ -1362,7 +1362,7 @@ describe(`features/st-var`, () => {
                         flatValue: undefined,
                         value: {
                             b: {
-                                flatValue: undefined,
+                                flatValue: 'red',
                                 type: 'string',
                                 value: 'red',
                             },
@@ -1433,7 +1433,7 @@ describe(`features/st-var`, () => {
                     flatValue: undefined,
                     value: [
                         {
-                            flatValue: undefined,
+                            flatValue: 'blue',
                             type: 'string',
                             value: 'blue',
                         },
@@ -1497,7 +1497,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.imported).to.containSubset({
                 value: 'red',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'red',
                     type: 'string',
                     value: 'red',
                 },
@@ -1506,7 +1506,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.a).to.containSubset({
                 value: 'red',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'red',
                     type: 'string',
                     value: 'red',
                 },
@@ -1543,7 +1543,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.validBefore).to.containSubset({
                 value: 'red',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'red',
                     type: 'string',
                     value: 'red',
                 },
@@ -1552,7 +1552,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.validAfter).to.containSubset({
                 value: 'green',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'green',
                     type: 'string',
                     value: 'green',
                 },
@@ -1561,7 +1561,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.invalid).to.containSubset({
                 value: 'invalid-func(imported)',
                 input: {
-                    flatValue: undefined,
+                    flatValue: 'invalid-func(imported)',
                     type: 'string',
                     value: 'invalid-func(imported)',
                 },
@@ -1596,7 +1596,7 @@ describe(`features/st-var`, () => {
             expect(computedVars.border).to.containSubset({
                 value: '',
                 input: {
-                    flatValue: undefined,
+                    flatValue: '',
                     type: 'string',
                     value: '',
                 },

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -10,6 +10,31 @@ import postcssValueParser from 'postcss-value-parser';
 chai.use(chaiSubset);
 
 describe(`features/st-var`, () => {
+    const stBorderDefinitionMock = `
+        const { createCustomValue, CustomValueStrategy } = require("@stylable/core");
+        exports.stBorder = createCustomValue({
+            processArgs: (node, customTypes) => {
+                return CustomValueStrategy.args(node, customTypes);
+            },
+            createValue: ([size, style, color]) => {
+                return {
+                    size,
+                    style,
+                    color,
+                };
+            },
+            getValue: (value, index) => {
+                return value[index];
+            },
+            flattenValue: ({ value: { size, style, color } }) => {
+                return {
+                    delimiter: ' ',
+                    parts: [size, style, color],
+                };
+            },
+        })
+    `;
+
     it(`should process :vars definitions`, () => {
         const { sheets } = testStylableCore(`
             /* @transform-remove */
@@ -1327,37 +1352,14 @@ describe(`features/st-var`, () => {
         it('should get computed custom value st-var', () => {
             const { stylable, sheets } = testStylableCore({
                 '/entry.st.css': `
-                @st-import [stBorder] from './st-border.js';
+                @st-import [stBorder as createBorder] from './st-border.js';
 
                 :vars {
-                    border: stBorder(1px, solid, red);
+                    border: createBorder(1px, solid, red);
                 }
                 `,
                 // Stylable custom value
-                '/st-border.js': `
-                    const { createCustomValue, CustomValueStrategy } = require("@stylable/core");
-                    exports.stBorder = createCustomValue({
-                        processArgs: (node, customTypes) => {
-                            return CustomValueStrategy.args(node, customTypes);
-                        },
-                        createValue: ([size, style, color]) => {
-                            return {
-                                size,
-                                style,
-                                color,
-                            };
-                        },
-                        getValue: (value, index) => {
-                            return value[index];
-                        },
-                        flattenValue: ({ value: { size, style, color } }) => {
-                            return {
-                                delimiter: ' ',
-                                parts: [size, style, color],
-                            };
-                        },
-                    })
-                `,
+                '/st-border.js': stBorderDefinitionMock,
             });
 
             const { meta } = sheets['/entry.st.css'];
@@ -1390,30 +1392,7 @@ describe(`features/st-var`, () => {
                 }
                 `,
                 // Stylable custom value
-                '/st-border.js': `
-                    const { createCustomValue, CustomValueStrategy } = require("@stylable/core");
-                    exports.stBorder = createCustomValue({
-                        processArgs: (node, customTypes) => {
-                            return CustomValueStrategy.args(node, customTypes);
-                        },
-                        createValue: ([size, style, color]) => {
-                            return {
-                                size,
-                                style,
-                                color,
-                            };
-                        },
-                        getValue: (value, index) => {
-                            return value[index];
-                        },
-                        flattenValue: ({ value: { size, style, color } }) => {
-                            return {
-                                delimiter: ' ',
-                                parts: [size, style, color],
-                            };
-                        },
-                    })
-                `,
+                '/st-border.js': stBorderDefinitionMock,
             });
 
             const { meta } = sheets['/entry.st.css'];

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -1284,330 +1284,569 @@ describe(`features/st-var`, () => {
         });
     });
     describe('introspection', () => {
-        it('should get computed st-vars', () => {
-            const { stylable, sheets } = testStylableCore(`
-            :vars {
-                a: red;
-                b: blue;
-                c: st-array(value(a), gold);
-            }
-            `);
+        describe('getComputed', () => {
+            it('should get computed st-vars', () => {
+                const { stylable, sheets } = testStylableCore(`
+                :vars {
+                    a: red;
+                    b: blue;
+                    c: st-array(value(a), gold);
+                }
+                `);
 
-            const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.stVar.getComputed(meta);
+                const { meta } = sheets['/entry.st.css'];
+                const computedVars = stylable.stVar.getComputed(meta);
 
-            expect(Object.keys(computedVars)).to.eql(['a', 'b', 'c']);
-            expect(computedVars.a).to.containSubset({
-                value: 'red',
-                input: {
-                    flatValue: 'red',
-                    type: 'string',
+                expect(Object.keys(computedVars)).to.eql(['a', 'b', 'c']);
+                expect(computedVars.a).to.containSubset({
                     value: 'red',
-                },
-                diagnostics: { reports: [] },
-            });
-            expect(computedVars.b).to.containSubset({
-                value: 'blue',
-                input: {
-                    flatValue: 'blue',
-                    type: 'string',
+                    input: {
+                        flatValue: 'red',
+                        type: 'string',
+                        value: 'red',
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.b).to.containSubset({
                     value: 'blue',
-                },
-                diagnostics: { reports: [] },
-            });
-            expect(computedVars.c).to.containSubset({
-                value: ['red', 'gold'],
-                input: {
-                    type: 'st-array',
-                    value: [
-                        {
-                            flatValue: 'red',
-                            type: 'string',
-                            value: 'red',
-                        },
-                        {
-                            flatValue: 'gold',
-                            type: 'string',
-                            value: 'gold',
-                        },
-                    ],
-                },
-                diagnostics: { reports: [] },
-            });
-        });
-
-        it('should get deep computed complex st-vars', () => {
-            const { stylable, sheets } = testStylableCore(`
-            :vars {
-                map: st-map(a st-map(b red));
-            }
-            `);
-
-            const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.stVar.getComputed(meta);
-
-            expect(Object.keys(computedVars)).to.eql(['map']);
-            expect(computedVars.map.diagnostics.reports.length).to.eql(0);
-            expect(computedVars.map.value).to.eql({
-                a: {
-                    b: 'red',
-                },
-            });
-            expect(computedVars.map.input).to.eql({
-                type: 'st-map',
-                flatValue: undefined,
-                value: {
-                    a: {
-                        type: 'st-map',
-                        flatValue: undefined,
-                        value: {
-                            b: {
+                    input: {
+                        flatValue: 'blue',
+                        type: 'string',
+                        value: 'blue',
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.c).to.containSubset({
+                    value: ['red', 'gold'],
+                    input: {
+                        type: 'st-array',
+                        value: [
+                            {
                                 flatValue: 'red',
                                 type: 'string',
                                 value: 'red',
                             },
-                        },
-                    },
-                },
-            });
-        });
-
-        it('should get computed custom value st-var', () => {
-            const { stylable, sheets } = testStylableCore({
-                '/entry.st.css': `
-                @st-import [stBorder as createBorder] from './st-border.js';
-
-                :vars {
-                    border: createBorder(1px, solid, red);
-                }
-                `,
-                // Stylable custom value
-                '/st-border.js': stBorderDefinitionMock,
-            });
-
-            const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.stVar.getComputed(meta);
-
-            expect(Object.keys(computedVars)).to.eql(['border']);
-            expect(computedVars.border).to.containSubset({
-                value: '1px solid red',
-                input: {
-                    type: 'createBorder',
-                    flatValue: '1px solid red',
-                    value: {
-                        color: 'red',
-                        size: '1px',
-                        style: 'solid',
-                    },
-                },
-                diagnostics: { reports: [] },
-            });
-        });
-
-        it('should get deep computed custom value st-var', () => {
-            const { stylable, sheets } = testStylableCore({
-                '/entry.st.css': `
-                @st-import [stBorder] from './st-border.js';
-
-                :vars {
-                    array: st-array(blue, stBorder(1px, solid, blue));
-                    map: st-map(
-                            border stBorder(value(array, 1, size), 
-                            solid, 
-                            value(array, 0))
-                        );
-                }
-                `,
-                // Stylable custom value
-                '/st-border.js': stBorderDefinitionMock,
-            });
-
-            const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.stVar.getComputed(meta);
-
-            expect(Object.keys(computedVars)).to.eql(['array', 'map']);
-            expect(computedVars.array).to.containSubset({
-                value: ['blue', '1px solid blue'],
-                input: {
-                    type: 'st-array',
-                    flatValue: undefined,
-                    value: [
-                        {
-                            flatValue: 'blue',
-                            type: 'string',
-                            value: 'blue',
-                        },
-                        {
-                            type: 'stBorder',
-                            flatValue: '1px solid blue',
-                            value: {
-                                color: 'blue',
-                                size: '1px',
-                                style: 'solid',
+                            {
+                                flatValue: 'gold',
+                                type: 'string',
+                                value: 'gold',
                             },
-                        },
-                    ],
-                },
-                diagnostics: { reports: [] },
+                        ],
+                    },
+                    diagnostics: { reports: [] },
+                });
             });
-            expect(computedVars.map).to.containSubset({
-                value: {
-                    border: '1px solid blue',
-                },
-                input: {
+
+            it('should get deep computed complex st-vars', () => {
+                const { stylable, sheets } = testStylableCore(`
+                :vars {
+                    map: st-map(a st-map(b red));
+                }
+                `);
+
+                const { meta } = sheets['/entry.st.css'];
+                const computedVars = stylable.stVar.getComputed(meta);
+
+                expect(Object.keys(computedVars)).to.eql(['map']);
+                expect(computedVars.map.diagnostics.reports.length).to.eql(0);
+                expect(computedVars.map.value).to.eql({
+                    a: {
+                        b: 'red',
+                    },
+                });
+                expect(computedVars.map.input).to.eql({
                     type: 'st-map',
                     flatValue: undefined,
                     value: {
-                        border: {
-                            type: 'stBorder',
-                            flatValue: '1px solid blue',
+                        a: {
+                            type: 'st-map',
+                            flatValue: undefined,
                             value: {
-                                color: 'blue',
-                                size: '1px',
-                                style: 'solid',
+                                b: {
+                                    flatValue: 'red',
+                                    type: 'string',
+                                    value: 'red',
+                                },
                             },
                         },
                     },
-                },
-                diagnostics: { reports: [] },
-            });
-        });
-
-        it('should get imported computed st-vars', () => {
-            const { stylable, sheets } = testStylableCore({
-                '/entry.st.css': `
-                @st-import [imported-var as imported] from './imported.st.css';
-
-                :vars {
-                    a: value(imported);
-                    b: st-map(a value(imported));
-                }
-                `,
-                'imported.st.css': `
-                :vars {
-                    imported-var: red;
-                }
-                `,
+                });
             });
 
-            const { meta } = sheets['/entry.st.css'];
-            const computedVars = stylable.stVar.getComputed(meta);
-
-            expect(Object.keys(computedVars)).to.eql(['imported', 'a', 'b']);
-            expect(computedVars.imported).to.containSubset({
-                value: 'red',
-                input: {
-                    flatValue: 'red',
-                    type: 'string',
-                    value: 'red',
-                },
-                diagnostics: { reports: [] },
-            });
-            expect(computedVars.a).to.containSubset({
-                value: 'red',
-                input: {
-                    flatValue: 'red',
-                    type: 'string',
-                    value: 'red',
-                },
-                diagnostics: { reports: [] },
-            });
-            expect(computedVars.b).to.containSubset({
-                value: { a: 'red' },
-                input: {
-                    type: 'st-map',
-                    value: {
-                        a: 'red',
-                    },
-                },
-                diagnostics: { reports: [] },
-            });
-        });
-
-        it('should emit diagnostics only on invalid computed st-vars', () => {
-            const { stylable, sheets } = testStylableCore(
-                `
-                :vars {
-                    validBefore: red;
-                    invalid: invalid-func(imported);
-                    validAfter: green;
-                }
-                `
-            );
-
-            const { meta } = sheets['/entry.st.css'];
-
-            const computedVars = stylable.stVar.getComputed(meta);
-
-            expect(Object.keys(computedVars)).to.eql(['validBefore', 'invalid', 'validAfter']);
-            expect(computedVars.validBefore).to.containSubset({
-                value: 'red',
-                input: {
-                    flatValue: 'red',
-                    type: 'string',
-                    value: 'red',
-                },
-                diagnostics: { reports: [] },
-            });
-            expect(computedVars.validAfter).to.containSubset({
-                value: 'green',
-                input: {
-                    flatValue: 'green',
-                    type: 'string',
-                    value: 'green',
-                },
-                diagnostics: { reports: [] },
-            });
-            expect(computedVars.invalid).to.containSubset({
-                value: 'invalid-func(imported)',
-                input: {
-                    flatValue: 'invalid-func(imported)',
-                    type: 'string',
-                    value: 'invalid-func(imported)',
-                },
-                diagnostics: {
-                    reports: [
-                        {
-                            message: functionWarnings.UNKNOWN_FORMATTER('invalid-func'),
-                            type: 'warning',
-                        },
-                    ],
-                },
-            });
-        });
-
-        it('should emit diagnostics only on invalid custom st-vars', () => {
-            const { stylable, sheets } = testStylableCore({
-                '/entry.st.css': `
-                    @st-import [stBorder] from './st-border.js';
-
+            it('should get computed custom value st-var', () => {
+                const { stylable, sheets } = testStylableCore({
+                    '/entry.st.css': `
+                    @st-import [stBorder as createBorder] from './st-border.js';
+    
                     :vars {
-                        border: stBorder(st-array(1px, 2px), solid, red);
+                        border: createBorder(1px, solid, red);
                     }
-                `,
-                // Stylable custom value
-                '/st-border.js': stBorderDefinitionMock,
+                    `,
+                    // Stylable custom value
+                    '/st-border.js': stBorderDefinitionMock,
+                });
+
+                const { meta } = sheets['/entry.st.css'];
+                const computedVars = stylable.stVar.getComputed(meta);
+
+                expect(Object.keys(computedVars)).to.eql(['border']);
+                expect(computedVars.border).to.containSubset({
+                    value: '1px solid red',
+                    input: {
+                        type: 'createBorder',
+                        flatValue: '1px solid red',
+                        value: {
+                            color: 'red',
+                            size: '1px',
+                            style: 'solid',
+                        },
+                    },
+                    diagnostics: { reports: [] },
+                });
             });
 
-            const { meta } = sheets['/entry.st.css'];
+            it('should get deep computed custom value st-var', () => {
+                const { stylable, sheets } = testStylableCore({
+                    '/entry.st.css': `
+                    @st-import [stBorder] from './st-border.js';
+    
+                    :vars {
+                        array: st-array(blue, stBorder(1px, solid, blue));
+                        map: st-map(
+                                border stBorder(value(array, 1, size), 
+                                solid, 
+                                value(array, 0))
+                            );
+                    }
+                    `,
+                    // Stylable custom value
+                    '/st-border.js': stBorderDefinitionMock,
+                });
 
-            const computedVars = stylable.stVar.getComputed(meta);
+                const { meta } = sheets['/entry.st.css'];
+                const computedVars = stylable.stVar.getComputed(meta);
 
-            expect(computedVars.border).to.containSubset({
-                value: '',
-                input: {
-                    flatValue: '',
-                    type: 'string',
-                    value: '',
-                },
-                diagnostics: {
-                    reports: [
-                        {
-                            message: STVar.diagnostics.COULD_NOT_RESOLVE_VALUE(),
-                            type: 'warning',
+                expect(Object.keys(computedVars)).to.eql(['array', 'map']);
+                expect(computedVars.array).to.containSubset({
+                    value: ['blue', '1px solid blue'],
+                    input: {
+                        type: 'st-array',
+                        flatValue: undefined,
+                        value: [
+                            {
+                                flatValue: 'blue',
+                                type: 'string',
+                                value: 'blue',
+                            },
+                            {
+                                type: 'stBorder',
+                                flatValue: '1px solid blue',
+                                value: {
+                                    color: 'blue',
+                                    size: '1px',
+                                    style: 'solid',
+                                },
+                            },
+                        ],
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.map).to.containSubset({
+                    value: {
+                        border: '1px solid blue',
+                    },
+                    input: {
+                        type: 'st-map',
+                        flatValue: undefined,
+                        value: {
+                            border: {
+                                type: 'stBorder',
+                                flatValue: '1px solid blue',
+                                value: {
+                                    color: 'blue',
+                                    size: '1px',
+                                    style: 'solid',
+                                },
+                            },
                         },
-                    ],
-                },
+                    },
+                    diagnostics: { reports: [] },
+                });
+            });
+
+            it('should get imported computed st-vars', () => {
+                const { stylable, sheets } = testStylableCore({
+                    '/entry.st.css': `
+                    @st-import [imported-var as imported] from './imported.st.css';
+    
+                    :vars {
+                        a: value(imported);
+                        b: st-map(a value(imported));
+                    }
+                    `,
+                    'imported.st.css': `
+                    :vars {
+                        imported-var: red;
+                    }
+                    `,
+                });
+
+                const { meta } = sheets['/entry.st.css'];
+                const computedVars = stylable.stVar.getComputed(meta);
+
+                expect(Object.keys(computedVars)).to.eql(['imported', 'a', 'b']);
+                expect(computedVars.imported).to.containSubset({
+                    value: 'red',
+                    input: {
+                        flatValue: 'red',
+                        type: 'string',
+                        value: 'red',
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.a).to.containSubset({
+                    value: 'red',
+                    input: {
+                        flatValue: 'red',
+                        type: 'string',
+                        value: 'red',
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.b).to.containSubset({
+                    value: { a: 'red' },
+                    input: {
+                        type: 'st-map',
+                        value: {
+                            a: 'red',
+                        },
+                    },
+                    diagnostics: { reports: [] },
+                });
+            });
+
+            it('should emit diagnostics only on invalid computed st-vars', () => {
+                const { stylable, sheets } = testStylableCore(
+                    `
+                    :vars {
+                        validBefore: red;
+                        invalid: invalid-func(imported);
+                        validAfter: green;
+                    }
+                    `
+                );
+
+                const { meta } = sheets['/entry.st.css'];
+
+                const computedVars = stylable.stVar.getComputed(meta);
+
+                expect(Object.keys(computedVars)).to.eql(['validBefore', 'invalid', 'validAfter']);
+                expect(computedVars.validBefore).to.containSubset({
+                    value: 'red',
+                    input: {
+                        flatValue: 'red',
+                        type: 'string',
+                        value: 'red',
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.validAfter).to.containSubset({
+                    value: 'green',
+                    input: {
+                        flatValue: 'green',
+                        type: 'string',
+                        value: 'green',
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.invalid).to.containSubset({
+                    value: 'invalid-func(imported)',
+                    input: {
+                        flatValue: 'invalid-func(imported)',
+                        type: 'string',
+                        value: 'invalid-func(imported)',
+                    },
+                    diagnostics: {
+                        reports: [
+                            {
+                                message: functionWarnings.UNKNOWN_FORMATTER('invalid-func'),
+                                type: 'warning',
+                            },
+                        ],
+                    },
+                });
+            });
+
+            it('should emit diagnostics only on invalid custom st-vars', () => {
+                const { stylable, sheets } = testStylableCore({
+                    '/entry.st.css': `
+                        @st-import [stBorder] from './st-border.js';
+    
+                        :vars {
+                            border: stBorder(st-array(1px, 2px), solid, red);
+                        }
+                    `,
+                    // Stylable custom value
+                    '/st-border.js': stBorderDefinitionMock,
+                });
+
+                const { meta } = sheets['/entry.st.css'];
+
+                const computedVars = stylable.stVar.getComputed(meta);
+
+                expect(computedVars.border).to.containSubset({
+                    value: '',
+                    input: {
+                        flatValue: '',
+                        type: 'string',
+                        value: '',
+                    },
+                    diagnostics: {
+                        reports: [
+                            {
+                                message: STVar.diagnostics.COULD_NOT_RESOLVE_VALUE(),
+                                type: 'warning',
+                            },
+                        ],
+                    },
+                });
+            });
+        });
+
+        describe('flatten', () => {
+            it('should flat simple st vars', () => {
+                const { stylable, sheets } = testStylableCore(`
+                    :vars {
+                        a: red;
+                        b: blue;
+                    }
+                `);
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'a',
+                        value: 'red',
+                        path: ['a'],
+                    },
+                    {
+                        symbol: 'b',
+                        value: 'blue',
+                        path: ['b'],
+                    },
+                ]);
+            });
+            it('should not flat native css function inside st vars', () => {
+                const { stylable, sheets } = testStylableCore(`
+                    :vars {
+                        a: linear-gradient(to right, red, blue);
+                    }
+                `);
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        path: ['a'],
+                        symbol: 'a',
+                        value: 'linear-gradient(to right, red, blue)',
+                    },
+                ]);
+            });
+            it('should flat imported simple st vars', () => {
+                const { stylable, sheets } = testStylableCore({
+                    '/entry.st.css': `
+                        @st-import [color as myColor] from './imported.st.css';
+                        .root { color: value(myColor); }
+                    `,
+                    '/imported.st.css': `
+                        :vars {
+                            color: red;
+                        }
+                    `,
+                });
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'myColor',
+                        value: 'red',
+                        path: ['myColor'],
+                    },
+                ]);
+            });
+
+            it('should flat st-array st vars', () => {
+                const { stylable, sheets } = testStylableCore(
+                    `
+                    :vars {
+                        array: st-array(1px, 2px);
+                    }
+
+                    `
+                );
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'array[0]',
+                        value: '1px',
+                        path: ['array', '0'],
+                    },
+                    {
+                        symbol: 'array[1]',
+                        value: '2px',
+                        path: ['array', '1'],
+                    },
+                ]);
+            });
+
+            it('should flat st-map st vars', () => {
+                const { stylable, sheets } = testStylableCore(
+                    `
+                    :vars {
+                        map: st-map(first 1px,second 2px);
+                    }
+
+                    `
+                );
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'map.first',
+                        value: '1px',
+                        path: ['map', 'first'],
+                    },
+                    {
+                        symbol: 'map.second',
+                        value: '2px',
+                        path: ['map', 'second'],
+                    },
+                ]);
+            });
+
+            it('should flat custom value st vars', () => {
+                const { stylable, sheets } = testStylableCore({
+                    '/entry.st.css': `
+                        @st-import [stBorder] from './st-border.js';
+
+                        :vars {
+                            border: stBorder(1px, solid, red);
+                        }
+                    `,
+                    '/st-border.js': stBorderDefinitionMock,
+                });
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'border',
+                        value: '1px solid red',
+                        path: ['border'],
+                    },
+                ]);
+            });
+            it('should flat nested st-array st vars', () => {
+                const { stylable, sheets } = testStylableCore(
+                    `
+                    :vars {
+                        nestedArray: st-array(
+                            red,
+                            st-array(red, green),
+                            st-map(color1 gold, color2 blue),
+                        );
+                    }
+
+                    `
+                );
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'nestedArray[0]',
+                        value: 'red',
+                        path: ['nestedArray', '0'],
+                    },
+                    {
+                        symbol: 'nestedArray[1][0]',
+                        value: 'red',
+                        path: ['nestedArray', '1', '0'],
+                    },
+                    {
+                        symbol: 'nestedArray[1][1]',
+                        value: 'green',
+                        path: ['nestedArray', '1', '1'],
+                    },
+                    {
+                        symbol: 'nestedArray[2].color1',
+                        value: 'gold',
+                        path: ['nestedArray', '2', 'color1'],
+                    },
+                    {
+                        symbol: 'nestedArray[2].color2',
+                        value: 'blue',
+                        path: ['nestedArray', '2', 'color2'],
+                    },
+                ]);
+            });
+            it('should flat nested st-map st vars', () => {
+                const { stylable, sheets } = testStylableCore(
+                    `
+                    :vars {
+                        nestedMap: st-map(
+                            simple red,
+                            array st-array(red, green),
+                            map st-map(color1 gold, color2 blue)
+                        );
+                    }
+
+                    `
+                );
+
+                const meta = sheets['/entry.st.css'].meta;
+                const flattenStVars = stylable.stVar.flatten(meta);
+
+                expect(flattenStVars).to.eql([
+                    {
+                        symbol: 'nestedMap.simple',
+                        value: 'red',
+                        path: ['nestedMap', 'simple'],
+                    },
+                    {
+                        symbol: 'nestedMap.array[0]',
+                        value: 'red',
+                        path: ['nestedMap', 'array', '0'],
+                    },
+                    {
+                        symbol: 'nestedMap.array[1]',
+                        value: 'green',
+                        path: ['nestedMap', 'array', '1'],
+                    },
+                    {
+                        symbol: 'nestedMap.map.color1',
+                        value: 'gold',
+                        path: ['nestedMap', 'map', 'color1'],
+                    },
+                    {
+                        symbol: 'nestedMap.map.color2',
+                        value: 'blue',
+                        path: ['nestedMap', 'map', 'color2'],
+                    },
+                ]);
             });
         });
     });


### PR DESCRIPTION
We want to give the option to flat the computed st-vars so they could be used for code modifications.