### PR TITLE
fix(webpack-plugin): preserve duplicate used/unused conflict

### DIFF
--- a/packages/webpack-plugin/src/plugin-utils.ts
+++ b/packages/webpack-plugin/src/plugin-utils.ts
@@ -440,7 +440,10 @@ export function createOptimizationMapping(
     return sortedModules.reduce<OptimizationMapping>(
         (acc, module) => {
             const { namespace, isUsed } = getStylableBuildMeta(module);
-            acc.usageMapping[namespace] = isUsed ?? true;
+
+            if (!acc.usageMapping[namespace]) {
+                acc.usageMapping[namespace] = isUsed ?? true;
+            }
             acc.namespaceMapping[namespace] = optimizer.getNamespace(namespace);
             if (acc.namespaceToFileMapping.has(namespace)) {
                 acc.namespaceToFileMapping.get(namespace)!.add(module);

--- a/packages/webpack-plugin/test/e2e/duplicate-namespace-perserve-modules.spec.ts
+++ b/packages/webpack-plugin/test/e2e/duplicate-namespace-perserve-modules.spec.ts
@@ -1,0 +1,43 @@
+import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { dirname } from 'path';
+
+const project = 'duplicate-namespace-perserve-modules';
+const projectDir = dirname(
+    require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
+);
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir,
+            launchOptions: {
+                devtools: true,
+
+                headless: false,
+            },
+            throwOnBuildError: false,
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('renders css', async () => {
+        // this fixture is pretty test specific, and depends on the module depth sorting order
+        const { page } = await projectRunner.openInBrowser();
+        const styleElements = await page.evaluate(browserFunctions.getStyleElementsMetadata);
+        const origins = await page.evaluate(() => {
+            return {
+                used: getComputedStyle(document.documentElement).color,
+                // expecting unused to be dropped
+                unused: getComputedStyle(document.documentElement).backgroundColor,
+            };
+        });
+
+        expect(origins.used, 'used should be included').to.eql('rgb(0, 128, 0)');
+        expect(origins.unused, 'unused should be dropped').to.not.eql('rgb(255, 0, 0)');
+
+        expect(styleElements).to.eql([{ id: './src/used.st.css', depth: '2' }]);
+    });
+});

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/src/index.js
@@ -1,0 +1,4 @@
+// "used" points to the "unused" module, both have the same identical namespace, due to webpack configuration
+import { classes as used } from './used.st.css';
+
+document.documentElement.classList.add(used.root);

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/src/unused.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/src/unused.st.css
@@ -1,0 +1,3 @@
+.root {
+    background: red;
+}

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/src/used.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/src/used.st.css
@@ -1,0 +1,5 @@
+@st-import Unused from "./unused.st.css";
+
+.root {
+    color: green;
+}

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-perserve-modules/webpack.config.js
@@ -1,0 +1,20 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [
+        new StylableWebpackPlugin({
+            stylableConfig(config) {
+                return {
+                    ...config,
+                    resolveNamespace: () => 'hardcodedNS',
+                };
+            },
+        }),
+        new HtmlWebpackPlugin(),
+    ],
+};


### PR DESCRIPTION
In a complex project using complex namespacing strategies - we have encountered a situation where there is a duplicate module that in one case appears to be used, and in the other, appears to be unused - this caused our optimizer to drop the used module. 

This fix should preserve any conflicting module that is `used` so that it is included in the final output.