### PR TITLE
feat(cli): generate index file with other outputs; `IndexGenerator` refactor

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,7 +85,7 @@ export interface BuildOptions {
     outDir: string;
     /** should the build need to output manifest file */
     manifest?: string;
-    /** Generates Stylable index file for the given name, the exported sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
+    /** generates Stylable index file for the given name, the index file will reference Stylable sources from the `srcDir` unless the `outputSources` option is `true` in which case it will reference the `outDir` */
     indexFile?: string;
     /** custom cli index generator class */
     IndexGenerator?: typeof IndexGenerator;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,7 +85,7 @@ export interface BuildOptions {
     outDir: string;
     /** should the build need to output manifest file */
     manifest?: string;
-    /** opt into build index file and specify the filepath for the generated index file */
+    /** Generates Stylable index file for the given name, the exports sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
     indexFile?: string;
     /** custom cli index generator class */
     IndexGenerator?: typeof IndexGenerator;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,7 +85,7 @@ export interface BuildOptions {
     outDir: string;
     /** should the build need to output manifest file */
     manifest?: string;
-    /** Generates Stylable index file for the given name, the exports sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
+    /** Generates Stylable index file for the given name, the exported sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
     indexFile?: string;
     /** custom cli index generator class */
     IndexGenerator?: typeof IndexGenerator;

--- a/packages/cli/src/base-generator.ts
+++ b/packages/cli/src/base-generator.ts
@@ -1,11 +1,11 @@
+import { nodeFs } from '@file-services/node';
 import type { IFileSystem } from '@file-services/types';
 import type { Stylable } from '@stylable/core';
 import { STSymbol } from '@stylable/core/dist/features';
 import camelcase from 'lodash.camelcase';
 import upperfirst from 'lodash.upperfirst';
-import { basename, relative } from 'path';
 import { normalizeRelative, ensureDirectory, tryRun } from './build-tools';
-import type { Log } from './logger';
+import { createDefaultLogger, Log } from './logger';
 
 export interface ReExports {
     root: string;
@@ -15,11 +15,29 @@ export interface ReExports {
     stVars: Record<string, string>;
 }
 
+export interface IndexGeneratorParameters {
+    indexFileTargetPath: string;
+    stylable: Stylable;
+    log?: Log;
+    fs?: Pick<IFileSystem, 'dirname' | 'relative' | 'basename'>;
+}
+
 export class IndexGenerator {
     private indexFileOutput = new Map<string, ReExports>();
     private collisionDetector = new NameCollisionDetector<string>();
+    private log: Log;
 
-    constructor(public stylable: Stylable, private log: Log) {}
+    public indexFileTargetPath: string;
+    public stylable: Stylable;
+    public fs: NonNullable<IndexGeneratorParameters['fs']>;
+
+    constructor({ log, stylable, indexFileTargetPath, fs }: IndexGeneratorParameters) {
+        this.stylable = stylable;
+        this.indexFileTargetPath = indexFileTargetPath;
+
+        this.log = log ?? createDefaultLogger();
+        this.fs = fs ?? nodeFs;
+    }
 
     public generateReExports(filePath: string): ReExports | undefined {
         return {
@@ -31,38 +49,46 @@ export class IndexGenerator {
         };
     }
 
-    public generateFileIndexEntry(filePath: string, fullOutDir: string) {
+    public generateFileIndexEntry(filePath: string) {
         const reExports = this.generateReExports(filePath);
         if (reExports) {
             this.checkForCollisions(reExports, filePath);
             this.log('[Generator Index]', `Add file: ${filePath}`);
-            this.indexFileOutput.set(normalizeRelative(relative(fullOutDir, filePath)), reExports);
+            this.indexFileOutput.set(
+                normalizeRelative(
+                    this.fs.relative(this.fs.dirname(this.indexFileTargetPath), filePath)
+                ),
+                reExports
+            );
         }
     }
 
-    public removeEntryFromIndex(filePath: string, fullOutDir: string) {
-        this.indexFileOutput.delete(normalizeRelative(relative(fullOutDir, filePath)));
+    public removeEntryFromIndex(filePath: string) {
+        this.indexFileOutput.delete(
+            normalizeRelative(this.fs.relative(this.fs.dirname(this.indexFileTargetPath), filePath))
+        );
     }
 
-    public async generateIndexFile(fs: IFileSystem, indexFileTargetPath: string) {
-        const indexFileContent = this.generateIndexSource(indexFileTargetPath);
-        ensureDirectory(fs.dirname(indexFileTargetPath), fs);
+    public async generateIndexFile(fs: IFileSystem) {
+        const indexFileContent = this.generateIndexSource();
+        ensureDirectory(fs.dirname(this.indexFileTargetPath), fs);
 
         await tryRun(
-            () => fs.promises.writeFile(indexFileTargetPath, '\n' + indexFileContent + '\n'),
+            () => fs.promises.writeFile(this.indexFileTargetPath, '\n' + indexFileContent + '\n'),
             'Write Index File Error'
         );
 
-        this.log('[Generator Index]', 'creating index file: ' + indexFileTargetPath);
+        this.log('[Generator Index]', 'creating index file: ' + this.indexFileTargetPath);
     }
 
     public filename2varname(filePath: string) {
-        const varname = basename(basename(filePath, '.css'), '.st') // remove prefixes and .st.css ext
+        const varname = this.fs
+            .basename(this.fs.basename(filePath, '.css'), '.st') // remove prefixes and .st.css ext
             .replace(/^\d+/, ''); // remove leading numbers
         return upperfirst(camelcase(varname));
     }
 
-    protected generateIndexSource(_indexFileTargetPath: string) {
+    protected generateIndexSource() {
         return [...this.indexFileOutput.entries()]
             .map(([from, reExports]) => createImportForComponent(from, reExports))
             .join('\n');

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -11,13 +11,14 @@ import type { Log } from './logger';
 import { DiagnosticsManager, DiagnosticsMode } from './diagnostics-manager';
 import type { Diagnostic } from './report-diagnostics';
 import { errorMessages } from './messages';
+import type { IFileSystem } from '@file-services/types';
 
 export interface BuildCommonOptions {
     fullOutDir: string;
     filePath: string;
     fullSrcDir: string;
     log: Log;
-    fs: any;
+    fs: IFileSystem;
     moduleFormats: string[];
     outputCSS?: boolean;
     outputCSSNameTemplate?: string;
@@ -68,7 +69,7 @@ export function buildSingleFile({
     diagnosticsManager = new DiagnosticsManager({ log }),
 }: BuildFileOptions) {
     const { basename, dirname, join, relative, resolve, isAbsolute } = fs;
-    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath)) as string;
+    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath));
     const outPath = targetFilePath + '.js';
     const fileDirectory = dirname(filePath);
     const outDirPath = dirname(outPath);
@@ -233,7 +234,7 @@ export function removeBuildProducts({
     dtsSourceMap,
 }: BuildCommonOptions) {
     const { basename, dirname, join, relative } = fs;
-    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath)) as string;
+    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath));
     const cssAssetFilename = nameTemplate(outputCSSNameTemplate, {
         filename: basename(targetFilePath, '.st.css'),
     });

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -68,7 +68,7 @@ export function buildSingleFile({
     diagnosticsManager = new DiagnosticsManager({ log }),
 }: BuildFileOptions) {
     const { basename, dirname, join, relative, resolve, isAbsolute } = fs;
-    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath));
+    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath)) as string;
     const outPath = targetFilePath + '.js';
     const fileDirectory = dirname(filePath);
     const outDirPath = dirname(outPath);
@@ -211,6 +211,10 @@ export function buildSingleFile({
             projectAssets.add(resolve(fileDirectory, url));
         }
     }
+
+    return {
+        targetFilePath,
+    };
 }
 
 export function removeBuildProducts({
@@ -229,7 +233,7 @@ export function removeBuildProducts({
     dtsSourceMap,
 }: BuildCommonOptions) {
     const { basename, dirname, join, relative } = fs;
-    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath));
+    const targetFilePath = join(fullOutDir, relative(fullSrcDir, filePath)) as string;
     const cssAssetFilename = nameTemplate(outputCSSNameTemplate, {
         filename: basename(targetFilePath, '.st.css'),
     });
@@ -275,6 +279,10 @@ export function removeBuildProducts({
     }
 
     log(mode, `removed: [${outputLogs.join(', ')}]`);
+
+    return {
+        targetFilePath,
+    };
 }
 
 export function getAllDiagnostics(res: StylableResults): Diagnostic[] {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -132,10 +132,12 @@ export async function build(
                             dtsSourceMap,
                         });
 
-                        generator.removeEntryFromIndex(
-                            outputSources ? targetFilePath : deletedFile,
-                            fullOutDir
-                        );
+                        if (indexFile) {
+                            generator.removeEntryFromIndex(
+                                outputSources ? targetFilePath : deletedFile,
+                                fullOutDir
+                            );
+                        }
                     }
                 }
             }
