### PR TITLE
feat(core): st-mixin scope nested rule public API

### DIFF
--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -6,6 +6,7 @@ import * as STVar from './st-var';
 import type { ElementSymbol } from './css-type';
 import type { ClassSymbol } from './css-class';
 import { createSubsetAst } from '../helpers/rule';
+import { scopeNestedSelector } from '../helpers/selector';
 import { mixinHelperDiagnostics, parseStMixin, parseStPartialMixin } from '../helpers/mixin';
 import { resolveArgumentsValue } from '../functions';
 import { cssObjectToAst } from '../parser';
@@ -19,6 +20,7 @@ import type { StylableTransformer } from '../stylable-transformer';
 import { dirname } from 'path';
 import { createDiagnosticReporter, Diagnostics } from '../diagnostics';
 import type { Stylable } from '../stylable';
+import { parseCssSelector } from '@tokey/css-selector-parser';
 
 export interface MixinValue {
     type: string;
@@ -185,6 +187,10 @@ export class StylablePublicApi {
             }
         }
         return result;
+    }
+    public scopeNestedSelector(scopeSelector: string, nestSelector: string): string {
+        return scopeNestedSelector(parseCssSelector(scopeSelector), parseCssSelector(nestSelector))
+            .selector;
     }
 }
 

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -2068,5 +2068,15 @@ describe(`features/st-mixin`, () => {
                 STMixin.diagnostics.JS_MIXIN_NOT_A_FUNC(),
             ]);
         });
+        it('should combine two selectors', () => {
+            const { stylable } = testStylableCore(``);
+            const api = stylable.stMixin;
+
+            expect(api.scopeNestedSelector('.a', '.b'), 'descendant').to.eql('.a .b');
+            expect(api.scopeNestedSelector('.a', '&'), 'replacement').to.eql('.a');
+            expect(api.scopeNestedSelector('.a', '&.b'), 'compound').to.eql('.a.b');
+            expect(api.scopeNestedSelector('.a', ':not(&)'), 'nested').to.eql(':not(.a)');
+            expect(api.scopeNestedSelector('.a', '.b&'), 'after').to.eql('.b.a');
+        });
     });
 });


### PR DESCRIPTION
This PR exposes the API to combine 2 selectors according to how stylable mixins selectors are combined (different then [CSS nesting](https://www.w3.org/TR/css-nesting-1/)). 

The API is available on stylable:

```js
stylable.stMixin.scopeNestedSelector(scopeSelector: string, nestSelector: string): string;
```