### PR TITLE
fix(language-service): filter out false diagnostics for st-scope selectors with special characters

### DIFF
--- a/packages/core/src/helpers/ast.ts
+++ b/packages/core/src/helpers/ast.ts
@@ -1,0 +1,26 @@
+import type * as postcss from 'postcss';
+
+// ToDo check empty file (position 0)
+export function getAstNodeAt(
+    root: postcss.Root,
+    offset: number
+): [node: postcss.AnyNode, offsetInNode: number] {
+    let closestNode: postcss.AnyNode = root;
+    let offsetInNode = 0;
+
+    root.walk((node) => {
+        if (node.source?.start && node.source?.end) {
+            const inNode =
+                node.source.start.offset <= offset && node.source.end.offset + 1 >= offset;
+            if (!inNode) {
+                // out of node: bailout
+                return false;
+            }
+            closestNode = node;
+            offsetInNode = offset - node.source.start.offset;
+        }
+        return;
+    });
+
+    return [closestNode, offsetInNode];
+}

--- a/packages/core/src/index-internal.ts
+++ b/packages/core/src/index-internal.ts
@@ -1,4 +1,5 @@
 export { safeParse } from './parser';
+export { getAstNodeAt } from './helpers/ast';
 export { process } from './stylable-processor';
 export { StylableTransformer } from './stylable-transformer';
 export type { MappedStates } from './features';

--- a/packages/core/test/helpers/ast.spec.ts
+++ b/packages/core/test/helpers/ast.spec.ts
@@ -1,0 +1,168 @@
+import { expect } from 'chai';
+import { parse } from 'postcss';
+import { getAstNodeAt } from '@stylable/core/dist/helpers/ast';
+import deindent from 'deindent';
+
+function setupWithCursor(source: string) {
+    const deindented = deindent(source);
+
+    const position = deindented.indexOf(`|`);
+    return {
+        position,
+        ast: parse(deindented.split(`|`).join(``)),
+    };
+}
+
+// ToDo: make added syntax zero space: semicolon at declaration end
+describe('helpers/ast', () => {
+    describe(`getAstNodeAt`, () => {
+        it(`should find position in declaration property (start)`, () => {
+            const { position, ast } = setupWithCursor(`
+                .selector {
+                    |decl: declValue;
+                }
+            `);
+
+            const [node, offsetInNode] = getAstNodeAt(ast, position);
+
+            expect(node, 'node').to.equal((ast as any).nodes[0].nodes[0]);
+            expect(offsetInNode, 'offset').to.equal(0);
+        });
+        it(`should find position in declaration value (end)`, () => {
+            const { position, ast } = setupWithCursor(`
+                .selector {
+                    decl1: declValue|;decl2: otherValue;
+                }
+            `);
+
+            const [node, offsetInNode] = getAstNodeAt(ast, position);
+            // ToDo: change to return value ast node
+            expect(node, 'node').to.equal((ast as any).nodes[0].nodes[0]);
+            expect(offsetInNode, 'offset').to.equal(16);
+        });
+        it(`should find position in declaration property (end)`, () => {
+            const { position, ast } = setupWithCursor(`
+                .selector {
+                    decl|: declValue;
+                }
+            `);
+
+            const [node, offsetInNode] = getAstNodeAt(ast, position);
+
+            expect(node, 'node').to.equal((ast as any).nodes[0].nodes[0]);
+            expect(offsetInNode, 'offset').to.equal(4);
+        });
+        it(`should find position in rule body (start)`, () => {
+            const { position, ast } = setupWithCursor(`
+                .selector {|
+                    decl: declValue;
+                }
+            `);
+
+            const [node, offsetInNode] = getAstNodeAt(ast, position);
+
+            expect(node, 'node').to.equal((ast as any).nodes[0]);
+            expect(offsetInNode, 'offset').to.equal(11);
+        });
+        it(`should find position in rule body (before declaration)`, () => {
+            const { position, ast } = setupWithCursor(`
+                .selector {
+                   | decl: declValue;
+                }
+            `);
+
+            const [node, offsetInNode] = getAstNodeAt(ast, position);
+
+            expect(node, 'node').to.equal((ast as any).nodes[0]);
+            expect(offsetInNode, 'offset').to.equal(15);
+        });
+    });
+
+    xdescribe(`parseForInspection (safe parse)`, () => {
+        // describe(`selector`, () => {
+        //     it.skip(`should close rule`, () => {
+        //         const ast = parseForInspection(`
+        //             .selector
+        //         `);
+        //         expect(ast.toString()).to.equal(
+        //             fullParse(`
+        //             .selector{}
+        //         `).toString()
+        //         );
+        //     });
+        //     it.skip(`should close final multiple rules`, () => {
+        //         const ast = parseForInspection(`
+        //             .selectorA
+        //             .selectorB
+        //         `);
+        //         expect(ast.toString()).to.equal(
+        //             fullParse(`
+        //             .selectorA
+        //             .selectorB{}
+        //         `).toString()
+        //         );
+        //     });
+        //     it.skip(`should close multiple unclosed selectors`, () => {
+        //         const ast = parseForInspection(`
+        //             .selectorA
+        //             ,
+        //             .selectorB
+        //         `);
+        //         expect(ast.toString()).to.equal(
+        //             fullParse(`
+        //             .selectorA
+        //             ,
+        //             .selectorB{}
+        //         `).toString()
+        //         );
+        //     });
+        //     it.skip(`should close opened at rule`, () => {
+        //         const ast = parseForInspection(`
+        //             @someatrule
+        //         `);
+        //         expect(ast.toString(), `fixed source`).to.equal(
+        //             fullParse(`
+        //             @someatrule
+        //         `).toString()
+        //         );
+        //         expect(ast.nodes.length, `rules amount`).to.equal(1);
+        //         expect(ast.nodes[0], `rules amount`).to.contain({
+        //             type: `atrule`,
+        //             name: `someatrule`,
+        //         });
+        //     });
+        // });
+        // describe(`declaration`, () => {
+        //     it(`should find position in standalone prop (declOrRule)`, () => {
+        //         const { position, ast } = setupWithCursor(`
+        //             .selector {
+        //                 decl|
+        //             }
+        //         `);
+        //         const [node, offsetInNode] = getAstNodeAt(ast, position);
+        //         expect(node, 'node').to.equal((ast as any).nodes[0].nodes[0]);
+        //         expect(offsetInNode, 'offset').to.equal(4);
+        //     });
+        //     it.skip(`should find position in empty value (unclosed)`, () => {
+        //         // const { position, ast } = setupWithCursor(`
+        //         //     .selector {
+        //         //         decl:|
+        //         //     }
+        //         // `);
+        //         // const [node, offsetInNode] = getAstNodeAt(ast, position);
+        //         // expect(node, 'node').to.equal((ast as any).nodes[0].nodes[0].valueAst);
+        //         // expect(offsetInNode, 'offset').to.equal(0);
+        //     });
+        //     it(`should find property for empty property`, () => {
+        //         const { position, ast } = setupWithCursor(`
+        //             .selector {
+        //                 |: value;
+        //             }
+        //         `);
+        //         const [node, offsetInNode] = getAstNodeAt(ast, position);
+        //         expect(node, 'node').to.equal((ast as any).nodes[0].nodes[0]);
+        //         expect(offsetInNode, 'offset').to.equal(0);
+        //     });
+        // });
+    });
+});

