### PR TITLE
feat: load stylable.config.cjs as well

### DIFF
--- a/packages/build-tools/src/load-stylable-config.ts
+++ b/packages/build-tools/src/load-stylable-config.ts
@@ -4,7 +4,9 @@ export function loadStylableConfig<T>(
     context: string,
     extract: (config: any) => T
 ): { path: string; config: T } | undefined {
-    const path = findConfig('stylable.config.js', { cwd: context });
+    const path =
+        findConfig('stylable.config.js', { cwd: context }) ??
+        findConfig('stylable.config.cjs', { cwd: context });
     let config;
     if (path) {
         try {

--- a/packages/cli/test/config-options.spec.ts
+++ b/packages/cli/test/config-options.spec.ts
@@ -78,6 +78,35 @@ describe('Stylable CLI config file options', function () {
         ]);
     });
 
+    it('picks up stylable.config.cjs', () => {
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            'style.st.css': `.root{color:red}`,
+            'stylable.config.cjs': `
+                  exports.stcConfig = { 
+                      options: { 
+                            outDir: './dist',
+                            cjs: false,
+                            esm: true,
+                        } 
+                    }
+                `,
+        });
+
+        const { stdout, stderr } = runCliSync(['--rootDir', tempDir.path]);
+        const dirContent = loadDirSync(tempDir.path);
+
+        expect(stderr, 'has cli error').not.to.match(/error/i);
+        expect(stdout, 'has diagnostic error').not.to.match(/error/i);
+
+        expect(Object.keys(dirContent)).to.eql([
+            'dist/style.st.css.mjs',
+            'package.json',
+            'stylable.config.cjs',
+            'style.st.css',
+        ]);
+    });
+
     it('should override config file from cli arguments', () => {
         populateDirectorySync(tempDir.path, {
             'package.json': `{"name": "test", "version": "0.0.0"}`,


### PR DESCRIPTION
to better support projects that move to "type": "module" (in package.json), allow stylable configuration file to be named stylable.config.cjs (exporting a commonjs module).

unfortunatly, stylable cannot currently support mjs config. the config loading function is sync, and we would need to import() that file if we want to support mjs.