### PR TITLE
feat(core): public transform class API

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -167,7 +167,7 @@ export const hooks = createFeature<{
 
 export class StylablePublicApi {
     constructor(private stylable: Stylable) {}
-    public transformToSelector(meta: StylableMeta, name: string): string | undefined {
+    public transformIntoSelector(meta: StylableMeta, name: string): string | undefined {
         const localSymbol = STSymbol.get(meta, name);
         const resolved =
             localSymbol?._kind === 'import'

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -11,11 +11,13 @@ import { namespaceEscape, unescapeCSS } from '../helpers/escape';
 import { convertToSelector, convertToClass, stringifySelector } from '../helpers/selector';
 import type { StylableMeta } from '../stylable-meta';
 import { validateRuleStateDefinition } from '../helpers/custom-state';
-import type {
+import type { Stylable } from '../stylable';
+import {
     ImmutableClass,
     Class,
     SelectorNode,
     ImmutableSelectorNode,
+    stringifySelectorAst,
 } from '@tokey/css-selector-parser';
 import type * as postcss from 'postcss';
 import { createDiagnosticReporter } from '../diagnostics';
@@ -162,6 +164,31 @@ export const hooks = createFeature<{
 });
 
 // API
+
+export class StylablePublicApi {
+    constructor(private stylable: Stylable) {}
+    public transformToSelector(meta: StylableMeta, name: string): string | undefined {
+        const localSymbol = STSymbol.get(meta, name);
+        const resolved =
+            localSymbol?._kind === 'import'
+                ? this.stylable.resolver.deepResolve(localSymbol)
+                : { _kind: 'css', meta, symbol: localSymbol };
+
+        if (resolved?._kind !== 'css' || resolved.symbol?._kind !== 'class') {
+            return undefined;
+        }
+
+        const node: Class = {
+            type: 'class',
+            value: '',
+            start: 0,
+            end: 0,
+            dotComments: [],
+        };
+        namespaceClass(resolved.meta, resolved.symbol, node, meta);
+        return stringifySelectorAst(node);
+    }
+}
 
 export function get(meta: StylableMeta, name: string): ClassSymbol | undefined {
     return STSymbol.get(meta, name, `class`);

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -14,7 +14,7 @@ import {
 } from './stylable-transformer';
 import type { IStylableOptimizer, ModuleResolver } from './types';
 import { createDefaultResolver } from './module-resolver';
-import { STImport, STVar, STMixin, CSSCustomProperty } from './features';
+import { STImport, STVar, STMixin, CSSClass, CSSCustomProperty } from './features';
 import { Dependency, visitMetaCSSDependencies } from './visit-meta-css-dependencies';
 import * as postcss from 'postcss';
 
@@ -51,6 +51,7 @@ export class Stylable {
     public stModule = new STImport.StylablePublicApi(this);
     public stVar = new STVar.StylablePublicApi(this);
     public stMixin = new STMixin.StylablePublicApi(this);
+    public cssClass = new CSSClass.StylablePublicApi(this);
     //
     public projectRoot: string;
     protected fileSystem: MinimalFS;

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -1115,14 +1115,14 @@ describe(`features/css-class`, () => {
 
             // ToDo: fix :global(.class) not registering as symbol?
 
-            expect(api.transformToSelector(meta, 'a'), 'local class').to.eql('.entry__a');
-            // expect(api.transformToSelector(meta, 'b'), 'local global class').to.eql('.b');
-            expect(api.transformToSelector(meta, 'c'), 'local mapped class').to.eql('[attr=c]');
-            expect(api.transformToSelector(meta, 'unknown'), 'unknown class').to.eql(undefined);
-            expect(api.transformToSelector(meta, 'not-a-class'), 'not class').to.eql(undefined);
-            expect(api.transformToSelector(meta, 'ext-x'), 'imported class').to.eql('.other__x');
-            // expect(api.transformToSelector(meta, 'ext-y'), 'imported global class').to.eql('.y');
-            expect(api.transformToSelector(meta, 'ext-z'), 'imported mapped class').to.eql(
+            expect(api.transformIntoSelector(meta, 'a'), 'local class').to.eql('.entry__a');
+            // expect(api.transformIntoSelector(meta, 'b'), 'local global class').to.eql('.b');
+            expect(api.transformIntoSelector(meta, 'c'), 'local mapped class').to.eql('[attr=c]');
+            expect(api.transformIntoSelector(meta, 'unknown'), 'unknown class').to.eql(undefined);
+            expect(api.transformIntoSelector(meta, 'not-a-class'), 'not class').to.eql(undefined);
+            expect(api.transformIntoSelector(meta, 'ext-x'), 'imported class').to.eql('.other__x');
+            // expect(api.transformIntoSelector(meta, 'ext-y'), 'imported global class').to.eql('.y');
+            expect(api.transformIntoSelector(meta, 'ext-z'), 'imported mapped class').to.eql(
                 '[attr=z]'
             );
         });


### PR DESCRIPTION
This PR exposes public API to transform a stylesheet class into its final selector.
- support both local & imported classes
- support global via `-st-global` declaration
- return `undefined` for unknown or non class symbols

> NOTE: passing class name that is declared within global (`:global(.class)`) returns undefined as `:global` selector doesn't register symbols atm.