### PR TITLE
fix(core): unescape intended quotes in mix arg

### DIFF
--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -14,6 +14,7 @@ import {
 } from './stylable-resolver';
 import type { replaceValueHook, RuntimeStVar, StylableTransformer } from './stylable-transformer';
 import { getFormatterArgs, getStringValue, stringifyFunction } from './helpers/value';
+import { unescapeCSS } from './helpers/escape';
 import type { ParsedValue } from './types';
 import type { FeatureTransformContext } from './features/feature';
 import { CSSCustomProperty, STVar } from './features';
@@ -92,7 +93,7 @@ export function resolveArgumentsValue(
     for (const k in options) {
         resolvedArgs[k] = evalDeclarationValue(
             transformer.resolver,
-            options[k],
+            unescapeCSS(options[k]),
             meta,
             node,
             variableOverride,

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -1572,7 +1572,7 @@ describe(`features/st-mixin`, () => {
 
             shouldReportNoDiagnostics(meta);
         });
-        it(`should override vars with comma values`, () => {
+        it(`should un-escape override arguments`, () => {
             const { sheets } = testStylableCore(`
                 :vars {
                     color: red;

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -1572,6 +1572,33 @@ describe(`features/st-mixin`, () => {
 
             shouldReportNoDiagnostics(meta);
         });
+        it(`should override vars with comma values`, () => {
+            const { sheets } = testStylableCore(`
+                :vars {
+                    color: red;
+                    font: Arial;
+                }
+                .mix {
+                    color: value(color);
+                    font-family: value(font);
+                }
+                
+                /* @rule .entry__groot {
+                    color: blue;
+                    font-family: "Avenir Next", Arial;
+                } */
+                .groot {
+                    -st-mixin: mix(
+                        font "\\"Avenir Next\\", Arial",
+                        color blue
+                    );
+                }
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
         it(`should override vars that are used as override `, () => {
             const { sheets } = testStylableCore({
                 '/mix.st.css': `


### PR DESCRIPTION
This PR fixes the bug reported in #2553 - by un-escaping mixin arguments before applying them.