### PR TITLE
refactor(core)!: removed processed AST from meta

### DIFF
--- a/packages/build-tools/src/process-url-dependencies.ts
+++ b/packages/build-tools/src/process-url-dependencies.ts
@@ -29,7 +29,7 @@ export function processUrlDependencies(
         }
     };
 
-    meta.outputAst!.walkDecls((node) => {
+    meta.targetAst!.walkDecls((node) => {
         processDeclarationFunctions(
             node,
             (functionNode) => {

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -156,7 +156,7 @@ export function buildSingleFile({
     });
     // .css
     if (outputCSS) {
-        let cssCode = res.meta.outputAst!.toString();
+        let cssCode = res.meta.targetAst!.toString();
         if (minify) {
             cssCode = optimizer.minifyCSS(cssCode);
         }

--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -131,7 +131,7 @@ export function generateStylableResult(
 }
 
 export function generateStylableRoot(config: Config) {
-    return generateStylableResult(config).meta.outputAst!;
+    return generateStylableResult(config).meta.targetAst!;
 }
 
 export function generateStylableExports(config: Config) {

--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -23,7 +23,7 @@ const testScopes = Object.keys(tests) as TestScopes[];
 const testScopesRegex = () => testScopes.join(`|`);
 
 interface Context {
-    meta: Pick<StylableMeta, 'outputAst' | 'rawAst' | 'diagnostics' | 'transformDiagnostics'>;
+    meta: Pick<StylableMeta, 'sourceAst' | 'targetAst' | 'diagnostics' | 'transformDiagnostics'>;
 }
 const isRoot = (val: any): val is postcss.Root => val.type === `root`;
 
@@ -65,14 +65,14 @@ export function testInlineExpects(result: postcss.Root | Context, expectedTestIn
     const context = isDeprecatedInput
         ? {
               meta: {
-                  outputAst: result,
-                  rawAst: result,
+                  sourceAst: result,
+                  targetAst: result,
                   diagnostics: null as unknown as StylableMeta['diagnostics'],
                   transformDiagnostics: null as unknown as StylableMeta['transformDiagnostics'],
               },
           }
         : result;
-    const rootAst = context.meta.rawAst;
+    const rootAst = context.meta.sourceAst;
     const expectedTestAmount =
         expectedTestInput ??
         (rootAst.toString().match(new RegExp(`${testScopesRegex()}`, `gm`))?.length || 0);
@@ -427,10 +427,10 @@ function diagnosticTest(
 
 function getTargetComment(meta: Context['meta'], { source }: postcss.Comment) {
     let match: postcss.Comment | undefined = undefined;
-    if (!meta.outputAst) {
+    if (!meta.targetAst) {
         return;
     }
-    meta.outputAst.walkComments((outputComment) => {
+    meta.targetAst.walkComments((outputComment) => {
         if (
             outputComment.source?.start?.offset === source?.start?.offset &&
             outputComment.source?.end?.offset === source?.end?.offset

--- a/packages/core-test-kit/src/matchers/results.ts
+++ b/packages/core-test-kit/src/matchers/results.ts
@@ -16,12 +16,12 @@ export function mediaQuery(chai: Chai.ChaiStatic, util: Chai.ChaiUtils) {
             );
         }
 
-        const { outputAst } = actual.meta;
-        if (!outputAst) {
-            throw new Error(`expected result to be transformed - missing outputAst on meta`);
+        const { targetAst } = actual.meta;
+        if (!targetAst) {
+            throw new Error(`expected result to be transformed - missing targetAst on meta`);
         }
 
-        const nodes = outputAst.nodes;
+        const nodes = targetAst.nodes;
 
         if (!nodes) {
             throw new Error(`no rules found for media`);
@@ -54,13 +54,13 @@ export function styleRules(chai: Chai.ChaiStatic, util: Chai.ChaiUtils) {
 
             let scopeRule: postcss.Container | undefined = flag(this, 'actualRule');
             if (!scopeRule) {
-                const { outputAst } = actual.meta;
-                if (!outputAst) {
+                const { targetAst } = actual.meta;
+                if (!targetAst) {
                     throw new Error(
-                        `expected result to be transfromed - missing outputAst on meta`
+                        `expected result to be transfromed - missing targetAst on meta`
                     );
                 } else {
-                    scopeRule = outputAst;
+                    scopeRule = targetAst;
                 }
             }
 

--- a/packages/core-test-kit/src/test-stylable-core.ts
+++ b/packages/core-test-kit/src/test-stylable-core.ts
@@ -59,7 +59,7 @@ export function testStylableCore(
     // inline test - build all and test
     for (const path of allSheets) {
         const meta = stylable.analyze(path);
-        if (!meta.outputAst) {
+        if (!meta.targetAst) {
             // ToDo: test
             stylable.transform(meta);
         }

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -8,6 +8,7 @@ import {
 import { transformerDiagnostics } from '@stylable/core/dist/stylable-transformer';
 import { STImport, CSSType, CSSClass } from '@stylable/core/dist/features';
 import { expect } from 'chai';
+import type { Rule } from 'postcss';
 
 const cssClassDiagnostics = diagnosticBankReportToStrings(CSSClass.diagnostics);
 const cssTypeDiagnostics = diagnosticBankReportToStrings(CSSType.diagnostics);
@@ -377,7 +378,7 @@ describe('inline-expectations', () => {
                 },
             });
 
-            result.meta.outputAst?.nodes[1].remove();
+            result.meta.targetAst?.nodes[1].remove();
 
             expect(() => testInlineExpects(result)).to.throw(
                 testInlineExpectsErrors.removedNode(`rule`, `(label): `)
@@ -471,7 +472,7 @@ describe('inline-expectations', () => {
                 },
             });
 
-            result.meta.outputAst?.nodes[1].remove();
+            result.meta.targetAst?.nodes[1].remove();
 
             expect(() => testInlineExpects(result)).to.throw(
                 testInlineExpectsErrors.removedNode(`atrule`, `(label): `)
@@ -614,7 +615,7 @@ describe('inline-expectations', () => {
                 },
             });
 
-            (result.meta.outputAst?.nodes[0] as any).nodes[1].remove();
+            (result.meta.targetAst!.nodes[0] as Rule).nodes[1].remove();
 
             expect(() => testInlineExpects(result)).to.throw(
                 testInlineExpectsErrors.removedNode(`decl`, `(label): `)

--- a/packages/core-test-kit/test/test-stylable-core.spec.ts
+++ b/packages/core-test-kit/test/test-stylable-core.spec.ts
@@ -43,7 +43,7 @@ describe(`testStylableCore()`, () => {
         const newMeta = stylable.analyze(`/new.st.css`);
         stylable.transform(newMeta);
 
-        expect(newMeta.outputAst?.toString().trim()).to.equal(`.entry__part {}`);
+        expect(newMeta.targetAst?.toString().trim()).to.equal(`.entry__part {}`);
     });
     describe(`multiple files`, () => {
         it(`should accept a multiple files (transform all by default)`, () => {

--- a/packages/core/src/features/st-custom-selector.ts
+++ b/packages/core/src/features/st-custom-selector.ts
@@ -98,10 +98,7 @@ export function getCustomSelector(meta: StylableMeta, name: string): SelectorLis
     return analyzed[name]?.ast;
 }
 
-export function getCustomSelectorExpended(
-    meta: StylableMeta,
-    name: string
-): string | undefined {
+export function getCustomSelectorExpended(meta: StylableMeta, name: string): string | undefined {
     const analyzed = plugableRecord.getUnsafe(meta.data, dataKey);
     return analyzed[name]?.selector;
 }

--- a/packages/core/src/features/st-import.ts
+++ b/packages/core/src/features/st-import.ts
@@ -96,7 +96,7 @@ export const hooks = createFeature<{
         const imports = plugableRecord.getUnsafe(context.meta.data, dataKey);
         const dirContext = path.dirname(context.meta.source);
         // collect shallow imports
-        for (const node of context.meta.ast.nodes) {
+        for (const node of context.meta.sourceAst.nodes) {
             if (!isImportStatement(node)) {
                 continue;
             }

--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -340,7 +340,7 @@ function createMixinRootFromCSSResolve(
     const mixDef = config.mixDef;
     const isRootMixin = resolvedClass.symbol.name === resolvedClass.meta.root;
     const mixinRoot = createSubsetAst<postcss.Root>(
-        resolvedClass.meta.ast,
+        resolvedClass.meta.sourceAst,
         (resolvedClass.symbol._kind === 'class' ? '.' : '') + resolvedClass.symbol.name,
         undefined,
         isRootMixin,

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -34,9 +34,8 @@ const features = [
 
 export class StylableMeta {
     public data: PlugableRecord = {};
-    public rawAst: postcss.Root = this.ast.clone();
     public root = 'root';
-    public source: string = getSourcePath(this.ast, this.diagnostics);
+    public source: string = getSourcePath(this.sourceAst, this.diagnostics);
     public namespace = '';
     public urls: string[] = [];
     public transformDiagnostics: Diagnostics | null = null;
@@ -44,9 +43,9 @@ export class StylableMeta {
     /** @deprecated */
     public scopes: postcss.AtRule[] = [];
     // Generated during transform
-    public outputAst?: postcss.Root;
+    public targetAst?: postcss.Root;
     public globals: Record<string, boolean> = {};
-    constructor(public ast: postcss.Root, public diagnostics: Diagnostics) {
+    constructor(public sourceAst: postcss.Root, public diagnostics: Diagnostics) {
         // initiate features
         const context: FeatureContext = { meta: this, diagnostics };
         for (const { hooks } of features) {

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -239,10 +239,10 @@ export class StylableProcessor implements FeatureContext {
 
     private handleNamespaceReference(namespace: string): string {
         let pathToSource: string | undefined;
-        let length = this.meta.ast.nodes.length;
+        let length = this.meta.sourceAst.nodes.length;
 
         while (length--) {
-            const node = this.meta.ast.nodes[length];
+            const node = this.meta.sourceAst.nodes[length];
             if (node.type === 'comment' && node.text.includes('st-namespace-reference')) {
                 const i = node.text.indexOf('=');
                 if (i === -1) {

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -432,7 +432,7 @@ function validateClassResolveExtends(
     deepResolved: CSSResolve<StylableSymbol> | JSResolve | null
 ): ReportError | undefined {
     return (res, extend) => {
-        const decl = findRule(meta.ast, '.' + name);
+        const decl = findRule(meta.sourceAst, '.' + name);
         if (decl) {
             // ToDo: move to STExtends
             if (res && res._kind === 'js') {
@@ -453,7 +453,7 @@ function validateClassResolveExtends(
             }
         } else {
             if (deepResolved?.symbol.alias) {
-                meta.ast.walkRules(new RegExp('\\.' + name), (rule) => {
+                meta.sourceAst.walkRules(new RegExp('\\.' + name), (rule) => {
                     diagnostics.report(CSSClass.diagnostics.UNKNOWN_IMPORT_ALIAS(name), {
                         node: rule,
                         word: name,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -139,7 +139,7 @@ export class StylableTransformer {
             keyframes: {},
         };
         meta.transformedScopes = null;
-        meta.outputAst = meta.ast.clone();
+        meta.targetAst = meta.sourceAst.clone();
         const context = {
             meta,
             diagnostics: this.diagnostics,
@@ -150,7 +150,7 @@ export class StylableTransformer {
         STImport.hooks.transformInit({ context });
         STGlobal.hooks.transformInit({ context });
         meta.transformedScopes = validateScopes(this, meta);
-        this.transformAst(meta.outputAst, meta, metaExports);
+        this.transformAst(meta.targetAst, meta, metaExports);
         meta.transformDiagnostics = this.diagnostics;
         const result = { meta, exports: metaExports };
 
@@ -248,7 +248,7 @@ export class StylableTransformer {
             }
         });
 
-        if (!mixinTransform && meta.outputAst && this.mode === 'development') {
+        if (!mixinTransform && meta.targetAst && this.mode === 'development') {
             this.addDevRules(meta);
         }
 
@@ -365,12 +365,12 @@ export class StylableTransformer {
         if (selectorList.length === 0) {
             context.elements.push([]);
         }
-        const outputAst = splitCompoundSelectors(selectorList);
-        context.additionalSelectors.forEach((addSelector) => outputAst.push(addSelector()));
-        for (let i = 0; i < outputAst.length; i++) {
-            selectorAst[i] = outputAst[i];
+        const targetAst = splitCompoundSelectors(selectorList);
+        context.additionalSelectors.forEach((addSelector) => targetAst.push(addSelector()));
+        for (let i = 0; i < targetAst.length; i++) {
+            selectorAst[i] = targetAst[i];
         }
-        return outputAst;
+        return targetAst;
     }
     private handleCompoundNode(context: Required<ScopeContext>) {
         const { currentAnchor, node, originMeta, topNestClassName } = context;
@@ -616,7 +616,7 @@ export class StylableTransformer {
         const resolvedSymbols = this.getResolvedSymbols(meta);
         for (const [className, resolved] of Object.entries(resolvedSymbols.class)) {
             if (resolved.length > 1) {
-                meta.outputAst!.walkRules(
+                meta.targetAst!.walkRules(
                     '.' + namespaceEscape(className, meta.namespace),
                     (rule) => {
                         const a = resolved[0];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,7 @@ export interface IStylableOptimizer {
     getClassName(className: string): string;
     optimizeAst(
         config: OptimizeConfig,
-        outputAst: postcss.Root,
+        targetAst: postcss.Root,
         usageMapping: Record<string, boolean>,
         jsExports: StylableExports,
         globals: Record<string, boolean>

--- a/packages/core/test/features/css-keyframes.spec.ts
+++ b/packages/core/test/features/css-keyframes.spec.ts
@@ -60,7 +60,7 @@ describe(`features/css-keyframes`, () => {
         expect(
             CSSKeyframes.getKeyframesStatements(meta),
             `CSSKeyframes.getKeyframesStatements(meta)`
-        ).to.containSubset([meta.ast.nodes[1], meta.ast.nodes[3]]);
+        ).to.containSubset([meta.sourceAst.nodes[1], meta.sourceAst.nodes[3]]);
     });
     it(`should namespace "animation" and "animation-name" declarations`, () => {
         const { sheets } = testStylableCore(`
@@ -130,7 +130,7 @@ describe(`features/css-keyframes`, () => {
 
         const { meta } = sheets['/entry.st.css'];
 
-        expect(meta.outputAst?.nodes[1]?.toString()).to.eql(`@keyframes {}`);
+        expect(meta.targetAst?.nodes[1]?.toString()).to.eql(`@keyframes {}`);
     });
     it('should report reserved @keyframes names', () => {
         CSSKeyframes.reservedKeyFrames.map((reserved) => {
@@ -494,7 +494,7 @@ describe(`features/css-keyframes`, () => {
             `);
 
             expect(
-                sheets[`/entry.st.css`].meta.outputAst?.toString().match(/@keyframes/g)!.length,
+                sheets[`/entry.st.css`].meta.targetAst?.toString().match(/@keyframes/g)!.length,
                 `only original @keyframes`
             ).to.eql(1);
         });
@@ -519,7 +519,7 @@ describe(`features/css-keyframes`, () => {
             });
 
             expect(
-                sheets[`/entry.st.css`].meta.outputAst?.toString(),
+                sheets[`/entry.st.css`].meta.targetAst?.toString(),
                 `@keyframes referenced & not copied`
             ).to.not.include(`@keyframes`);
         });

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -258,7 +258,7 @@ describe(`features/st-mixin`, () => {
                 stylableConfig: {
                     onProcess(meta) {
                         // remove -st-mixin origin before apply mixin.
-                        const mixToClass = meta.ast.nodes[2] as postcss.Rule;
+                        const mixToClass = meta.sourceAst.nodes[2] as postcss.Rule;
                         const stMixinDecl = mixToClass.nodes[1];
                         stMixinDecl.remove();
                         return meta;
@@ -1687,7 +1687,7 @@ describe(`features/st-mixin`, () => {
                 shouldReportNoDiagnostics(meta);
 
                 matchRuleAndDeclaration(
-                    meta.outputAst!.nodes[2] as postcss.Container,
+                    meta.targetAst!.nodes[2] as postcss.Container,
                     0,
                     '.entry__a',
                     'id: nested'
@@ -1722,7 +1722,7 @@ describe(`features/st-mixin`, () => {
                 shouldReportNoDiagnostics(meta);
 
                 matchRuleAndDeclaration(
-                    meta.outputAst!.nodes[2] as postcss.Container,
+                    meta.targetAst!.nodes[2] as postcss.Container,
                     0,
                     '.entry__a',
                     'id: nested'
@@ -1756,7 +1756,7 @@ describe(`features/st-mixin`, () => {
                 shouldReportNoDiagnostics(meta);
 
                 matchRuleAndDeclaration(
-                    meta.outputAst!.nodes[3] as postcss.Container,
+                    meta.targetAst!.nodes[3] as postcss.Container,
                     0,
                     '.entry__a .mixin__mix',
                     'id: nested'
@@ -1792,7 +1792,7 @@ describe(`features/st-mixin`, () => {
                 shouldReportNoDiagnostics(meta);
 
                 matchRuleAndDeclaration(
-                    meta.outputAst!.nodes[2] as postcss.Container,
+                    meta.targetAst!.nodes[2] as postcss.Container,
                     0,
                     '.entry__a',
                     'id: nested'
@@ -1827,7 +1827,7 @@ describe(`features/st-mixin`, () => {
                 shouldReportNoDiagnostics(meta);
 
                 matchRuleAndDeclaration(
-                    meta.outputAst!.nodes[2] as postcss.Container,
+                    meta.targetAst!.nodes[2] as postcss.Container,
                     0,
                     '.entry__a',
                     'id: nested'
@@ -1861,7 +1861,7 @@ describe(`features/st-mixin`, () => {
                 shouldReportNoDiagnostics(meta);
 
                 matchRuleAndDeclaration(
-                    meta.outputAst!.nodes[3] as postcss.Container,
+                    meta.targetAst!.nodes[3] as postcss.Container,
                     0,
                     '.entry__a .mixin__mix',
                     'id: nested'

--- a/packages/core/test/pseudo-states.spec.ts
+++ b/packages/core/test/pseudo-states.spec.ts
@@ -1321,7 +1321,7 @@ describe('pseudo-states', () => {
                         },
                     });
 
-                    testInlineExpects(res.meta.outputAst!);
+                    testInlineExpects(res.meta.targetAst!);
                     expect(
                         res.meta.diagnostics.reports,
                         'no diagnostics reported for native states'
@@ -2020,7 +2020,6 @@ describe('pseudo-states', () => {
                     },
                 });
 
-                // result.meta.outputAst.toString();
                 expect(
                     result.meta.diagnostics.reports,
                     'no diagnostics reported for imported states'

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -78,7 +78,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[0] as Rule).selector).to.equal(
+            expect((meta.targetAst!.nodes[0] as Rule).selector).to.equal(
                 '.entry__root .entry__part'
             );
         });
@@ -100,7 +100,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[0] as Rule).selector).to.equal(
+            expect((meta.targetAst!.nodes[0] as Rule).selector).to.equal(
                 '.entry__scope1 .entry__part1, .entry__scope2 .entry__part1, .entry__scope1 .entry__part2, .entry__scope2 .entry__part2'
             );
         });
@@ -122,7 +122,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[0] as Rule).selector).to.equal('* .entry__part');
+            expect((meta.targetAst!.nodes[0] as Rule).selector).to.equal('* .entry__part');
         });
 
         it('should support :global() selector', () => {
@@ -142,7 +142,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[0] as Rule).selector).to.equal('.my-class .entry__part');
+            expect((meta.targetAst!.nodes[0] as Rule).selector).to.equal('.my-class .entry__part');
         });
 
         it('should selectors with internal parts', () => {
@@ -172,7 +172,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[1] as Rule).selector).to.equal(
+            expect((meta.targetAst!.nodes[1] as Rule).selector).to.equal(
                 '.entry__root .imported__part .entry__part1, .entry__root .imported__part .entry__part2'
             );
         });
@@ -204,7 +204,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.first as Rule).selector).to.equal(
+            expect((meta.targetAst!.first as Rule).selector).to.equal(
                 '.imported__importedPart .entry__part'
             );
         });
@@ -229,7 +229,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[2] as Rule).selector).to.equal(
+            expect((meta.targetAst!.nodes[2] as Rule).selector).to.equal(
                 '.entry__root .entry__part .entry__scopedPart'
             );
 
@@ -259,7 +259,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect((meta.outputAst!.nodes[0] as Rule).selector).to.equal(
+            expect((meta.targetAst!.nodes[0] as Rule).selector).to.equal(
                 '.entry__root .entry__part, .entry__root .entry__otherPart, .entry__root .entry__oneMorePart'
             );
         });
@@ -289,7 +289,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect(meta.outputAst!.first).to.flatMatch({
+            expect(meta.targetAst!.first).to.flatMatch({
                 selector: '.imported__root .entry__part',
             });
         });
@@ -319,7 +319,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            expect(meta.outputAst!.first).to.flatMatch({
+            expect(meta.targetAst!.first).to.flatMatch({
                 selector: '.entry__root .imported__root',
             });
         });
@@ -354,7 +354,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            const rule: Rule = meta.outputAst!.first as Rule;
+            const rule: Rule = meta.targetAst!.first as Rule;
             const decl: Declaration = rule.first as Declaration;
             expect(decl).to.equal(undefined);
         });
@@ -390,7 +390,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            const rule: Rule = meta.outputAst!.nodes[1] as Rule;
+            const rule: Rule = meta.targetAst!.nodes[1] as Rule;
             const decl: Declaration = rule.first as Declaration;
             expect(decl.value).to.equal('red');
         });
@@ -428,7 +428,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            const rule = meta.outputAst!.nodes[1] as Rule;
+            const rule = meta.targetAst!.nodes[1] as Rule;
             expect(rule.selector).to.equal('.entry__root.imported--myState');
         });
 
@@ -451,7 +451,7 @@ describe('@st-scope', () => {
 
             shouldReportNoDiagnostics(meta);
 
-            const atRule = meta.outputAst!.nodes[0] as AtRule;
+            const atRule = meta.targetAst!.nodes[0] as AtRule;
             const rule = atRule.nodes[0] as Rule;
             expect(rule.selector).to.equal('.entry__root .entry__part');
         });
@@ -480,7 +480,7 @@ describe('@st-scope', () => {
                     severity: 'error',
                 },
             ]);
-            expect((meta.outputAst!.first as Rule).selector).to.equal(
+            expect((meta.targetAst!.first as Rule).selector).to.equal(
                 '.entry__root::unknownPart .entry__part'
             );
         });
@@ -512,7 +512,7 @@ describe('@st-scope', () => {
                     skipLocationCheck: true,
                 },
             ]);
-            expect((meta.outputAst!.first as Rule).selector).to.equal(
+            expect((meta.targetAst!.first as Rule).selector).to.equal(
                 '.entry__root::unknownPart .entry__part::unknownPart'
             );
         });
@@ -538,7 +538,7 @@ describe('@st-scope', () => {
                     severity: 'error',
                 },
             ]);
-            expect((meta.outputAst!.first as Rule).selector).to.equal('.entry__part');
+            expect((meta.targetAst!.first as Rule).selector).to.equal('.entry__part');
         });
     });
 });

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -400,7 +400,7 @@ describe('stylable-resolver', () => {
             },
         });
 
-        const rule = meta.outputAst!.nodes[0] as postcss.Rule;
+        const rule = meta.targetAst!.nodes[0] as postcss.Rule;
         expect(rule.selector).to.equal('.A__root');
         expect(meta.diagnostics.reports).to.eql([]);
         expect(meta.transformDiagnostics!.reports).to.eql([]);

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -37,9 +37,9 @@ describe('Stylable postcss transform (Global)', () => {
             d: true,
             e: true,
         });
-        expect((meta.outputAst!.nodes[1] as postcss.Rule).selector).to.equal('.global-test');
-        expect((meta.outputAst!.nodes[2] as postcss.Rule).selector).to.equal('.a .b');
-        expect((meta.outputAst!.nodes[3] as postcss.Rule).selector).to.equal('.c .d');
-        expect((meta.outputAst!.nodes[4] as postcss.Rule).selector).to.equal('.e');
+        expect((meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal('.global-test');
+        expect((meta.targetAst!.nodes[2] as postcss.Rule).selector).to.equal('.a .b');
+        expect((meta.targetAst!.nodes[3] as postcss.Rule).selector).to.equal('.c .d');
+        expect((meta.targetAst!.nodes[4] as postcss.Rule).selector).to.equal('.e');
     });
 });

--- a/packages/core/test/stylable-transformer/post-process.spec.ts
+++ b/packages/core/test/stylable-transformer/post-process.spec.ts
@@ -7,7 +7,7 @@ describe('post-process', () => {
             stylableConfig: {
                 hooks: {
                     postProcessor(res) {
-                        res.meta.outputAst!.walkRules((rule) => {
+                        res.meta.targetAst!.walkRules((rule) => {
                             rule.selector = rule.selector.replace(`.entry__part`, `.custom-part`);
                         });
                         res.exports.classes.part = `custom-part`;
@@ -18,7 +18,7 @@ describe('post-process', () => {
         });
 
         const { meta, exports } = sheets[`/entry.st.css`];
-        expect(meta.outputAst?.toString(), `change meta`).to.eql(`.custom-part {}`);
+        expect(meta.targetAst?.toString(), `change meta`).to.eql(`.custom-part {}`);
         expect(exports.classes.part, `JS exports`).to.eql(`custom-part`);
     });
 });

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -30,12 +30,12 @@ describe('Stylable', () => {
             const overrideMeta = stylable.analyze(path, overrideContent);
             const fsMetaAfter = stylable.analyze(path);
 
-            expect(overrideMeta.ast.toString(), `override src ast`).to.eql(`.override {}`);
+            expect(overrideMeta.sourceAst.toString(), `override src ast`).to.eql(`.override {}`);
             expect(overrideMeta, `override meta`).to.contain({
                 source: path,
                 namespace: `entry`,
             });
-            expect(fsMetaBefore.ast.toString(), `fs before src ast`).to.eql(`.fs {}`);
+            expect(fsMetaBefore.sourceAst.toString(), `fs before src ast`).to.eql(`.fs {}`);
             expect(fsMetaBefore, `fs meta`).to.contain({
                 source: path,
                 namespace: `entry`,
@@ -51,7 +51,7 @@ describe('Stylable', () => {
 
             const { meta, exports } = stylable.transform(src, path);
 
-            expect(meta.outputAst?.toString(), `output CSS`).to.eql(`.entry__a {}`);
+            expect(meta.targetAst?.toString(), `output CSS`).to.eql(`.entry__a {}`);
             expect(exports.classes.a, `JS export`).to.eql(`entry__a`);
         });
         it(`should transform a stylesheet from meta`, () => {
@@ -62,7 +62,7 @@ describe('Stylable', () => {
 
             const { meta, exports } = stylable.transform(stylable.analyze(path));
 
-            expect(meta.outputAst?.toString(), `output CSS`).to.eql(`.entry__a {}`);
+            expect(meta.targetAst?.toString(), `output CSS`).to.eql(`.entry__a {}`);
             expect(exports.classes.a, `JS export`).to.eql(`entry__a`);
         });
         it(`should transform selector`, () => {

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -122,11 +122,11 @@ const stylableLoader: LoaderDefinition = function (content) {
     ];
 
     if (mode !== 'development') {
-        optimizer.removeStylableDirectives(meta.outputAst!);
+        optimizer.removeStylableDirectives(meta.targetAst!);
     }
 
     postcss(plugins)
-        .process(meta.outputAst!, {
+        .process(meta.targetAst!, {
             from: this.resourcePath,
             to: this.resourcePath,
             map: false,

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -314,8 +314,9 @@ export const TopLevelDirectiveProvider: CompletionProvider = {
                 return topLevelDeclarations
                     .filter(
                         (d) =>
-                            !meta.ast.source!.input.css.includes(topLevelDirectives.namespace) ||
-                            d !== 'namespace'
+                            !meta.sourceAst.source!.input.css.includes(
+                                topLevelDirectives.namespace
+                            ) || d !== 'namespace'
                     )
                     .filter((d) => topLevelDirectives[d].startsWith(fullLineText.trim()))
                     .map((d) =>

--- a/packages/language-service/src/lib/diagnosis.ts
+++ b/packages/language-service/src/lib/diagnosis.ts
@@ -21,7 +21,7 @@ export function createDiagnosis(
         /*TODO: report this failure to transform */
     }
 
-    const cleanDoc = cssService.createSanitizedDocument(meta.rawAst, filePath, version);
+    const cleanDoc = cssService.createSanitizedDocument(meta.sourceAst, filePath, version);
 
     return meta.diagnostics.reports
         .concat(meta.transformDiagnostics ? meta.transformDiagnostics.reports : [])

--- a/packages/language-service/src/lib/feature/color-provider.ts
+++ b/packages/language-service/src/lib/feature/color-provider.ts
@@ -93,7 +93,7 @@ export function resolveDocumentColors(
         });
 
         const cleanDocument = cssService.createSanitizedDocument(
-            meta.rawAst,
+            meta.sourceAst,
             filePath,
             document.version
         );
@@ -118,7 +118,7 @@ export function getColorPresentation(
         params.range.start.character + 1
     );
     let noPicker = false;
-    meta?.rawAst.walkDecls(`-st-named`, (node) => {
+    meta?.sourceAst.walkDecls(`-st-named`, (node) => {
         if (
             node &&
             ((wordStart.line === node.source!.start!.line &&

--- a/packages/language-service/test/test-kit/asserters.ts
+++ b/packages/language-service/test/test-kit/asserters.ts
@@ -45,7 +45,10 @@ export function getPath(fileName: string): postcss.Node[] {
     const pos = getCaretPosition(src);
     src = src.replace('|', '');
     const proc = createMeta(src, fullPath);
-    return pathFromPosition(proc.meta!.rawAst, new ProviderPosition(pos.line + 1, pos.character));
+    return pathFromPosition(
+        proc.meta!.sourceAst,
+        new ProviderPosition(pos.line + 1, pos.character)
+    );
 }
 
 export function getDefinition(fileName: string): ProviderLocation[] {

--- a/packages/module-utils/src/generate-dts-sourcemaps.ts
+++ b/packages/module-utils/src/generate-dts-sourcemaps.ts
@@ -18,7 +18,7 @@ function getClassSrcPosition(className: string, meta: StylableMeta): Position | 
     let res;
 
     if (cls) {
-        meta.rawAst.walkRules(`.${className}`, (rule) => {
+        meta.sourceAst.walkRules(`.${className}`, (rule) => {
             if (rule.source && rule.source.start) {
                 res = { line: rule.source.start.line - 1, column: rule.source.start.column - 1 };
                 return false;
@@ -37,7 +37,7 @@ function getVarsSrcPosition(varName: string, meta: StylableMeta): Position | und
     let res;
 
     if (cssVar) {
-        meta.rawAst.walkDecls(cssVar.name, (decl) => {
+        meta.sourceAst.walkDecls(cssVar.name, (decl) => {
             if (decl.source && decl.source.start) {
                 res = { line: decl.source.start.line - 1, column: decl.source.start.column - 1 };
                 return false;
@@ -61,7 +61,7 @@ function getStVarsSrcPosition(varName: string, meta: StylableMeta): Position | u
     } else {
         // TODO: move this logic to Stylable core and enhance it. The meta should provide the API to get to the inner parts of the st-var
         let res: Position;
-        meta.rawAst.walkRules(':vars', (rule) => {
+        meta.sourceAst.walkRules(':vars', (rule) => {
             return rule.walkDecls((decl) => {
                 if (decl.source?.start) {
                     if (decl.prop === varName) {
@@ -176,7 +176,7 @@ function createStateLineMapping(
 
         const srcClassName = findDefiningClassName(stateToken, meta.getClass(entryClassName)!);
 
-        meta.rawAst.walkRules(`.${srcClassName}`, (rule) => {
+        meta.sourceAst.walkRules(`.${srcClassName}`, (rule) => {
             return rule.walkDecls(`-st-states`, (decl) => {
                 if (decl.source && decl.source.start)
                     stateSourcePosition = {

--- a/packages/module-utils/src/module-factory.ts
+++ b/packages/module-utils/src/module-factory.ts
@@ -32,7 +32,7 @@ export function stylableModuleFactory(
             `runtime.$`,
             `runtime.create`,
             `runtime.createRenderable`,
-            injectCSS ? JSON.stringify(res.meta.outputAst!.toString()) : '""',
+            injectCSS ? JSON.stringify(res.meta.targetAst!.toString()) : '""',
             '-1', // ToDo: calc depth for node as well
             'module.exports',
             '' /* afterModule */,

--- a/packages/module-utils/src/module-source.ts
+++ b/packages/module-utils/src/module-source.ts
@@ -51,7 +51,7 @@ export function createModuleSource(
         throw new Error('Configuration conflict (renderableOnly && !includeCSSInJS)');
     }
     const cssString = includeCSSInJS
-        ? JSON.stringify(stylableResult.meta.outputAst!.toString())
+        ? JSON.stringify(stylableResult.meta.targetAst!.toString())
         : '""';
 
     switch (moduleFormat) {

--- a/packages/optimizer/src/stylable-optimizer.ts
+++ b/packages/optimizer/src/stylable-optimizer.ts
@@ -29,12 +29,11 @@ export class StylableOptimizer implements IStylableOptimizer {
         usageMapping: Record<string, boolean>
     ) {
         const {
-            meta: { globals, outputAst: _outputAst },
+            meta: { globals, targetAst },
             exports: jsExports,
         } = stylableResults;
-        const outputAst = _outputAst!;
 
-        this.optimizeAst(config, outputAst, usageMapping, jsExports, globals);
+        this.optimizeAst(config, targetAst as Root, usageMapping, jsExports, globals);
     }
 
     public getNamespace(namespace: string) {
@@ -47,25 +46,25 @@ export class StylableOptimizer implements IStylableOptimizer {
 
     public optimizeAst(
         config: OptimizeConfig,
-        outputAst: Root,
+        targetAst: Root,
         usageMapping: Record<string, boolean>,
         jsExports: StylableExports,
         globals: Record<string, boolean>
     ) {
         if (config.removeComments) {
-            this.removeComments(outputAst);
+            this.removeComments(targetAst);
         }
         if (config.removeStylableDirectives) {
-            this.removeStylableDirectives(outputAst);
+            this.removeStylableDirectives(targetAst);
         }
         if (config.removeUnusedComponents && usageMapping) {
-            this.removeUnusedComponents(outputAst, usageMapping);
+            this.removeUnusedComponents(targetAst, usageMapping);
         }
         if (config.removeEmptyNodes) {
-            this.removeEmptyNodes(outputAst);
+            this.removeEmptyNodes(targetAst);
         }
         this.optimizeAstAndExports(
-            outputAst,
+            targetAst,
             jsExports.classes,
             undefined,
             usageMapping,
@@ -202,12 +201,12 @@ export class StylableOptimizer implements IStylableOptimizer {
     }
 
     private removeUnusedComponents(
-        outputAst: Root,
+        targetAst: Root,
         usageMapping: Record<string, boolean>,
         shouldComment = false
     ) {
         const matchNamespace = new RegExp(`(.+)${delimiter}(.+)`);
-        outputAst.walkRules((rule) => {
+        targetAst.walkRules((rule) => {
             const outputSelectors = rule.selectors.filter((selector) => {
                 const selectorAst = parseCssSelector(selector);
                 return !this.isContainsUnusedParts(selectorAst[0], usageMapping, matchNamespace);

--- a/packages/optimizer/test/stylable-optimizer.spec.ts
+++ b/packages/optimizer/test/stylable-optimizer.spec.ts
@@ -71,7 +71,7 @@ describe('StylableOptimizer', () => {
 
         new StylableOptimizer().optimize({ removeUnusedComponents: true }, result, usageMapping);
 
-        expect(result.meta.outputAst!.toString().trim()).to.equal('');
+        expect(result.meta.targetAst!.toString().trim()).to.equal('');
     });
 
     it('minifyCSS', () => {
@@ -88,7 +88,7 @@ describe('StylableOptimizer', () => {
             },
         };
         const { meta } = generateStylableResult({ entry: index, files });
-        const output = new StylableOptimizer().minifyCSS(meta.outputAst!.toString());
+        const output = new StylableOptimizer().minifyCSS(meta.targetAst!.toString());
         expect(output).to.equal(`.${meta.namespace}__x{color:red}`);
     }).timeout(25000);
 });

--- a/packages/rollup-plugin/src/plugin-utils.ts
+++ b/packages/rollup-plugin/src/plugin-utils.ts
@@ -37,7 +37,7 @@ export function generateCssString(
     assetsIds: string[]
 ) {
     const css = meta
-        .outputAst!.toString()
+        .targetAst!.toString()
         .replace(/__stylable_url_asset_(.*?)__/g, (_$0, $1) => assetsIds[Number($1)]);
 
     if (minify && stylable.optimizer) {

--- a/packages/schema-extract/src/cssdocs.ts
+++ b/packages/schema-extract/src/cssdocs.ts
@@ -21,7 +21,7 @@ export function getCssDocsForSymbol(meta: StylableMeta, symbol: StylableSymbol):
 
 function extractCSSDocsToSymbolMap(meta: StylableMeta) {
     const docs = new Map<StylableSymbol, CssDoc>();
-    meta.rawAst.walkComments((comment) => {
+    meta.sourceAst.walkComments((comment) => {
         const node = comment.next();
         if (node?.type === 'rule') {
             const symbol = meta.getSymbol(

--- a/packages/webpack-extensions/src/create-metadata-stylesheet.ts
+++ b/packages/webpack-extensions/src/create-metadata-stylesheet.ts
@@ -44,7 +44,7 @@ export function rewriteImports(
     const sourcesByHash: Record<string, string> = {};
     for (const [meta, resolvedImports] of usedMeta.entries()) {
         const hash = ensureHash(meta, hashes);
-        const rawAst = meta.rawAst.clone();
+        const rawAst = meta.sourceAst.clone();
         for (const { resolved, stImport } of resolvedImports) {
             if (resolved && resolved._kind === 'css') {
                 const rawRule = rawAst.nodes?.find(ruleByLocation(stImport.rule));
@@ -103,7 +103,7 @@ export function ensureHash(meta: StylableMeta, hashes: Map<StylableMeta, string>
 export function createContentHashPerMeta(usedMeta: Iterable<StylableMeta>) {
     const hashes = new Map<StylableMeta, string>();
     for (const meta of usedMeta) {
-        hashes.set(meta, hashContent(meta.rawAst.toString()));
+        hashes.set(meta, hashContent(meta.sourceAst.toString()));
     }
     return hashes;
 }

--- a/packages/webpack-extensions/src/stylable-forcestates-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-forcestates-plugin.ts
@@ -35,7 +35,7 @@ export function createDataAttr(dataAttrPrefix: string, stateName: string, param?
 }
 
 export function applyStylableForceStateSelectors(
-    outputAst: postcss.Root,
+    targetAst: postcss.Root,
     namespaceMapping: Record<string, boolean> | ((namespace: string) => boolean) = {},
     dataPrefix = OVERRIDE_STATE_PREFIX,
     plugin: (ctx: AddForceStateSelectorsContext) => AddForceStateSelectorsContext = (id) => id
@@ -47,7 +47,7 @@ export function applyStylableForceStateSelectors(
 
     const mapping: Record<string, string> = {};
     addForceStateSelectors(
-        outputAst,
+        targetAst,
         plugin({
             getForceStateAttrContentFromNative(name) {
                 return this.getForceStateAttrContent(name);

--- a/packages/webpack-extensions/test/unit/forcestates-plugin.spec.ts
+++ b/packages/webpack-extensions/test/unit/forcestates-plugin.spec.ts
@@ -96,11 +96,11 @@ describe('stylable-forcestates-plugin', () => {
             },
         });
 
-        applyStylableForceStateSelectors(res.meta.outputAst!, {
+        applyStylableForceStateSelectors(res.meta.targetAst!, {
             entry: true,
         });
 
-        expect((res.meta.outputAst!.nodes[1] as postcss.Rule).selector).to.equal(
+        expect((res.meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal(
             '.entry__root.entry--myState,.entry__root[stylable-force-state-myState]'
         );
     });
@@ -123,11 +123,11 @@ describe('stylable-forcestates-plugin', () => {
             },
         });
 
-        applyStylableForceStateSelectors(res.meta.outputAst!, (name) => {
+        applyStylableForceStateSelectors(res.meta.targetAst!, (name) => {
             return name === 'entry';
         });
 
-        expect((res.meta.outputAst!.nodes[1] as postcss.Rule).selector).to.equal(
+        expect((res.meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal(
             '.entry__root.entry--myState,.entry__root[stylable-force-state-myState]'
         );
     });
@@ -149,11 +149,11 @@ describe('stylable-forcestates-plugin', () => {
             },
         });
 
-        applyStylableForceStateSelectors(res.meta.outputAst!, {
+        applyStylableForceStateSelectors(res.meta.targetAst!, {
             entry: true,
         });
 
-        expect((res.meta.outputAst!.nodes[1] as postcss.Rule).selector).to.equal(
+        expect((res.meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal(
             '.entry__root:hover,.entry__root[stylable-force-state-hover]'
         );
     });
@@ -177,11 +177,11 @@ describe('stylable-forcestates-plugin', () => {
             },
         });
 
-        applyStylableForceStateSelectors(res.meta.outputAst!, {
+        applyStylableForceStateSelectors(res.meta.targetAst!, {
             entry: true,
         });
 
-        expect((res.meta.outputAst!.nodes[1] as postcss.Rule).selector).to.equal(
+        expect((res.meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal(
             `.entry__root.entry---myState-5-value,.entry__root[${createDataAttr(
                 OVERRIDE_STATE_PREFIX,
                 'myState',
@@ -209,11 +209,11 @@ describe('stylable-forcestates-plugin', () => {
             },
         });
 
-        applyStylableForceStateSelectors(res.meta.outputAst!, {
+        applyStylableForceStateSelectors(res.meta.targetAst!, {
             entry: true,
         });
 
-        expect((res.meta.outputAst!.nodes[1] as postcss.Rule).selector).to.equal(
+        expect((res.meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal(
             `.entry__root.entry---myState-10-some_value,.entry__root[${createDataAttr(
                 OVERRIDE_STATE_PREFIX,
                 'myState',

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -21,7 +21,7 @@ export default function StylableWebpackLoader(this: StylableLoaderContext, sourc
     const varType = this.target === 'oldie' ? 'var' : 'const';
 
     this.flagStylableModule({
-        css: meta.outputAst!.toString(),
+        css: meta.targetAst!.toString(),
         globals: meta.globals,
         exports,
         namespace: meta.namespace,

--- a/packages/webpack-plugin/test/e2e/projects/autoprefixer-project/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/autoprefixer-project/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
                     ...config,
                     hooks: {
                         postProcessor: (stylableResult) => {
-                            autoprefixProcessor.process(stylableResult.meta.outputAst).sync();
+                            autoprefixProcessor.process(stylableResult.meta.targetAst).sync();
                             return stylableResult;
                         },
                     },

--- a/packages/webpack-plugin/test/e2e/projects/emit-info-diagnostic/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/emit-info-diagnostic/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
                                 message: 'test info diagnostic!',
                                 severity: 'info',
                             },
-                            { node: result.meta.ast.root() }
+                            { node: result.meta.sourceAst.root() }
                         );
                         return result;
                     },

--- a/packages/webpack-plugin/test/e2e/projects/hooked-project/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/hooked-project/stylable.config.js
@@ -8,7 +8,7 @@ module.exports.webpackPlugin = function (options) {
                 hooks: {
                     postProcessor(result) {
                         const actions = [];
-                        result.meta.outputAst.walkDecls((decl) => {
+                        result.meta.targetAst.walkDecls((decl) => {
                             actions.push(() =>
                                 decl.after(
                                     decl.clone({


### PR DESCRIPTION
- renamed `rawAst` to `sourceAst`
- renamed `outputAst` to `targetAst`
- removed `ast` property