### PR TITLE
refactor(core): prepare process AST mods for move to transform

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -204,7 +204,7 @@ export function validateClassScoping({
     context,
     classSymbol,
     locallyScoped,
-    inStScope,
+    reportUnscoped,
     node,
     nodes,
     index,
@@ -213,7 +213,7 @@ export function validateClassScoping({
     context: FeatureContext;
     classSymbol: ClassSymbol;
     locallyScoped: boolean;
-    inStScope: boolean;
+    reportUnscoped: boolean;
     node: ImmutableClass;
     nodes: ImmutableSelectorNode[];
     index: number;
@@ -221,11 +221,13 @@ export function validateClassScoping({
 }): boolean {
     if (!classSymbol.alias) {
         return true;
-    } else if (locallyScoped === false && !inStScope) {
+    } else if (locallyScoped === false) {
         if (checkForScopedNodeAfter(context, rule, nodes, index) === false) {
-            context.diagnostics.warn(rule, diagnostics.UNSCOPED_CLASS(node.value), {
-                word: node.value,
-            });
+            if (reportUnscoped) {
+                context.diagnostics.warn(rule, diagnostics.UNSCOPED_CLASS(node.value), {
+                    word: node.value,
+                });
+            }
             return false;
         } else {
             return true;

--- a/packages/core/src/features/css-custom-property.ts
+++ b/packages/core/src/features/css-custom-property.ts
@@ -81,7 +81,7 @@ export const hooks = createFeature<{
             }
         }
     },
-    analyzeAtRule({ context, atRule, toRemove }) {
+    analyzeAtRule({ context, atRule }) {
         if (atRule.name === `property`) {
             let name = atRule.params;
             let global = false;
@@ -105,7 +105,6 @@ export const hooks = createFeature<{
             validateAtProperty(atRule, context.diagnostics);
         } else if (atRule.name === `st-global-custom-property`) {
             analyzeDeprecatedStGlobalCustomProperty(context, atRule);
-            toRemove.push(atRule); // ToDo: move to transform
         }
     },
     analyzeDeclaration({ context, decl }) {
@@ -122,6 +121,11 @@ export const hooks = createFeature<{
         // register value
         if (decl.value.includes('var(')) {
             analyzeDeclValueVarCalls(context, decl);
+        }
+    },
+    prepareAST({ node, toRemove }) {
+        if (node.type === `atrule` && node.name === 'st-global-custom-property') {
+            toRemove.push(node);
         }
     },
     transformResolve({ context: { meta, getResolvedSymbols } }) {

--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -110,7 +110,7 @@ export function addType(context: FeatureContext, name: string, rule?: postcss.Ru
 export function validateTypeScoping({
     context,
     locallyScoped,
-    inStScope,
+    reportUnscoped,
     node,
     nodes,
     index,
@@ -118,17 +118,19 @@ export function validateTypeScoping({
 }: {
     context: FeatureContext;
     locallyScoped: boolean;
-    inStScope: boolean;
+    reportUnscoped: boolean;
     node: ImmutableType;
     nodes: ImmutableSelectorNode[];
     index: number;
     rule: postcss.Rule;
 }): boolean {
-    if (locallyScoped === false && !inStScope) {
+    if (locallyScoped === false) {
         if (CSSClass.checkForScopedNodeAfter(context, rule, nodes, index) === false) {
-            context.diagnostics.warn(rule, diagnostics.UNSCOPED_TYPE_SELECTOR(node.value), {
-                word: node.value,
-            });
+            if (reportUnscoped) {
+                context.diagnostics.warn(rule, diagnostics.UNSCOPED_TYPE_SELECTOR(node.value), {
+                    word: node.value,
+                });
+            }
             return false;
         } else {
             locallyScoped = true;

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -34,11 +34,7 @@ type SelectorWalkReturn = number | undefined | void;
 export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
     metaInit: (context: FeatureContext) => void;
     analyzeInit: (context: FeatureContext) => void;
-    analyzeAtRule: (options: {
-        context: FeatureContext;
-        atRule: postcss.AtRule;
-        toRemove: postcss.AtRule[]; // ToDo: remove once rawAst is immutable in processor
-    }) => void;
+    analyzeAtRule: (options: { context: FeatureContext; atRule: postcss.AtRule }) => void;
     analyzeSelectorNode: (options: {
         context: FeatureContext;
         node: T['IMMUTABLE_SELECTOR'];

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -46,6 +46,7 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
         walkContext: SelectorNodeContext;
     }) => SelectorWalkReturn;
     analyzeDeclaration: (options: { context: FeatureContext; decl: postcss.Declaration }) => void;
+    prepareAST: (options: { node: postcss.ChildNode; toRemove: postcss.Node[] }) => void;
     transformInit: (options: { context: FeatureTransformContext }) => void;
     transformResolve: (options: { context: FeatureTransformContext }) => T['RESOLVED'];
     transformAtRuleNode: (options: {
@@ -91,6 +92,9 @@ const defaultHooks: FeatureHooks<NodeTypes> = {
         /**/
     },
     analyzeDeclaration() {
+        /**/
+    },
+    prepareAST() {
         /**/
     },
     transformInit() {

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -34,7 +34,11 @@ type SelectorWalkReturn = number | undefined | void;
 export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
     metaInit: (context: FeatureContext) => void;
     analyzeInit: (context: FeatureContext) => void;
-    analyzeAtRule: (options: { context: FeatureContext; atRule: postcss.AtRule }) => void;
+    analyzeAtRule: (options: {
+        context: FeatureContext;
+        atRule: postcss.AtRule;
+        analyzeRule: (rule: postcss.Rule, options: { isScoped: boolean }) => boolean;
+    }) => void;
     analyzeSelectorNode: (options: {
         context: FeatureContext;
         node: T['IMMUTABLE_SELECTOR'];
@@ -42,7 +46,10 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
         walkContext: SelectorNodeContext;
     }) => SelectorWalkReturn;
     analyzeDeclaration: (options: { context: FeatureContext; decl: postcss.Declaration }) => void;
-    prepareAST: (options: { node: postcss.ChildNode; toRemove: postcss.Node[] }) => void;
+    prepareAST: (options: {
+        node: postcss.ChildNode;
+        toRemove: Array<postcss.Node | (() => void)>;
+    }) => void;
     transformInit: (options: { context: FeatureTransformContext }) => void;
     transformResolve: (options: { context: FeatureTransformContext }) => T['RESOLVED'];
     transformAtRuleNode: (options: {

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -8,6 +8,8 @@ export type { ImportSymbol, Imported } from './st-import';
 
 export * as STGlobal from './st-global';
 
+export * as STScope from './st-scope';
+
 export * as STVar from './st-var';
 export type { VarSymbol, ComputedStVar, FlatComputedStVar } from './st-var';
 

--- a/packages/core/src/features/st-import.ts
+++ b/packages/core/src/features/st-import.ts
@@ -85,10 +85,7 @@ export const hooks = createFeature<{
         const dirContext = path.dirname(context.meta.source);
         // collect shallow imports
         for (const node of context.meta.ast.nodes) {
-            const isImportDef =
-                (node.type === `atrule` && node.name === `st-import`) ||
-                (node.type === `rule` && node.selector === `:import`);
-            if (!isImportDef) {
+            if (!isImportStatement(node)) {
                 continue;
             }
             const parsedImport =
@@ -109,8 +106,6 @@ export const hooks = createFeature<{
         if (atRule.parent?.type !== `root`) {
             context.diagnostics.warn(atRule, diagnostics.NO_ST_IMPORT_IN_NESTED_SCOPE());
         }
-        // remove `@st-import` at rules - ToDo: move to transformer
-        atRule.remove();
     },
     analyzeSelectorNode({ context, rule, node }) {
         if (node.value !== `import`) {
@@ -126,8 +121,11 @@ export const hooks = createFeature<{
         if (rule.parent?.type !== `root`) {
             context.diagnostics.warn(rule, diagnostics.NO_PSEUDO_IMPORT_IN_NESTED_SCOPE());
         }
-        // remove rules with `:import` selector - ToDo: move to transformer
-        rule.remove();
+    },
+    prepareAST({ node, toRemove }) {
+        if (isImportStatement(node)) {
+            toRemove.push(node);
+        }
     },
     transformInit({ context }) {
         validateImports(context);
@@ -135,6 +133,13 @@ export const hooks = createFeature<{
 });
 
 // API
+
+function isImportStatement(node: postcss.ChildNode): node is postcss.Rule | postcss.AtRule {
+    return (
+        (node.type === `atrule` && node.name === `st-import`) ||
+        (node.type === `rule` && node.selector === `:import`)
+    );
+}
 
 export function getImportStatements({ data }: StylableMeta): ReadonlyArray<Imported> {
     const state = plugableRecord.getUnsafe(data, dataKey);

--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -1,0 +1,59 @@
+import { createFeature } from './feature';
+import { parseSelectorWithCache, scopeNestedSelector } from '../helpers/selector';
+import type { ImmutablePseudoClass } from '@tokey/css-selector-parser';
+import * as postcss from 'postcss';
+import type { SRule } from '../deprecated/postcss-ast-extension';
+
+export const diagnostics = {
+    MISSING_SCOPING_PARAM() {
+        return '"@st-scope" missing scoping selector parameter';
+    },
+};
+
+// HOOKS
+
+export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutablePseudoClass }>({
+    analyzeAtRule({ context, atRule, analyzeRule }) {
+        if (!isStScopeStatement(atRule)) {
+            return;
+        }
+        if (!atRule.params) {
+            context.diagnostics.warn(atRule, diagnostics.MISSING_SCOPING_PARAM());
+        }
+        analyzeRule(
+            postcss.rule({
+                selector: atRule.params,
+                source: atRule.source,
+            }),
+            {
+                isScoped: true,
+            }
+        );
+        context.meta.scopes.push(atRule);
+    },
+    prepareAST({ node, toRemove }) {
+        if (isStScopeStatement(node)) {
+            flattenScope(node);
+            toRemove.push(() => node.replaceWith(node.nodes || []));
+        }
+    },
+});
+
+// API
+
+function isStScopeStatement(node: postcss.ChildNode): node is postcss.AtRule {
+    return node.type === 'atrule' && node.name === 'st-scope';
+}
+
+function flattenScope(atRule: postcss.AtRule) {
+    const scopeSelector = atRule.params;
+    if (scopeSelector) {
+        atRule.walkRules((rule) => {
+            rule.selector = scopeNestedSelector(
+                parseSelectorWithCache(scopeSelector),
+                parseSelectorWithCache(rule.selector)
+            ).selector;
+            (rule as SRule).stScopeSelector = atRule.params;
+        });
+    }
+}

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -85,13 +85,17 @@ export const hooks = createFeature<{
             } else {
                 collectVarSymbols(context, rule);
             }
-            rule.remove();
             // stop further walk into `:vars {}`
             return walkSelector.stopAll;
         } else {
             context.diagnostics.warn(rule, diagnostics.FORBIDDEN_DEF_IN_COMPLEX_SELECTOR(`:vars`));
         }
         return;
+    },
+    prepareAST({ node, toRemove }) {
+        if (node.type === 'rule' && node.selector === ':vars') {
+            toRemove.push(node);
+        }
     },
     transformResolve({ context }) {
         // Resolve local vars

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -17,7 +17,7 @@ import { ignoreDeprecationWarn } from './deprecation';
 import type { SRule } from '../deprecated/postcss-ast-extension';
 
 export function isChildOfAtRule(rule: postcss.Container, atRuleName: string) {
-    return (
+    return !!(
         rule.parent &&
         rule.parent.type === 'atrule' &&
         (rule.parent as postcss.AtRule).name === atRuleName

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -63,6 +63,7 @@ export class StylableMeta {
     public mappedSymbols: Record<string, StylableSymbol> = {};
     /** @deprecated */
     public mappedKeyframes: Record<string, KeyframesSymbol> = {};
+    /** @deprecated */
     public customSelectors: Record<string, string> = {};
     public urls: string[] = [];
     public transformDiagnostics: Diagnostics | null = null;

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -68,6 +68,7 @@ export class StylableMeta {
     public urls: string[] = [];
     public transformDiagnostics: Diagnostics | null = null;
     public transformedScopes: Record<string, SelectorList> | null = null;
+    /** @deprecated */
     public scopes: postcss.AtRule[] = [];
     /** @deprecated */
     public mixins: RefedMixin[] = [];

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -158,6 +158,7 @@ export class StylableProcessor implements FeatureContext {
             // extracted features
             STImport.hooks.prepareAST(input);
             STVar.hooks.prepareAST(input);
+            CSSCustomProperty.hooks.prepareAST(input);
         });
         for (const node of toRemove) {
             node.remove();
@@ -166,7 +167,6 @@ export class StylableProcessor implements FeatureContext {
 
     protected handleAtRules(root: postcss.Root) {
         let namespace = '';
-        const toRemove: postcss.AtRule[] = [];
 
         root.walkAtRules((atRule) => {
             switch (atRule.name) {
@@ -174,7 +174,6 @@ export class StylableProcessor implements FeatureContext {
                     STImport.hooks.analyzeAtRule({
                         context: this,
                         atRule,
-                        toRemove,
                     });
                     break;
                 }
@@ -186,7 +185,6 @@ export class StylableProcessor implements FeatureContext {
                         } else {
                             this.diagnostics.error(atRule, processorWarnings.EMPTY_NAMESPACE_DEF());
                         }
-                        // toRemove.push(atRule);
                     } else {
                         this.diagnostics.error(atRule, processorWarnings.INVALID_NAMESPACE_DEF());
                     }
@@ -196,7 +194,6 @@ export class StylableProcessor implements FeatureContext {
                     CSSKeyframes.hooks.analyzeAtRule({
                         context: this,
                         atRule,
-                        toRemove,
                     });
                     break;
                 case 'custom-selector': {
@@ -223,12 +220,11 @@ export class StylableProcessor implements FeatureContext {
                     break;
                 case 'property':
                 case 'st-global-custom-property': {
-                    CSSCustomProperty.hooks.analyzeAtRule({ context: this, atRule, toRemove });
+                    CSSCustomProperty.hooks.analyzeAtRule({ context: this, atRule });
                     break;
                 }
             }
         });
-        toRemove.forEach((node) => node.remove());
         namespace = namespace || filename2varname(path.basename(this.meta.source)) || 's';
         this.meta.namespace = this.handleNamespaceReference(namespace);
     }

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -709,6 +709,23 @@ describe(`features/css-custom-property`, () => {
 
             shouldReportNoDiagnostics(meta);
         });
+        it(`should NOT define property as var value (change in v5)`, () => {
+            // ToDo: in the future property should be able to be defined in var value
+            const { sheets } = testStylableCore(`
+                :vars {
+                    myVar: var(--color);
+                }
+
+                .root {
+                    /* @decl prop: var(--color) */
+                    prop: value(myVar);
+                }
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
     });
     describe(`st-formatter`, () => {
         it(`should resolve a value to be set`, () => {

--- a/packages/core/test/features/st-custom-selector.spec.ts
+++ b/packages/core/test/features/st-custom-selector.spec.ts
@@ -1,0 +1,63 @@
+import chaiSubset from 'chai-subset';
+import { CSSType } from '@stylable/core/dist/features';
+import { testStylableCore, shouldReportNoDiagnostics } from '@stylable/core-test-kit';
+import chai, { expect } from 'chai';
+
+chai.use(chaiSubset);
+
+describe('features/st-custom-selector', () => {
+    // ToDo: move and add tests when extracting feature
+    // ToDo: migrate to @st-custom-selector
+    it('should define selector symbols', () => {
+        const { sheets } = testStylableCore(`
+            /* @transform-remove */
+            @custom-selector :--node .root > .node;
+        `);
+
+        const { meta, exports } = sheets['/entry.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+
+        // JS exports
+        expect(exports.classes.node, 'JS export').to.eql('entry__node');
+    });
+    it('should expand rule selector', () => {
+        const { sheets } = testStylableCore(`
+            @custom-selector :--node .a > .b ~ .c;
+
+            /* @rule(just custom) .entry__a > .entry__b ~ .entry__c */
+            :--node {}
+
+            /* @rule(complex) .entry__x.entry__a > .entry__b ~ .entry__c.entry__y */
+            .x:--node.y {}
+        `);
+
+        const { meta } = sheets['/entry.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+    });
+    it('should report selector on atrule', () => {
+        testStylableCore(`
+            /* @analyze-error ${CSSType.diagnostics.INVALID_FUNCTIONAL_SELECTOR('div', 'type')} */
+            @custom-selector :--functional-div div();
+        `);
+    });
+    it('should validate scope on used selector (rule)', () => {
+        const { sheets } = testStylableCore(`
+            @custom-selector :--unscoped div;
+            @custom-selector :--scoped .root div;
+
+            /* @analyze-warn ${CSSType.diagnostics.UNSCOPED_TYPE_SELECTOR('span')} */
+            :--unscoped span {}
+
+            :--scoped ul {}
+        `);
+
+        const { meta } = sheets['/entry.st.css'];
+
+        expect(
+            meta.diagnostics.reports.length,
+            'only a single unscoped diagnostic for span'
+        ).to.eql(1);
+    });
+});

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -1,0 +1,27 @@
+import chaiSubset from 'chai-subset';
+import { testStylableCore, shouldReportNoDiagnostics } from '@stylable/core-test-kit';
+import chai, { expect } from 'chai';
+
+chai.use(chaiSubset);
+
+describe(`features/st-namespace`, () => {
+    // ToDo: move and add tests when extracting feature
+    it(`should override default namespace`, () => {
+        const { sheets } = testStylableCore({
+            '/other.st.css': `
+                /* @transform-remove */
+                @namespace "button";
+
+                /* @rule .button__x */
+                .x {}
+            `,
+        });
+
+        const { meta, exports } = sheets['/other.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+
+        // JS exports
+        expect(exports.classes.x, `JS export`).to.eql(`button__x`);
+    });
+});

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -7,15 +7,12 @@ import {
     processSource,
     shouldReportNoDiagnostics,
 } from '@stylable/core-test-kit';
-import {
-    processorWarnings,
-    SRule,
-    transformerWarnings,
-    getRuleScopeSelector,
-} from '@stylable/core';
+import { SRule, transformerWarnings, getRuleScopeSelector } from '@stylable/core';
+import { STScope } from '@stylable/core/dist/features';
 
 use(flatMatch);
 
+// ToDo: refactor into feature spec
 describe('@st-scope', () => {
     describe('processing scopes', () => {
         it('should parse "@st-scope" directives', () => {
@@ -569,7 +566,7 @@ describe('@st-scope', () => {
 
             const { meta } = expectTransformDiagnostics(config, [
                 {
-                    message: processorWarnings.MISSING_SCOPING_PARAM(),
+                    message: STScope.diagnostics.MISSING_SCOPING_PARAM(),
                     file: '/entry.st.css',
                     severity: 'warning',
                 },


### PR DESCRIPTION
This PR refactor the AST modifications that occur in the processor to prepare them to be moved to the transformer

- [x] `prepareAST` - new feature hook called on every node at the end of the analyze process
- modifiers
  - [x] `@namespace`
  - [x] `:vars`
  - [x] `@st-import` / `:import`
  - [x] `@st-global-custom-property`
  - [x] `@custom-selector`
  - [x] `@st-scope`