### PR TITLE
feat(core): public API to get st-scope atrule

### DIFF
--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -69,7 +69,7 @@ function flattenScope(atRule: postcss.AtRule) {
     }
 }
 
-export function getStScope(rule: postcss.Rule): postcss.AtRule | undefined {
+function getStScope(rule: postcss.Rule): postcss.AtRule | undefined {
     let current: postcss.Container | postcss.Document = rule;
     while (current?.parent) {
         current = current.parent;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,3 +37,4 @@ export { createDefaultResolver } from './module-resolver';
 // low-level api
 export { parseModuleImportStatement, ensureModuleImport } from './helpers/import';
 export { validateCustomPropertyName } from './helpers/css-custom-property';
+export { getStScope } from './features/st-scope';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,4 +37,3 @@ export { createDefaultResolver } from './module-resolver';
 // low-level api
 export { parseModuleImportStatement, ensureModuleImport } from './helpers/import';
 export { validateCustomPropertyName } from './helpers/css-custom-property';
-export { getStScope } from './features/st-scope';

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -14,7 +14,7 @@ import {
 } from './stylable-transformer';
 import type { IStylableOptimizer, ModuleResolver } from './types';
 import { createDefaultResolver } from './module-resolver';
-import { STImport, STVar, STMixin, CSSCustomProperty } from './features';
+import { STImport, STScope, STVar, STMixin, CSSCustomProperty } from './features';
 import { Dependency, visitMetaCSSDependencies } from './visit-meta-css-dependencies';
 import * as postcss from 'postcss';
 
@@ -49,6 +49,7 @@ export class Stylable {
     public fileProcessor: FileProcessor<StylableMeta>;
     public resolver: StylableResolver;
     public stModule = new STImport.StylablePublicApi(this);
+    public stScope = new STScope.StylablePublicApi(this);
     public stVar = new STVar.StylablePublicApi(this);
     public stMixin = new STMixin.StylablePublicApi(this);
     //

--- a/packages/core/test/features/st-scope.spec.ts
+++ b/packages/core/test/features/st-scope.spec.ts
@@ -30,7 +30,7 @@ describe(`features/st-scope`, () => {
     // ToDo: move relevant tests here
 
     describe('stylable API', () => {
-        it.only(`should get @st-scope for rule`, () => {
+        it(`should get @st-scope for rule`, () => {
             const { stylable, sheets } = testStylableCore(`
                 @st-scope a {
                     .direct {}

--- a/packages/core/test/features/st-scope.spec.ts
+++ b/packages/core/test/features/st-scope.spec.ts
@@ -1,0 +1,66 @@
+// import { STScope } from '@stylable/core/dist/features';
+import type { StylableMeta } from '@stylable/core';
+import { testStylableCore } from '@stylable/core-test-kit';
+import { expect } from 'chai';
+import type * as postcss from 'postcss';
+
+// const STScopeDiagnostics = diagnosticBankReportToStrings(STScope.diagnostics);
+
+const queryBySelector = (meta: StylableMeta, selector: string): postcss.Rule | undefined => {
+    let match: postcss.Rule | undefined;
+    meta.sourceAst.walkRules((rule) => {
+        if (rule.selector === selector) {
+            match = rule;
+            return false;
+        }
+        return;
+    });
+    return match;
+};
+const queryStScope = (meta: StylableMeta, params: string): postcss.AtRule | undefined => {
+    for (const node of meta.sourceAst.nodes) {
+        if (node.type === 'atrule' && node.name === 'st-scope' && node.params === params) {
+            return node;
+        }
+    }
+    return;
+};
+
+describe(`features/st-scope`, () => {
+    // ToDo: move relevant tests here
+
+    describe('stylable API', () => {
+        it.only(`should get @st-scope for rule`, () => {
+            const { stylable, sheets } = testStylableCore(`
+                @st-scope a {
+                    .direct {}
+                }
+                @st-scope b {
+                    @media screen {
+                        .nested {}
+                    }
+                }
+                top-rule {
+                    @st-scope c {
+                        .error-nested-scope {}
+                    }
+                }
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            expect(
+                stylable.stScope.getStScope(queryBySelector(meta, '.direct')!),
+                'direct'
+            ).to.equal(queryStScope(meta, 'a'));
+            expect(
+                stylable.stScope.getStScope(queryBySelector(meta, '.nested')!),
+                'nested'
+            ).to.equal(queryStScope(meta, 'b'));
+            expect(
+                stylable.stScope.getStScope(queryBySelector(meta, '.error-nested-scope')!),
+                'not-top-level-scope'
+            ).to.equal(undefined);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds an API to find the `@st-scope` atrule of a nested rule from source AST. The API is available on stylable instance:

```js
const stScope = stylable.stScope.getStScope(rule);
```