@@ -233,10 +235,12 @@ export async function build(
                     generated,
                 });
 
-                generator.generateFileIndexEntry(
-                    outputSources ? targetFilePath : filePath,
-                    fullOutDir
-                );
+                if (indexFile) {
+                    generator.generateFileIndexEntry(
+                        outputSources ? targetFilePath : filePath,
+                        fullOutDir
+                    );
+                }
             } catch (error) {
                 setFileErrorDiagnostic(filePath, error);
             }

--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -103,7 +103,7 @@ export function getCliArguments(): Arguments<CliArguments> {
         .option('indexFile', {
             type: 'string',
             description:
-                'filename of the generated index, the exports sources will be Stylable files from the `srcDir` unless the `--stcss` option is set then it will be the generated Stylable files from the `outDir`',
+                'filename of the generated index, the exported sources will be Stylable files from the `srcDir` unless the `--stcss` option is set then it will be the generated Stylable files from the `outDir`',
             defaultDescription: String(defaults.indexFile),
         })
         .option('manifest', {

--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -103,7 +103,7 @@ export function getCliArguments(): Arguments<CliArguments> {
         .option('indexFile', {
             type: 'string',
             description:
-                'filename of the generated index, the exported sources will be Stylable files from the `srcDir` unless the `--stcss` option is set then it will be the generated Stylable files from the `outDir`',
+                'filename of the generated index, the index file will reference Stylable sources from the `srcDir` unless the `outputSources` option is `true` in which case it will reference the `outDir`',
             defaultDescription: String(defaults.indexFile),
         })
         .option('manifest', {

--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -102,7 +102,8 @@ export function getCliArguments(): Arguments<CliArguments> {
         })
         .option('indexFile', {
             type: 'string',
-            description: 'filename of the generated index',
+            description:
+                'filename of the generated index, the exports sources will be Stylable files from the `srcDir` unless the `--stcss` option is set then it will be the generated Stylable files from the `outDir`',
             defaultDescription: String(defaults.indexFile),
         })
         .option('manifest', {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ export { build } from './build';
 export { Log, createLogger } from './logger';
 export {
     IndexGenerator,
-    IndexGenerator as Generator,
+    IndexGeneratorParameters,
     ReExports,
     reExportsAllSymbols,
 } from './base-generator';

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -117,7 +117,7 @@ export interface BuildOptions {
     outDir: string;
     /** should the build need to output manifest file */
     manifest?: string;
-    /** Generates Stylable index file for the given name, the exported sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
+    /** generates Stylable index file for the given name, the index file will reference Stylable sources from the `srcDir` unless the `outputSources` option is `true` in which case it will reference the `outDir` */
     indexFile?: string;
     /** custom cli index generator class */
     IndexGenerator?: typeof IndexGenerator;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -117,7 +117,7 @@ export interface BuildOptions {
     outDir: string;
     /** should the build need to output manifest file */
     manifest?: string;
-    /** opt into build index file and specify the filepath for the generated index file */
+    /** Generates Stylable index file for the given name, the exports sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
     indexFile?: string;
     /** custom cli index generator class */
     IndexGenerator?: typeof IndexGenerator;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -117,7 +117,7 @@ export interface BuildOptions {
     outDir: string;
     /** should the build need to output manifest file */
     manifest?: string;
-    /** Generates Stylable index file for the given name, the exports sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
+    /** Generates Stylable index file for the given name, the exported sources will be Stylable files from the `srcDir` unless the `outputSources` option is `true` then it will be the generated Stylable files from the `outDir` */
     indexFile?: string;
     /** custom cli index generator class */
     IndexGenerator?: typeof IndexGenerator;

--- a/packages/cli/test/fixtures/named-exports-generator.ts
+++ b/packages/cli/test/fixtures/named-exports-generator.ts
@@ -1,11 +1,11 @@
-import { Generator as Base, ReExports, reExportsAllSymbols } from '@stylable/cli';
+import { IndexGenerator, ReExports, reExportsAllSymbols } from '@stylable/cli';
 
-export class Generator extends Base {
+export class Generator extends IndexGenerator {
     public generateReExports(filePath: string): ReExports {
         return reExportsAllSymbols(filePath, this);
     }
-    protected generateIndexSource(indexFileTargetPath: string) {
-        const source = super.generateIndexSource(indexFileTargetPath);
+    protected generateIndexSource() {
+        const source = super.generateIndexSource();
         return '@namespace "INDEX";\n' + source;
     }
 }

--- a/packages/cli/test/fixtures/test-generator.ts
+++ b/packages/cli/test/fixtures/test-generator.ts
@@ -1,6 +1,6 @@
-import { Generator as Base, ReExports } from '@stylable/cli';
+import { IndexGenerator, ReExports } from '@stylable/cli';
 
-export class Generator extends Base {
+export class Generator extends IndexGenerator {
     private count = 0;
     public generateReExports(filePath: string): ReExports | undefined {
         if (filePath.includes('FILTER-ME')) {

--- a/packages/cli/test/generate-index.spec.ts
+++ b/packages/cli/test/generate-index.spec.ts
@@ -96,6 +96,52 @@ describe('build index', () => {
             ].join('\n')
         );
     });
+
+    it('should create index file importing all matched stylesheets in srcDir when has output cjs files', async () => {
+        const fs = createMemoryFs({
+            src: {
+                '/compA.st.css': `
+                .a{}
+                `,
+                '/a/b/comp-B.st.css': `
+                .b{}
+                `,
+            },
+        });
+
+        const stylable = new Stylable({
+            projectRoot: '/',
+            fileSystem: fs,
+            requireModule: () => ({}),
+        });
+
+        await build(
+            {
+                outDir: '.',
+                srcDir: '.',
+                indexFile: './dist/index.st.css',
+                cjs: true,
+            },
+            {
+                fs,
+                stylable,
+                rootDir: '/',
+                projectRoot: '/',
+                log,
+            }
+        );
+
+        const res = fs.readFileSync('/dist/index.st.css').toString();
+
+        expect(res.trim()).to.equal(
+            [
+                ':import {-st-from: "../src/compA.st.css";-st-default:CompA;}',
+                '.root CompA{}',
+                ':import {-st-from: "../src/a/b/comp-B.st.css";-st-default:CompB;}',
+                '.root CompB{}',
+            ].join('\n')
+        );
+    });
     it('should create index file using a the default generator', async () => {
         const fs = createMemoryFs({
             '/comp-A.st.css': `

--- a/packages/cli/test/generate-index.spec.ts
+++ b/packages/cli/test/generate-index.spec.ts
@@ -51,6 +51,51 @@ describe('build index', () => {
             ].join('\n')
         );
     });
+    it.only('should create index file importing all matched stylesheets in outDir (outputSources)', async () => {
+        const fs = createMemoryFs({
+            src: {
+                '/compA.st.css': `
+               .a{}
+            `,
+                '/a/b/comp-B.st.css': `
+               .b{}
+            `,
+            },
+        });
+
+        const stylable = new Stylable({
+            projectRoot: '/',
+            fileSystem: fs,
+            requireModule: () => ({}),
+        });
+
+        await build(
+            {
+                outDir: './dist',
+                srcDir: './src',
+                indexFile: 'index.st.css',
+                outputSources: true,
+            },
+            {
+                fs,
+                stylable,
+                rootDir: '/',
+                projectRoot: '/',
+                log,
+            }
+        );
+
+        const res = fs.readFileSync('./dist/index.st.css').toString();
+
+        expect(res.trim()).to.equal(
+            [
+                ':import {-st-from: "./compA.st.css";-st-default:CompA;}',
+                '.root CompA{}',
+                ':import {-st-from: "./a/b/comp-B.st.css";-st-default:CompB;}',
+                '.root CompB{}',
+            ].join('\n')
+        );
+    });
     it('should create index file using a the default generator', async () => {
         const fs = createMemoryFs({
             '/comp-A.st.css': `
@@ -136,7 +181,6 @@ describe('build index', () => {
             ].join('\n')
         );
     });
-
     it('should create index file when srcDir is parent directory of outDir', async () => {
         const fs = createMemoryFs({
             dist: {
@@ -183,7 +227,6 @@ describe('build index', () => {
             ].join('\n')
         );
     });
-
     it('custom generator is able to filter files from the index', async () => {
         const fs = createMemoryFs({
             '/comp-A.st.css': `
@@ -222,7 +265,6 @@ describe('build index', () => {
             ':import {-st-from: "./comp-A.st.css";-st-default:Style0;}\n.root Style0{}'
         );
     });
-
     it('should create index file using a custom generator with named exports generation and @namespace', async () => {
         const fs = createMemoryFs({
             '/comp-A.st.css': `
@@ -275,7 +317,6 @@ describe('build index', () => {
             ].join('\n')
         );
     });
-
     it('should create non-existing folders in path to the generated indexFile', async () => {
         const fs = createMemoryFs({
             '/comp.st.css': `

--- a/packages/cli/test/generate-index.spec.ts
+++ b/packages/cli/test/generate-index.spec.ts
@@ -51,7 +51,7 @@ describe('build index', () => {
             ].join('\n')
         );
     });
-    it.only('should create index file importing all matched stylesheets in outDir (outputSources)', async () => {
+    it('should create index file importing all matched stylesheets in outDir (outputSources)', async () => {
         const fs = createMemoryFs({
             src: {
                 '/compA.st.css': `


### PR DESCRIPTION
# Changes

* It's possible to create an index file with additional output file formats.
* The index file will target the output st.css if it exists.
* `Base` symbol removed from the CLI index file.
* `IndexGenerator` API parameters changes.

closes #2470