### PR TITLE
feat(create-stylable-app): add `stcConfig` to the integrations templates

### DIFF
--- a/packages/create-stylable-app/src/create-project.ts
+++ b/packages/create-stylable-app/src/create-project.ts
@@ -142,8 +142,7 @@ export async function createProjectFromTemplate({
         await executeWithProgress(
             `# Running postinstall template commands.`,
             async () => {
-                for (const script of postinstall) {
-                    const [command, ...params] = script;
+                for (const [command, ...params] of postinstall) {
                     await spawnSafe(command, params, spawnOptions);
                 }
             },

--- a/packages/create-stylable-app/template/ts-react-rollup/README.md
+++ b/packages/create-stylable-app/template/ts-react-rollup/README.md
@@ -12,7 +12,7 @@ The following scripts are available:
 
 `npm run clean` - Delete the `dist` folder. Uses [rimraf](https://github.com/isaacs/rimraf).
 
-`npm run typecheck` - Verify syntactic/semantic correctness. Uses [typescript](https://github.com/microsoft/TypeScript).
+`npm run typecheck` - Verify syntactic/semantic correctness. Uses [typescript](https://github.com/microsoft/TypeScript). To read more about Stylable integration with typescript check out [our documentation](https://stylable.io/docs/getting-started/typescript-integration).
 
 `npm run lint` - Verify best practices and find common issues. Uses [eslint](https://github.com/eslint/eslint).
 

--- a/packages/create-stylable-app/template/ts-react-rollup/rollup.config.cjs
+++ b/packages/create-stylable-app/template/ts-react-rollup/rollup.config.cjs
@@ -29,7 +29,7 @@ module.exports = {
     commonjs(),
     html({}),
     rollupTypescript(),
-    stylableRollupPlugin({ optimization: { minify: isProductionMode } }),
+    stylableRollupPlugin({ stcConfig: true, optimization: { minify: isProductionMode } }),
     copy({
       targets: [{ src: 'favicon.ico', dest: 'dist' }],
     }),

--- a/packages/create-stylable-app/template/ts-react-rollup/stylable.config.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/stylable.config.js
@@ -1,0 +1,11 @@
+//@ts-check
+const { typedConfiguration } = require('@stylable/cli');
+
+exports.stcConfig = typedConfiguration({
+    options: {
+        srcDir: './src',
+        outDir: './st-types',
+        dts: true,
+        cjs: false,
+    },
+});

--- a/packages/create-stylable-app/template/ts-react-rollup/template.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/template.js
@@ -1,3 +1,4 @@
+//@ts-check
 /** @type {import('create-stylable-app').TemplateDefinition} */
 module.exports = {
     dependencies: ['react', 'react-dom'],
@@ -9,6 +10,7 @@ module.exports = {
         '@rollup/plugin-replace',
         '@rollup/plugin-typescript',
         '@stylable/core',
+        '@stylable/cli',
         '@stylable/rollup-plugin',
         '@stylable/runtime',
         '@types/react',
@@ -42,4 +44,5 @@ module.exports = {
             test: 'npm run typecheck && npm run lint',
         },
     },
+    postinstall: [['npm', 'run', 'build']],
 };

--- a/packages/create-stylable-app/template/ts-react-rollup/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-rollup/tsconfig.json
@@ -47,7 +47,7 @@
     "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "rootDirs": ["./src", "./st-types"],            /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     "types": ["react/next", "react-dom/next"],      /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */

--- a/packages/create-stylable-app/template/ts-react-rollup/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-rollup/typings/globals.d.ts
@@ -1,10 +1,3 @@
-declare module '*.st.css' {
-    export * from '@stylable/runtime/stylesheet';
-
-    const defaultExport: unknown;
-    export default defaultExport;
-}
-
 declare module '*.png' {
     const urlToFile: string;
     export default urlToFile;

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/README.md
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/README.md
@@ -14,7 +14,7 @@ The following scripts are available:
 
 `npm run clean` - Delete the `dist` folder. Uses [rimraf](https://github.com/isaacs/rimraf).
 
-`npm run typecheck` - Verify syntactic/semantic correctness. Uses [typescript](https://github.com/microsoft/TypeScript).
+`npm run typecheck` - Verify syntactic/semantic correctness. Uses [typescript](https://github.com/microsoft/TypeScript). To read more about Stylable integration with typescript check out [our documentation](https://stylable.io/docs/getting-started/typescript-integration).
 
 `npm run lint` - Verify best practices and find common issues. Uses [eslint](https://github.com/eslint/eslint).
 

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/stylable.config.js
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/stylable.config.js
@@ -1,0 +1,11 @@
+//@ts-check
+const { typedConfiguration } = require('@stylable/cli');
+
+exports.stcConfig = typedConfiguration({
+    options: {
+        srcDir: './src',
+        outDir: './st-types',
+        dts: true,
+        cjs: false,
+    },
+});

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/template.js
@@ -1,8 +1,10 @@
+//@ts-check
 /** @type {import('create-stylable-app').TemplateDefinition} */
 module.exports = {
     dependencies: ['react', 'react-dom'],
     devDependencies: [
         '@stylable/core',
+        '@stylable/cli',
         '@stylable/runtime',
         '@stylable/webpack-plugin',
         '@types/react',
@@ -38,4 +40,5 @@ module.exports = {
             test: 'npm run typecheck && npm run lint',
         },
     },
+    postinstall: [['npm', 'run', 'build']],
 };

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/tsconfig.json
@@ -47,7 +47,7 @@
     "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "rootDirs": ["./src", "./st-types"],            /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     "types": ["react/next", "react-dom/next"],      /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/typings/globals.d.ts
@@ -1,10 +1,3 @@
-declare module '*.st.css' {
-    export * from '@stylable/runtime/stylesheet';
-
-    const defaultExport: unknown;
-    export default defaultExport;
-}
-
 declare module '*.png' {
     const urlToFile: string;
     export default urlToFile;

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/webpack.config.js
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/webpack.config.js
@@ -23,6 +23,9 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.json'],
     },
-    plugins: [new StylableWebpackPlugin(), new HtmlWebpackPlugin({ title: 'Stylable App' })],
+    plugins: [
+        new StylableWebpackPlugin({ stcConfig: true }),
+        new HtmlWebpackPlugin({ title: 'Stylable App' }),
+    ],
     cache: { type: 'filesystem' },
 };

--- a/packages/create-stylable-app/template/ts-react-webpack/README.md
+++ b/packages/create-stylable-app/template/ts-react-webpack/README.md
@@ -14,7 +14,7 @@ The following scripts are available:
 
 `npm run clean` - Delete the `dist` folder. Uses [rimraf](https://github.com/isaacs/rimraf).
 
-`npm run typecheck` - Verify syntactic/semantic correctness. Uses [typescript](https://github.com/microsoft/TypeScript).
+`npm run typecheck` - Verify syntactic/semantic correctness. Uses [typescript](https://github.com/microsoft/TypeScript). To read more about Stylable integration with typescript check out [our documentation](https://stylable.io/docs/getting-started/typescript-integration).
 
 `npm run lint` - Verify best practices and find common issues. Uses [eslint](https://github.com/eslint/eslint).
 

--- a/packages/create-stylable-app/template/ts-react-webpack/stylable.config.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/stylable.config.js
@@ -1,0 +1,11 @@
+//@ts-check
+const { typedConfiguration } = require('@stylable/cli');
+
+exports.stcConfig = typedConfiguration({
+    options: {
+        srcDir: './src',
+        outDir: './st-types',
+        dts: true,
+        cjs: false,
+    },
+});

--- a/packages/create-stylable-app/template/ts-react-webpack/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/template.js
@@ -1,8 +1,10 @@
+//@ts-check
 /** @type {import('create-stylable-app').TemplateDefinition} */
 module.exports = {
     dependencies: ['react', 'react-dom'],
     devDependencies: [
         '@stylable/core',
+        '@stylable/cli',
         '@stylable/runtime',
         '@stylable/webpack-plugin',
         '@types/react',
@@ -38,4 +40,5 @@ module.exports = {
             test: 'npm run typecheck && npm run lint',
         },
     },
+    postinstall: [['npm', 'run', 'build']],
 };

--- a/packages/create-stylable-app/template/ts-react-webpack/tsconfig.json
+++ b/packages/create-stylable-app/template/ts-react-webpack/tsconfig.json
@@ -47,7 +47,7 @@
     "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "rootDirs": ["./src", "./st-types"],            /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     "types": ["react/next", "react-dom/next"],      /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */

--- a/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
+++ b/packages/create-stylable-app/template/ts-react-webpack/typings/globals.d.ts
@@ -1,10 +1,3 @@
-declare module '*.st.css' {
-    export * from '@stylable/runtime/stylesheet';
-
-    const defaultExport: unknown;
-    export default defaultExport;
-}
-
 declare module '*.png' {
     const urlToFile: string;
     export default urlToFile;

--- a/packages/create-stylable-app/template/ts-react-webpack/webpack.config.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/webpack.config.js
@@ -23,6 +23,9 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.json'],
     },
-    plugins: [new StylableWebpackPlugin(), new HtmlWebpackPlugin({ title: 'Stylable App' })],
+    plugins: [
+        new StylableWebpackPlugin({ stcConfig: true }),
+        new HtmlWebpackPlugin({ title: 'Stylable App' }),
+    ],
     cache: { type: 'filesystem' },
 };

--- a/packages/create-stylable-app/typings/template.d.ts
+++ b/packages/create-stylable-app/typings/template.d.ts
@@ -1,0 +1,6 @@
+declare module '*.st.css' {
+    export * from '@stylable/runtime/stylesheet';
+
+    const defaultExport: unknown;
+    export default defaultExport;
+}


### PR DESCRIPTION
After we introduced the option you use `stc` in our integration https://github.com/wix/stylable/pull/2342, this PR adds this ability to our templates.
We can now generate Stylable stylesheets declaration files to give the users a strong typed experience when using Stylable and Typescript together seamlessly.

> This process requires the users to "run" their integration while developing.

- [x] Add documentation to `stylable.io` https://github.com/wixplosives/stylable.io/pull/35