### PR TITLE
feat(core): override st-vars with transformer options

### DIFF
--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -142,6 +142,7 @@ export const hooks = createFeature<{
         for (const name of Object.keys(symbols)) {
             const symbol = symbols[name];
             const evaluated = context.evaluator.evaluateValue(noDaigContext, {
+                // ToDo: change to `value(${name})` in order to fix overrides in exports
                 value: stripQuotation(symbol.text),
                 meta: context.meta,
                 node: symbol.node,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -95,6 +95,7 @@ export interface TransformerOptions {
     postProcessor?: postProcessor;
     mode?: EnvMode;
     resolverCache?: StylableResolverCache;
+    stVarOverride?: Record<string, string>;
 }
 
 export const transformerDiagnostics = {
@@ -113,6 +114,7 @@ export class StylableTransformer {
     public replaceValueHook: replaceValueHook | undefined;
     public postProcessor: postProcessor | undefined;
     public mode: EnvMode;
+    private defaultStVarOverride: Record<string, string>;
     private evaluator: StylableEvaluator = new StylableEvaluator();
     private getResolvedSymbols: ReturnType<typeof createSymbolResolverWithCache>;
 
@@ -129,6 +131,7 @@ export class StylableTransformer {
             options.resolverCache || new Map()
         );
         this.mode = options.mode || 'production';
+        this.defaultStVarOverride = options.stVarOverride || {};
         this.getResolvedSymbols = createSymbolResolverWithCache(this.resolver, this.diagnostics);
     }
     public transform(meta: StylableMeta): StylableResults {
@@ -160,7 +163,7 @@ export class StylableTransformer {
         ast: postcss.Root,
         meta: StylableMeta,
         metaExports?: StylableExports,
-        stVarOverride?: Record<string, string>,
+        stVarOverride: Record<string, string> = this.defaultStVarOverride,
         path: string[] = [],
         mixinTransform = false,
         topNestClassName = ``

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -145,19 +145,21 @@ export class Stylable {
             ...options,
         });
     }
+    // ToDo: unify signature - accept only meta + optional transformer options
     public transform(meta: StylableMeta): StylableResults;
     public transform(source: string, resourcePath: string): StylableResults;
     public transform(
-        meta: string | StylableMeta,
+        metaOrSource: string | StylableMeta,
         resourcePath?: string,
         options: Partial<TransformerOptions> = {},
         processorOptions: CreateProcessorOptions = {}
     ): StylableResults {
-        if (typeof meta === 'string') {
-            meta = this.createProcessor(processorOptions).process(
-                this.cssParser(meta, { from: resourcePath })
-            );
-        }
+        const meta =
+            typeof metaOrSource === 'string'
+                ? this.createProcessor(processorOptions).process(
+                      this.cssParser(metaOrSource, { from: resourcePath })
+                  )
+                : metaOrSource;
         const transformer = this.createTransformer(options);
         this.fileProcessor.add(meta.source, meta);
         return transformer.transform(meta);

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -132,6 +132,34 @@ describe('Stylable', () => {
                 value: `var(--entry-x) jump`,
             });
         });
+        it(`should transform declaration prop/value with override st-vars`, () => {
+            const path = `/entry.st.css`;
+            const { stylable } = testStylableCore({
+                [path]: `
+                    :vars {
+                        x: red;
+                        a: value(x);
+                        b: blue;
+                    }
+                `,
+            });
+
+            const declAnimation = stylable.transformDecl(
+                path,
+                `prop`,
+                `value(a) value(b) value(x)`,
+                {
+                    stVarOverride: {
+                        x: 'green',
+                    },
+                }
+            );
+
+            expect(declAnimation, `animation context`).to.eql({
+                prop: `prop`,
+                value: `green blue green`,
+            });
+        });
         it(`should transform custom property`, () => {
             const path = `/entry.st.css`;
             const { stylable } = testStylableCore({


### PR DESCRIPTION
This PR adds the ability to pass override stylable vars through transformer options using a new `stVarOverride` arg. This is useful for the new top level APIs: `stylable.transform` and `stylable.transformDecl` that were missing the ability that existed previously when accessing the transformer directly.