### PR TITLE
refactor(templates): enable react/jsx-runtime

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/.eslintrc
+++ b/packages/create-stylable-app/template/ts-react-rollup/.eslintrc
@@ -7,6 +7,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:stylable/recommended",
     "prettier"
   ],
@@ -21,8 +22,7 @@
     "no-console": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
-    "react/prop-types": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/prop-types": "off"
   },
   "overrides": [
     {

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/.eslintrc
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/.eslintrc
@@ -7,6 +7,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:stylable/recommended",
     "prettier"
   ],
@@ -21,8 +22,7 @@
     "no-console": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
-    "react/prop-types": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/prop-types": "off"
   },
   "overrides": [
     {

--- a/packages/create-stylable-app/template/ts-react-webpack/.eslintrc
+++ b/packages/create-stylable-app/template/ts-react-webpack/.eslintrc
@@ -7,6 +7,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:stylable/recommended",
     "prettier"
   ],
@@ -21,8 +22,7 @@
     "no-console": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
-    "react/prop-types": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/prop-types": "off"
   },
   "overrides": [
     {


### PR DESCRIPTION
instead of explicitly turning off "react/react-in-jsx-scope".

see:
https://github.com/jsx-eslint/eslint-plugin-react#configuration
https://github.com/jsx-eslint/eslint-plugin-react/blob/b9aa04b10d9bb0b7274ad314ca125ddefd9fbdb3/index.js#L171