### PR TITLE
fix: collect `meta.mixins` only during analyze

### DIFF
--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -146,7 +146,7 @@ function collectDeclMixins(
     context: FeatureContext,
     decl: postcss.Declaration,
     paramSignature: (mixinSymbolName: string) => 'named' | 'args',
-    emitStrategyDiagnostics: boolean,
+    isTransformPhase: boolean,
     previousMixins?: RefedMixin[]
 ): RefedMixin[] {
     const { meta } = context;
@@ -161,7 +161,7 @@ function collectDeclMixins(
         return previousMixins || mixins;
     }
 
-    parser(decl, paramSignature, context.diagnostics, emitStrategyDiagnostics).forEach((mixin) => {
+    parser(decl, paramSignature, context.diagnostics, isTransformPhase).forEach((mixin) => {
         const mixinRefSymbol = STSymbol.get(meta, mixin.type);
         if (
             mixinRefSymbol &&
@@ -183,7 +183,9 @@ function collectDeclMixins(
                 ref: mixinRefSymbol,
             };
             mixins.push(refedMixin);
-            ignoreDeprecationWarn(() => meta.mixins).push(refedMixin);
+            if (!isTransformPhase) {
+                ignoreDeprecationWarn(() => meta.mixins).push(refedMixin);
+            }
         } else {
             context.diagnostics.warn(decl, diagnostics.UNKNOWN_MIXIN(mixin.type), {
                 word: mixin.type,

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -1952,4 +1952,23 @@ describe(`features/st-mixin`, () => {
             });
         });
     });
+    describe(`regressions`, () => {
+        it(`should not change meta.mixins during transform`, () => {
+            // ToDo: remove in v5 (no meta.mixins)
+            const { stylable, sheets } = testStylableCore(
+                `
+                .root { -st-mixin: mix; }
+                .mix { color: green }
+            `
+            );
+            const { meta } = sheets['/entry.st.css'];
+
+            stylable.transform(meta);
+            const mixins1 = [...meta.mixins];
+            stylable.transform(meta);
+            const mixins2 = [...meta.mixins];
+
+            expect(mixins1).to.eql(mixins2);
+        });
+    });
 });


### PR DESCRIPTION
This PR fixes a regression that was introduced in the mixins analyze data. The `meta.mixins`, originally holds the list of all mixins in a stylesheet, was wrongfully pushed more definitions during the transform phase.

Notice that `meta.mixins` is deprecated and will be removed soon in `v5`