### PR TITLE
refactor!: simplify `stylable.transform` API (v5)

### DIFF
--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -87,7 +87,7 @@ export function buildSingleFile({
         `Read File Error: ${filePath}`
     );
     const res = tryRun(
-        () => stylable.transform(stylable.analyze(filePath, content)),
+        () => stylable.transform(stylable.analyze(filePath)),
         errorMessages.STYLABLE_PROCESS(filePath)
     );
     const optimizer = new StylableOptimizer();

--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -87,7 +87,7 @@ export function buildSingleFile({
         `Read File Error: ${filePath}`
     );
     const res = tryRun(
-        () => stylable.transform(content, filePath),
+        () => stylable.transform(stylable.analyze(filePath, content)),
         errorMessages.STYLABLE_PROCESS(filePath)
     );
     const optimizer = new StylableOptimizer();

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -146,21 +146,11 @@ export class Stylable {
             ...options,
         });
     }
-    // ToDo: unify signature - accept only meta + optional transformer options
-    public transform(meta: StylableMeta): StylableResults;
-    public transform(source: string, resourcePath: string): StylableResults;
     public transform(
-        metaOrSource: string | StylableMeta,
-        resourcePath?: string,
-        options: Partial<TransformerOptions> = {},
-        processorOptions: CreateProcessorOptions = {}
+        pathOrMeta: string | StylableMeta,
+        options: Partial<TransformerOptions> = {}
     ): StylableResults {
-        const meta =
-            typeof metaOrSource === 'string'
-                ? this.createProcessor(processorOptions).process(
-                      this.cssParser(metaOrSource, { from: resourcePath })
-                  )
-                : metaOrSource;
+        const meta = typeof pathOrMeta === `string` ? this.analyze(pathOrMeta) : pathOrMeta;
         const transformer = this.createTransformer(options);
         this.fileProcessor.add(meta.source, meta);
         return transformer.transform(meta);

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -152,7 +152,6 @@ export class Stylable {
     ): StylableResults {
         const meta = typeof pathOrMeta === `string` ? this.analyze(pathOrMeta) : pathOrMeta;
         const transformer = this.createTransformer(options);
-        this.fileProcessor.add(meta.source, meta);
         return transformer.transform(meta);
     }
     public transformSelector(

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -73,21 +73,23 @@ describe('Stylable', () => {
             );
             expect(defaultTransform.exports.classes.a, `JS export`).to.eql(`entry__a`);
             expect(defaultTransform.exports.stVars.varA, `default var JS export`).to.eql(`red`);
-            // ToDo: run test once stylable.transform is fixed
-            // const varOverrideTransform = stylable.transform(meta, {
-            //     stVarOverride: { varA: 'green' },
-            // });
 
-            // expect(
-            //     deindent(varOverrideTransform.meta.targetAst!.toString()),
-            //     `override vars output CSS`
-            // ).to.eql(
-            //     deindent(`
-            //         .entry__a {
-            //             prop: green;
-            //         }
-            //     `)
-            // );
+            // test with override
+            const varOverrideTransform = stylable.transform(meta, {
+                stVarOverride: { varA: 'green' },
+            });
+
+            expect(
+                deindent(varOverrideTransform.meta.targetAst!.toString()),
+                `override vars output CSS`
+            ).to.eql(
+                deindent(`
+                    .entry__a {
+                        prop: green;
+                    }
+                `)
+            );
+            // ToDo: fix JS export for programmatic override
             // expect(varOverrideTransform.exports.stVars.varA, `override var JS export`).to.eql(
             //     `green`
             // );

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -45,16 +45,6 @@ describe('Stylable', () => {
         });
     });
     describe(`transformation`, () => {
-        it(`should transform a stylesheet by content & path`, () => {
-            const src = `.a {}`;
-            const path = `/entry.st.css`;
-            const { stylable } = testStylableCore({});
-
-            const { meta, exports } = stylable.transform(src, path);
-
-            expect(meta.targetAst?.toString(), `output CSS`).to.eql(`.entry__a {}`);
-            expect(exports.classes.a, `JS export`).to.eql(`entry__a`);
-        });
         it(`should transform a stylesheet from meta`, () => {
             const src = `
                 :vars {
@@ -84,7 +74,7 @@ describe('Stylable', () => {
             expect(defaultTransform.exports.classes.a, `JS export`).to.eql(`entry__a`);
             expect(defaultTransform.exports.stVars.varA, `default var JS export`).to.eql(`red`);
             // ToDo: run test once stylable.transform is fixed
-            // const varOverrideTransform = stylable.transform(meta, '', {
+            // const varOverrideTransform = stylable.transform(meta, {
             //     stVarOverride: { varA: 'green' },
             // });
 

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -71,7 +71,7 @@ const stylableLoader: LoaderDefinition = function (content) {
         resolveNamespace,
     });
 
-    const { meta, exports } = stylable.transform(content, this.resourcePath);
+    const { meta, exports } = stylable.transform(stylable.analyze(this.resourcePath, content));
 
     emitDiagnostics(this, meta, diagnosticsMode);
 

--- a/packages/module-utils/src/module-factory.ts
+++ b/packages/module-utils/src/module-factory.ts
@@ -21,7 +21,8 @@ export function stylableModuleFactory(
 ) {
     const stylable = new Stylable(stylableOptions);
     return function stylableToModule(source: string, path: string) {
-        const res = stylable.transform(source, path);
+        const meta = stylable.analyze(path, source);
+        const res = stylable.transform(meta);
         return generateModuleSource(
             res,
             runtimeStylesheetId === 'module' ? 'module.id' : res.meta.namespace,

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -154,7 +154,7 @@ export function stylableRollupPlugin({
             if (!id.endsWith(ST_CSS)) {
                 return null;
             }
-            const { meta, exports } = stylable.transform(source, id);
+            const { meta, exports } = stylable.transform(stylable.analyze(id, source));
             const assetsIds = emitAssets(this, stylable, meta, emittedAssets, inlineAssets);
             const css = generateCssString(meta, minify, stylable, assetsIds);
             const moduleImports = [];

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -3,7 +3,9 @@ import type { StylableLoaderContext } from './types';
 import { emitDiagnostics } from '@stylable/core/dist/index-internal';
 
 export default function StylableWebpackLoader(this: StylableLoaderContext, source: string) {
-    const { meta, exports } = this.stylable.transform(source, this.resourcePath);
+    const { meta, exports } = this.stylable.transform(
+        this.stylable.analyze(this.resourcePath, source)
+    );
 
     const { urls, imports, buildDependencies, unusedImports } = getImports(
         this.stylable,


### PR DESCRIPTION
This PR simplify the `stylable.transform`:

## simplify input
Change signature from accepting either `meta or source+path` to accepting `meta or path`. The new signature is inline with other top level transform functions like `transformSelector` or `transformDecl`. 

To transform custom source on specific context path now you first need to create a `meta` and pass it to the transform method: `stylable.transform(stylable.analyze(path, source), {/*optional transform options*/})`

This also fix a Typescript issue that the old signature could theoretically accept transform options, but couldn't in reality since they weren't in the typescript signature.

## remove cache on transform

Calling transform used to replace the file processor cache with whatever was passed in. That means that potential override content that was not synced with filesystem would be returned for future calls. This PR changes transform so it doesn't directly change the cache. Only calls to `stylable.analyze(path)` (without override content) caches, and calling `stylable.transform(path)` calls `analyze`.