### PR TITLE
feat: add ability to pass buildNamespace function to default namespace strategy

### DIFF
--- a/packages/core/src/index-deprecated.ts
+++ b/packages/core/src/index-deprecated.ts
@@ -159,7 +159,11 @@ export {
     nativePseudoClasses,
     nativePseudoElements,
 } from './native-reserved-lists';
-export { noCollisionNamespace, packageNamespaceFactory } from './resolve-namespace-factories';
+export {
+    noCollisionNamespace,
+    packageNamespaceFactory,
+    defaultBuildNamespace,
+} from './resolve-namespace-factories';
 export { DiagnosticsMode, EmitDiagnosticsContext, emitDiagnostics } from './report-diagnostic';
 import { visitMetaCSSDependenciesBFS as deprecatedVisitMetaCSSDependenciesBFS } from './visit-meta-css-dependencies';
 /**@deprecated use Stylable.getDependencies in v5*/

--- a/packages/node/src/resolve-namespace.ts
+++ b/packages/node/src/resolve-namespace.ts
@@ -1,12 +1,21 @@
-import { packageNamespaceFactory } from '@stylable/core';
+import { packageNamespaceFactory, defaultBuildNamespace } from '@stylable/core';
 import { dirname, relative } from 'path';
 import findConfig from 'find-config';
 
 export function resolveNamespaceFactory(
     hashSalt = '',
-    prefix = ''
+    prefix = '',
+    buildNamespace = defaultBuildNamespace
 ): ReturnType<typeof packageNamespaceFactory> {
-    return packageNamespaceFactory(findConfig, require, { dirname, relative }, hashSalt, prefix);
+    return packageNamespaceFactory(
+        findConfig,
+        require,
+        { dirname, relative },
+        hashSalt,
+        prefix,
+        undefined,
+        buildNamespace
+    );
 }
 
 export const resolveNamespace: ReturnType<typeof packageNamespaceFactory> =


### PR DESCRIPTION
This PR will allow others to use our default namespace strategy with more complex namespace logic for each package
This will open the possibility to enable `module federation` and allow the federated packages to get different consistent namespace then the rest of the build