--- a/packages/language-service/src/lib/diagnosis.ts
+++ b/packages/language-service/src/lib/diagnosis.ts
@@ -26,12 +26,14 @@ export function createDiagnosis(
     return meta.diagnostics.reports
         .concat(meta.transformDiagnostics ? meta.transformDiagnostics.reports : [])
         .map(reportToDiagnostic)
-        .concat(cssService.getDiagnostics(cleanDoc));
+        .concat(cssService.getDiagnostics(cleanDoc, meta));
 
     // stylable diagnostic to protocol diagnostic
     function reportToDiagnostic(report: StylableDiagnostic) {
         const severity = report.type === 'error' ? 1 : 2;
         const range = createRange(report);
+
+        // todo: incorporate diagnostics code in v5
         return Diagnostic.create(range, report.message, severity, undefined, 'stylable');
     }
 }

--- a/packages/language-service/src/lib/utils/postcss-ast-utils.ts
+++ b/packages/language-service/src/lib/utils/postcss-ast-utils.ts
@@ -147,7 +147,8 @@ export function getAtRuleByPosition(
     return res;
 }
 
-export function getPositionInSrc(src: string, position: ProviderPosition) {
+// todo rename this function
+export function getOffsetFromPosition(src: string, position: ProviderPosition) {
     const lines = src.split('\n');
     return (
         lines.slice(0, position.line).reduce((total: number, line) => line.length + total + 1, -1) +

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -3,6 +3,7 @@ import { Stylable } from '@stylable/core';
 import { safeParse } from '@stylable/core/dist/index-internal';
 import { StylableLanguageService } from '@stylable/language-service';
 import { expect } from 'chai';
+import deindent from 'deindent';
 import { createDiagnostics } from '../test-kit/diagnostics-setup';
 
 describe('diagnostics', () => {
@@ -161,6 +162,40 @@ describe('diagnostics', () => {
                     
                     @media value(size) {
                         .part{}
+                    }
+                    `,
+                },
+                filePath
+            );
+
+            expect(diagnostics).to.eql([]);
+        });
+
+        it('should ignore errors for attribute selectors inside @st-scope', () => {
+            const filePath = '/style.st.css';
+
+            const diagnostics = createDiagnostics(
+                {
+                    [filePath]: deindent`
+                    @st-scope [div=rtl] {
+                         .root {}
+                    }
+                    `,
+                },
+                filePath
+            );
+
+            expect(diagnostics).to.eql([]);
+        });
+
+        it('should ignore errors for "*" selectors inside @st-scope', () => {
+            const filePath = '/style.st.css';
+
+            const diagnostics = createDiagnostics(
+                {
+                    [filePath]: deindent`
+                    @st-scope * {
+                         .root {}
                     }
                     `,
                 },

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -171,7 +171,7 @@ describe('diagnostics', () => {
             expect(diagnostics).to.eql([]);
         });
 
-        it('should ignore errors for attribute selectors inside @st-scope', () => {
+        it('should ignore native css lsp diagnostics for selectors with special characters inside @st-scope params', () => {
             const filePath = '/style.st.css';
 
             const diagnostics = createDiagnostics(
@@ -180,22 +180,9 @@ describe('diagnostics', () => {
                     @st-scope [div=rtl] {
                          .root {}
                     }
-                    `,
-                },
-                filePath
-            );
 
-            expect(diagnostics).to.eql([]);
-        });
-
-        it('should ignore errors for "*" selectors inside @st-scope', () => {
-            const filePath = '/style.st.css';
-
-            const diagnostics = createDiagnostics(
-                {
-                    [filePath]: deindent`
                     @st-scope * {
-                         .root {}
+                        .root {}
                     }
                     `,
                 },


### PR DESCRIPTION
Resolves #2200