### PR TITLE
chore(core): st-state with value interpolation intentions  

### DIFF
--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -29,18 +29,8 @@ export const hooks = createFeature<{
     SELECTOR: Type;
     IMMUTABLE_SELECTOR: ImmutableType;
 }>({
-    analyzeSelectorNode({ context, node, rule, walkContext: [_index, _nodes, parents] }): void {
-        /**
-         * intent to deprecate: currently `value(param)` can be used
-         * as a custom state value. Unless there is a reasonable
-         * use case, this should be removed.
-         */
-        if (
-            node.nodes &&
-            (parents.length < 2 ||
-                parents[parents.length - 2].type !== `pseudo_class` ||
-                node.value !== `value`)
-        ) {
+    analyzeSelectorNode({ context, node, rule, walkContext: [_index, _nodes] }): void {
+        if (node.nodes) {
             // error on functional type
             context.diagnostics.error(
                 rule,


### PR DESCRIPTION
This PR clarifies some intentions related to analyzing value interpolation into a custom pseudo class:

 - **chore**: remove unrequired code that relates to an exception for unsupported functional type selector (e.g. `div()`) - The code is no longer required as nested selectors of custom pseudo-classes are not processed deeply (e.g. `:myState(value(myVar))`).
 - **test**: add tests to indicate future intentions relating to mixins ability to template `st-var` definition & call.

for example:
```css
:vars {
  myVar: b;
  overrideVar: c;
}

.mix {
  -st-states: x(enum(a, value(myVar)));
}
.mix:x(value(myVar)) {}

/* rule[1] .entry__into.entry---x-1-c*/
.into {
  -st-mixin: mix(myVar (overrideVar))
}
```