### PR TITLE
feat: implement new namespace strategy

### DIFF
--- a/packages/core/src/helpers/namespace.ts
+++ b/packages/core/src/helpers/namespace.ts
@@ -1,3 +1,129 @@
 export function namespace(name: string, namespace: string, delimiter = '__') {
     return namespace ? namespace + delimiter + name : name;
 }
+
+export interface PackageInfo {
+    name: string;
+    version: string;
+    dirPath: string;
+}
+
+export interface NamespaceBuilderOptions {
+    hashSalt: string;
+    prefix: string;
+    namespace: string;
+    paths: {
+        file: string;
+        origin: string;
+    };
+    packageInfo: PackageInfo;
+}
+
+export interface NamespaceBuilder {
+    (options: NamespaceBuilderOptions): {
+        namespace: string;
+        hashPart: string;
+    };
+}
+
+export interface CreateNamespaceOptions {
+    prefix?: string;
+    hashSalt?: string;
+    hashFragment?: 'full' | 'minimal' | number;
+    buildNamespace?: NamespaceBuilder;
+    getPackageInfo?: (filePath: string) => PackageInfo;
+    normalizePath: (dirPath: string, filePath: string) => string;
+    hashFn: (i: string) => string | number;
+}
+
+function defaultGetPackageInfo() {
+    return {
+        name: '',
+        version: '0.0.0',
+        dirPath: '',
+    };
+}
+
+export function defaultNamespaceBuilder({
+    prefix,
+    namespace,
+    hashSalt,
+    paths,
+    packageInfo,
+}: NamespaceBuilderOptions) {
+    return {
+        namespace: prefix + namespace,
+        hashPart: hashSalt + packageInfo.name + '@' + packageInfo.version + '/' + paths.origin,
+    };
+}
+
+// function defaultHash(input: string) {
+//     //Node12 compatibility - we might want to use base64Url instead
+//     return createHash('sha256').update(input).digest('hex');
+// }
+
+// function normPath(packageRoot: string, stylesheetPath: string) {
+//     return relative(packageRoot, stylesheetPath).replace(/\\/g, '/');
+// }
+
+export function createNamespaceStrategy(options: CreateNamespaceOptions) {
+    const {
+        prefix = '',
+        hashSalt = '',
+        hashFragment = 'minimal',
+        buildNamespace = defaultNamespaceBuilder,
+        getPackageInfo = defaultGetPackageInfo,
+        hashFn,
+        normalizePath,
+    } = options;
+
+    const usedNamespaces = new Map<string, string>();
+
+    return (
+        namespace: string,
+        stylesheetPath: string,
+        stylesheetOriginPath: string = stylesheetPath
+    ) => {
+        const packageInfo = getPackageInfo(stylesheetPath);
+
+        const results = buildNamespace({
+            prefix,
+            hashSalt,
+            namespace,
+            paths: {
+                file: packageInfo.dirPath
+                    ? normalizePath(packageInfo.dirPath, stylesheetPath)
+                    : stylesheetPath,
+                origin: packageInfo.dirPath
+                    ? normalizePath(packageInfo.dirPath, stylesheetOriginPath)
+                    : stylesheetOriginPath,
+            },
+            packageInfo,
+        });
+
+        const { namespace: resultNs, hashPart } = results;
+
+        const hashStr = hashFn(hashPart).toString();
+        let i =
+            typeof hashFragment === 'number'
+                ? hashFragment
+                : hashFragment === 'full'
+                ? hashStr.length
+                : 0;
+
+        while (i <= hashStr.length) {
+            const hashSlice = hashStr.slice(0, i);
+            const ns = resultNs + (hashSlice ? '-' + hashSlice : '');
+            const used = usedNamespaces.get(ns);
+            if (!used) {
+                usedNamespaces.set(ns, stylesheetPath);
+                return ns;
+            }
+            if (used === stylesheetPath) {
+                return ns;
+            }
+            i++;
+        }
+        throw new Error('Could not create namespace for ' + stylesheetPath);
+    };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,15 @@ export { parseModuleImportStatement, ensureModuleImport } from './helpers/import
 export { validateCustomPropertyName } from './helpers/css-custom-property';
 
 // namespace helpers
-export * from './helpers/namespace';
+export {
+    createNamespaceStrategy,
+    defaultNoMatchHandler,
+    defaultNamespaceBuilder,
+    CreateNamespaceOptions,
+    NamespaceBuilder,
+    NamespaceBuilderParams,
+    PackageInfo,
+} from './helpers/namespace';
 
 // deprecations
 export * from './index-deprecated';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,5 +27,8 @@ export { processNamespace } from './stylable-processor';
 export { parseModuleImportStatement, ensureModuleImport } from './helpers/import';
 export { validateCustomPropertyName } from './helpers/css-custom-property';
 
+// namespace helpers
+export * from './helpers/namespace';
+
 // deprecations
 export * from './index-deprecated';

--- a/packages/core/src/resolve-namespace-factories.ts
+++ b/packages/core/src/resolve-namespace-factories.ts
@@ -1,6 +1,7 @@
 import { murmurhash3_32_gc } from './murmurhash';
 import type { processNamespace } from './stylable-processor';
 
+/** @deprecated use createNamespaceStrategy */
 export function packageNamespaceFactory(
     findConfig: (fileName: string, options: { cwd: string }) => string | null,
     loadConfig: (filePath: string) => object,
@@ -33,6 +34,7 @@ export function packageNamespaceFactory(
     };
 }
 
+/** @deprecated use createNamespaceStrategy */
 export function noCollisionNamespace({
     prefix = '',
     used: usedNamespaces = new Map<

--- a/packages/core/src/resolve-namespace-factories.ts
+++ b/packages/core/src/resolve-namespace-factories.ts
@@ -12,13 +12,17 @@ export function packageNamespaceFactory(
     prefix = '',
     normalizeVersion = (semver: string) => semver
 ): typeof processNamespace {
-    return (namespace: string, stylesheetPath: string) => {
+    return (
+        namespace: string,
+        originStylesheetPath: string,
+        stylesheetPath: string = originStylesheetPath
+    ) => {
         const configPath = findConfig('package.json', { cwd: dirname(stylesheetPath) });
         if (!configPath) {
-            throw new Error(`Could not find package.json for ${stylesheetPath}`);
+            throw new Error(`Could not find package.json for ${originStylesheetPath}`);
         }
         const config = loadConfig(configPath) as { name: string; version: string };
-        const fromRoot = relative(dirname(configPath), stylesheetPath).replace(/\\/g, '/');
+        const fromRoot = relative(dirname(configPath), originStylesheetPath).replace(/\\/g, '/');
         return (
             prefix +
             namespace +

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -241,7 +241,8 @@ export class StylableProcessor implements FeatureContext {
             namespace,
             pathToSource
                 ? path.resolve(path.dirname(this.meta.source), pathToSource)
-                : this.meta.source
+                : this.meta.source,
+            this.meta.source
         );
     }
 
@@ -491,8 +492,8 @@ export function createEmptyMeta(root: postcss.Root, diagnostics: Diagnostics): S
     return new StylableMeta(root, diagnostics);
 }
 
-export function processNamespace(namespace: string, source: string) {
-    return namespace + murmurhash3_32_gc(source); // .toString(36);
+export function processNamespace(namespace: string, origin: string, _source?: string) {
+    return namespace + murmurhash3_32_gc(origin); // .toString(36);
 }
 
 export function process(

--- a/packages/core/test/helpers/namespace.spec.ts
+++ b/packages/core/test/helpers/namespace.spec.ts
@@ -1,0 +1,154 @@
+import { expect } from 'chai';
+import {
+    type NamespaceBuilderOptions,
+    createNamespaceStrategy,
+    defaultNamespaceBuilder,
+} from '@stylable/core/dist/helpers/namespace';
+
+describe('createNamespaceStrategy', () => {
+    it('should return smallest namespace for the same file', () => {
+        const resolveNamespace = createNamespaceStrategy({
+            hashFn: () => '1',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+    });
+    it('should return smallest namespace for the same file with prefix', () => {
+        const resolveNamespace = createNamespaceStrategy({
+            prefix: 'test-',
+            hashFn: () => '1',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('test-x');
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('test-x');
+    });
+    it('should salt the hash', () => {
+        let usedInput: string | undefined;
+        const resolveNamespace = createNamespaceStrategy({
+            hashSalt: '__SALT__',
+            hashFn: (input) => {
+                usedInput = input;
+                return '1';
+            },
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+        expect(usedInput).to.equal('__SALT__package@0.0.0//x.st.css');
+    });
+    it('should call buildNamespace hook', () => {
+        let usedOptions: NamespaceBuilderOptions | undefined;
+        const resolveNamespace = createNamespaceStrategy({
+            hashFn: () => '1',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+            buildNamespace(options) {
+                usedOptions = options;
+                return defaultNamespaceBuilder(options);
+            },
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+        expect(usedOptions).to.eql({
+            prefix: '',
+            hashSalt: '',
+            namespace: 'x',
+            paths: {
+                file: '/x.st.css',
+                origin: '/x.st.css',
+            },
+            packageInfo: {
+                name: 'package',
+                version: '0.0.0',
+                dirPath: '/package',
+            },
+        });
+    });
+    it('should add a small part of the hash for same namespace from different file', () => {
+        let nextHash = 0;
+        const resolveNamespace = createNamespaceStrategy({
+            hashFn: () => nextHash++,
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x'); // hash 0
+        expect(resolveNamespace('x', '/package/x1.st.css')).to.equal('x-1'); // hash 1
+        expect(resolveNamespace('x', '/package/x2.st.css')).to.equal('x-2'); // hash 2
+    });
+    it('should throw when no unique namespace can be generated and hash slice size is larger then hash length', () => {
+        const resolveNamespace = createNamespaceStrategy({
+            hashFn: () => '1',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+        expect(resolveNamespace('x', '/package/x1.st.css')).to.equal('x-1');
+        expect(() => {
+            resolveNamespace('x', '/package/x2.st.css');
+        }).to.throw('Could not create namespace for /package/x2.st.css');
+    });
+    it('should use minimum hash slice size', () => {
+        const resolveNamespace = createNamespaceStrategy({
+            hashFragment: 4, // min size hash slice
+            hashFn: () => '12345',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x-1234');
+        expect(resolveNamespace('x', '/package/x1.st.css')).to.equal('x-12345');
+    });
+
+    it('should use full hash', () => {
+        const resolveNamespace = createNamespaceStrategy({
+            hashFragment: 'full', // min size hash slice
+            hashFn: () => '12345',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => filePath.replace(dirPath, ''),
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x-12345');
+    });
+
+    it('should use stylesheet path when dirPath from getPackageInfo does not exists', () => {
+        let usedInput: string | undefined;
+        const resolveNamespace = createNamespaceStrategy({
+            hashFn: (input) => {
+                usedInput = input;
+                return '12345';
+            },
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '' }),
+            normalizePath: () => {
+                throw new Error('Should not be called');
+            },
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+        expect(usedInput).to.equal('package@0.0.0//package/x.st.css');
+    });
+
+    it('should use normalizePath when dirPath from getPackageInfo exists', () => {
+        let usedDirPath: string | undefined;
+        let usedFilePath: string | undefined;
+        const resolveNamespace = createNamespaceStrategy({
+            hashFn: () => '12345',
+            getPackageInfo: () => ({ name: 'package', version: '0.0.0', dirPath: '/package' }),
+            normalizePath: (dirPath, filePath) => {
+                usedDirPath = dirPath;
+                usedFilePath = filePath;
+                return filePath.replace(dirPath, '');
+            },
+        });
+
+        expect(resolveNamespace('x', '/package/x.st.css')).to.equal('x');
+        expect(usedDirPath).to.equal('/package');
+        expect(usedFilePath).to.equal('/package/x.st.css');
+    });
+});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,7 @@
 export { Options, attachHook } from './require-hook';
-export { resolveNamespace, resolveNamespaceFactory } from './resolve-namespace';
+export {
+    resolveNamespace,
+    resolveNamespaceFactory,
+    createNamespaceStrategyNode,
+} from './resolve-namespace';
 export { FileSystem, findFiles } from './find-files';

--- a/packages/node/src/resolve-namespace.ts
+++ b/packages/node/src/resolve-namespace.ts
@@ -1,5 +1,4 @@
 import {
-    murmurhash3_32_gc,
     packageNamespaceFactory,
     createNamespaceStrategy,
     CreateNamespaceOptions,
@@ -17,7 +16,6 @@ export function resolveNamespaceFactory(
 
 export function createNamespaceStrategyNode(options: Partial<CreateNamespaceOptions> = {}) {
     return createNamespaceStrategy({
-        hashFn: murmurhash3_32_gc,
         normalizePath(packageRoot: string, stylesheetPath: string) {
             return relative(packageRoot, stylesheetPath).replace(/\\/g, '/');
         },

--- a/packages/node/src/resolve-namespace.ts
+++ b/packages/node/src/resolve-namespace.ts
@@ -6,8 +6,12 @@ import {
 import { dirname, relative } from 'path';
 import findConfig from 'find-config';
 
-export function resolveNamespaceFactory(hashSalt = '', prefix = '') {
-    return createNamespaceStrategyNode({ hashSalt, prefix });
+export function resolveNamespaceFactory(
+    hashSalt = '',
+    prefix = '',
+    options: Partial<Omit<CreateNamespaceOptions, 'hashSalt' | 'prefix'>> = {}
+) {
+    return createNamespaceStrategyNode({ hashSalt, prefix, ...options });
 }
 
 export function createNamespaceStrategyNode(options: Partial<CreateNamespaceOptions> = {}) {

--- a/packages/node/src/resolve-namespace.ts
+++ b/packages/node/src/resolve-namespace.ts
@@ -1,4 +1,10 @@
-import { packageNamespaceFactory } from '@stylable/core';
+import {
+    murmurhash3_32_gc,
+    packageNamespaceFactory,
+    createNamespaceStrategy,
+    CreateNamespaceOptions,
+    defaultNoMatchHandler,
+} from '@stylable/core';
 import { dirname, relative } from 'path';
 import findConfig from 'find-config';
 
@@ -9,5 +15,33 @@ export function resolveNamespaceFactory(
     return packageNamespaceFactory(findConfig, require, { dirname, relative }, hashSalt, prefix);
 }
 
-export const resolveNamespace: ReturnType<typeof packageNamespaceFactory> =
-    resolveNamespaceFactory();
+export function createNamespaceStrategyNode(options: Partial<CreateNamespaceOptions> = {}) {
+    return createNamespaceStrategy({
+        hashFn: murmurhash3_32_gc,
+        normalizePath(packageRoot: string, stylesheetPath: string) {
+            return relative(packageRoot, stylesheetPath).replace(/\\/g, '/');
+        },
+        getPackageInfo: (stylesheetPath) => {
+            const configPath = findConfig('package.json', { cwd: dirname(stylesheetPath) });
+            if (!configPath) {
+                throw new Error(`Could not find package.json for ${stylesheetPath}`);
+            }
+            const config = require(configPath) as { name: string; version: string };
+            return {
+                name: config.name,
+                version: config.version,
+                dirPath: dirname(configPath),
+            };
+        },
+        handleNoMatch(strict, ns, stylesheetPath, usedBy) {
+            return strict ? defaultNoMatchHandler(strict, ns, stylesheetPath, usedBy) : ns;
+        },
+        hashSalt: '',
+        hashFragment: 'full',
+        hashSeparator: '',
+        strict: false,
+        ...options,
+    });
+}
+
+export const resolveNamespace = createNamespaceStrategyNode();

--- a/packages/node/src/resolve-namespace.ts
+++ b/packages/node/src/resolve-namespace.ts
@@ -1,5 +1,4 @@
 import {
-    packageNamespaceFactory,
     createNamespaceStrategy,
     CreateNamespaceOptions,
     defaultNoMatchHandler,
@@ -7,11 +6,8 @@ import {
 import { dirname, relative } from 'path';
 import findConfig from 'find-config';
 
-export function resolveNamespaceFactory(
-    hashSalt = '',
-    prefix = ''
-): ReturnType<typeof packageNamespaceFactory> {
-    return packageNamespaceFactory(findConfig, require, { dirname, relative }, hashSalt, prefix);
+export function resolveNamespaceFactory(hashSalt = '', prefix = '') {
+    return createNamespaceStrategyNode({ hashSalt, prefix });
 }
 
 export function createNamespaceStrategyNode(options: Partial<CreateNamespaceOptions> = {}) {

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -1,18 +1,15 @@
 import {
     Stylable,
     StylableConfig,
-    packageNamespaceFactory,
     OptimizeConfig,
     DiagnosticsMode,
     IStylableOptimizer,
 } from '@stylable/core';
+import { createNamespaceStrategyNode } from '@stylable/node';
 import { sortModulesByDepth, loadStylableConfig, calcDepth } from '@stylable/build-tools';
 import { StylableOptimizer } from '@stylable/optimizer';
 import cloneDeep from 'lodash.clonedeep';
-import { dirname, relative } from 'path';
 import type { Compilation, Compiler, NormalModule, WebpackError } from 'webpack';
-
-import findConfig from 'find-config';
 
 import {
     getStaticPublicPath,
@@ -359,13 +356,9 @@ export class StylableWebpackPlugin {
                         ...resolverOptions,
                         extensions: [], // use Stylable's default extensions
                     },
-                    resolveNamespace: packageNamespaceFactory(
-                        findConfig,
-                        require,
-                        { dirname, relative },
-                        compiler.options.output.hashSalt || '',
-                        ''
-                    ),
+                    resolveNamespace: createNamespaceStrategyNode({
+                        hashSalt: compiler.options.output.hashSalt || '',
+                    }),
                     requireModule: createDecacheRequire(compiler),
                     optimizer: this.options.optimizer,
                     resolverCache: createStylableResolverCacheMap(compiler),


### PR DESCRIPTION
Implement new universal namespace strategy
Features: 
* custom hash function
* custom hash length strategy
* custom/optional package info
* better hook interface for complex namespace generation

This strategy should support our existing node, no collision and default strategy  

Should close:
- https://github.com/wix/stylable/pull/2516
- #2286

Should handle:
- https://github.com/wix/stylable/pull/2313

TODO:

- [x] pass in the origin argument
- [x] check if StylableOptimizer can still work for namespaces without hash
- [x] replace usages of old namespace strategy (maybe only in v5)?

Notes:
This strategy should not treated as breaking change unless someone was depending on the current hash (murmur) output. 
We still need to check if we don't use `namespace\d+` regexp in out solutions like:
* packages\webpack-extensions\test\e2e\metadata-loader-case.spec.ts
* packages\webpack-plugin\test\e2e\dev-mode-warnings-project.spec.ts
* packages\webpack-plugin\test\e2e\hooked-project.spec.ts
* packages\webpack-plugin\test\e2e\mixins-project.spec.ts
* packages\webpack-plugin\test\e2e\stc-watched-project.spec.ts
* packages\webpack-plugin\test\e2e\watched-project.spec.ts
* packages\webpack-plugin\test\e2e\projects\hooked-project\stylable.config.js

