### PR TITLE
fix: cachedProcessFile should not based on mtime

### DIFF
--- a/packages/core/src/cached-process-file.ts
+++ b/packages/core/src/cached-process-file.ts
@@ -2,42 +2,39 @@ export type processFn<T> = (fullpath: string, content: string) => T;
 
 export interface CacheItem<T> {
     value: T;
-    stat: { mtime: Date };
+    content: string;
 }
 
 export interface MinimalFS {
-    statSync: (fullpath: string) => { mtime: Date };
-    readFileSync: (fullpath: string, encoding: 'utf8') => string;
-    readlinkSync: (fullpath: string) => string;
+    statSync: (filePath: string) => { mtime: Date };
+    readFileSync: (filePath: string, encoding: 'utf8') => string;
+    readlinkSync: (filePath: string) => string;
 }
 
 export interface FileProcessor<T> {
-    process: (fullpath: string, invalidateCache?: boolean) => T;
-    add: (fullpath: string, value: T) => void;
-    processContent: (content: string, fullpath: string) => T;
+    process: (filePath: string, invalidateCache?: boolean) => T;
+    add: (filePath: string, value: T) => void;
+    processContent: (content: string, filePath: string) => T;
     cache: Record<string, CacheItem<T>>;
     postProcessors: Array<(value: T, path: string) => T>;
 }
 
 export function cachedProcessFile<T = any>(
     processor: processFn<T>,
-    fs: MinimalFS,
+    readFileSync: MinimalFS['readFileSync'],
     postProcessors: Array<(value: T, path: string) => T> = [],
     cache: { [key: string]: CacheItem<T> } = {}
 ): FileProcessor<T> {
-    function process(fullpath: string, invalidateCache = false) {
-        const stat = fs.statSync(fullpath);
-        const cached = cache[fullpath];
-        if (
-            invalidateCache ||
-            !cached ||
-            (cached && cached.stat.mtime.valueOf() !== stat.mtime.valueOf())
-        ) {
-            const content = fs.readFileSync(fullpath, 'utf8');
-            const value = processContent(content, fullpath);
-            cache[fullpath] = { value, stat: { mtime: stat.mtime } };
+    function process(filePath: string, invalidateCache = false) {
+        const content = readFileSync(filePath, 'utf8');
+        const cached = cache[filePath];
+        if (invalidateCache || !cached || (cached && cached.content !== content)) {
+            cache[filePath] = {
+                value: processContent(content, filePath),
+                content,
+            };
         }
-        return cache[fullpath].value;
+        return cache[filePath].value;
     }
 
     function processContent(content: string, filePath: string): T {
@@ -47,18 +44,16 @@ export function cachedProcessFile<T = any>(
         );
     }
 
-    function add(fullpath: string, value: T) {
-        let mtime;
+    function add(filePath: string, value: T) {
+        let content;
         try {
-            mtime = fs.statSync(fullpath).mtime;
+            content = readFileSync(filePath, 'utf8');
         } catch (e) {
-            mtime = new Date();
+            content = '';
         }
-        cache[fullpath] = {
+        cache[filePath] = {
             value,
-            stat: {
-                mtime,
-            },
+            content,
         };
     }
 

--- a/packages/core/src/create-stylable-processor.ts
+++ b/packages/core/src/create-stylable-processor.ts
@@ -25,22 +25,8 @@ export function createStylableFileProcessor({
                 cssParser(content, { from })
             );
         },
-        {
-            readFileSync(resolvedPath: string) {
-                return fileSystem.readFileSync(resolvedPath, 'utf8');
-            },
-            statSync(resolvedPath: string) {
-                const stat = fileSystem.statSync(resolvedPath);
-                if (!stat.mtime) {
-                    return {
-                        mtime: new Date(0),
-                    };
-                }
-                return stat;
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
+        (resolvedPath: string) => {
+            return fileSystem.readFileSync(resolvedPath, 'utf8');
         },
         onProcess && [onProcess],
         cache

--- a/packages/core/test/cached-process-file.spec.ts
+++ b/packages/core/test/cached-process-file.spec.ts
@@ -1,29 +1,19 @@
 import { expect } from 'chai';
-import { cachedProcessFile, MinimalFS } from '@stylable/core';
+import { cachedProcessFile } from '@stylable/core';
 
 describe('cachedProcessFile', () => {
     it('return process file content', () => {
         const file = 'C:/file.txt';
-        const fs: MinimalFS = {
-            readFileSync(fullpath: string) {
-                if (fullpath === file) {
-                    return 'content';
-                }
-                return '';
-            },
-            statSync() {
-                return {
-                    mtime: new Date(0),
-                } as any;
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
+        function readFileSync(fullpath: string) {
+            if (fullpath === file) {
+                return 'content';
+            }
+            return '';
+        }
 
         const p = cachedProcessFile((_fullpath, content) => {
             return content + '!';
-        }, fs);
+        }, readFileSync);
 
         expect(p.process(file)).to.equal('content!');
     });
@@ -31,77 +21,28 @@ describe('cachedProcessFile', () => {
     it('not process file if not changed', () => {
         const file = 'C:/file.txt';
         let res: {};
-        const fs: MinimalFS = {
-            readFileSync(fullpath: string) {
-                if (fullpath === file) {
-                    return 'content';
-                }
-                return '';
-            },
-            statSync() {
-                return {
-                    mtime: new Date(0),
-                };
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
+        function readFileSync(fullpath: string) {
+            if (fullpath === file) {
+                return 'content';
+            }
+            return '';
+        }
 
         const p = cachedProcessFile((fullpath, content) => {
             const processed = { content, fullpath };
             res = res ? res : processed;
             return processed;
-        }, fs);
+        }, readFileSync);
 
         expect(p.process(file)).to.equal(p.process(file));
     });
 
-    it('not read file if not changed', () => {
-        const file = 'C:/file.txt';
-
-        let count = 0;
-
-        const fs: MinimalFS = {
-            readFileSync(fullpath: string) {
-                count++;
-                return fullpath;
-            },
-            statSync() {
-                return {
-                    mtime: new Date(0),
-                };
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
-
-        const p = cachedProcessFile(() => null, fs);
-        p.process(file);
-        p.process(file);
-        p.process(file);
-        expect(count).to.equal(1);
-    });
-
     it('should accept post processors used in process and processContent', () => {
         const file = 'C:/file.txt';
-
-        const fs: MinimalFS = {
-            readFileSync(fullpath: string) {
-                return fullpath;
-            },
-            statSync() {
-                return {
-                    mtime: new Date(0),
-                };
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
-
-        const p = cachedProcessFile(() => 'Hello', fs, [
+        function readFileSync(fullpath: string) {
+            return fullpath;
+        }
+        const p = cachedProcessFile(() => 'Hello', readFileSync, [
             (content) => {
                 return content + '!post-processor';
             },
@@ -114,25 +55,14 @@ describe('cachedProcessFile', () => {
 
     it('should accept cache', () => {
         const file = 'C:/file.txt';
-        const mtime = new Date(0);
-        const fs: MinimalFS = {
-            readFileSync(fullpath: string) {
-                return fullpath;
-            },
-            statSync() {
-                return {
-                    mtime,
-                };
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
+        function readFileSync(fullpath: string) {
+            return fullpath;
+        }
 
-        const p = cachedProcessFile(() => 'Hello', fs, [], {
+        const p = cachedProcessFile(() => 'Hello', readFileSync, [], {
             [file]: {
                 value: 'FROM CACHE',
-                stat: { mtime },
+                content: file,
             },
         });
 
@@ -148,26 +78,12 @@ describe('cachedProcessFile', () => {
 
         let readCount = 0;
         let processCount = 0;
-
-        const fs: MinimalFS = {
-            readFileSync() {
-                readCount++;
-                return '';
-            },
-            statSync() {
-                return {
-                    mtime: readCount === 0 ? new Date(0) : new Date(1),
-                };
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
-
+        function readFileSync() {
+            return String(readCount++);
+        }
         const p = cachedProcessFile(() => {
-            processCount++;
-            return null;
-        }, fs);
+            return String(processCount++);
+        }, readFileSync);
 
         p.process(file);
         p.process(file);
@@ -182,25 +98,14 @@ describe('cachedProcessFile', () => {
         let readCount = 0;
         let processCount = 0;
 
-        const fs: MinimalFS = {
-            readFileSync() {
-                readCount++;
-                return '';
-            },
-            statSync() {
-                return {
-                    mtime: readCount === 0 ? new Date(0) : new Date(1),
-                };
-            },
-            readlinkSync() {
-                throw new Error(`not implemented`);
-            },
-        };
+        function readFileSync() {
+            return String(readCount++);
+        }
 
         const p = cachedProcessFile(() => {
             processCount++;
             return null;
-        }, fs);
+        }, readFileSync);
 
         p.process(file);
         p.process(file);

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -19,9 +19,12 @@ function createResolveExtendsResults(
 ) {
     const moduleResolver = createDefaultResolver(fs, {});
 
-    const processFile = cachedProcessFile<StylableMeta>((fullpath, content) => {
-        return process(cssParse(content, { from: fullpath }));
-    }, fs);
+    const processFile = cachedProcessFile<StylableMeta>(
+        (fullpath, content) => {
+            return process(cssParse(content, { from: fullpath }));
+        },
+        (filePath: string) => fs.readFileSync(filePath, 'utf8')
+    );
 
     const resolver = new StylableResolver(
         processFile,


### PR DESCRIPTION
After noticing mtime based cache can lead to unexpected false negative.
This PR removes the mtime based caching in the cachedProcessFile 