### PR TITLE
fix(create-stylable-app): remove stylable eslint plugin

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/.eslintrc
+++ b/packages/create-stylable-app/template/ts-react-rollup/.eslintrc
@@ -8,7 +8,6 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
-    "plugin:stylable/recommended",
     "prettier"
   ],
   "plugins": ["react-hooks"],

--- a/packages/create-stylable-app/template/ts-react-rollup/template.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/template.js
@@ -21,7 +21,6 @@ module.exports = {
         'eslint-config-prettier',
         'eslint-plugin-react',
         'eslint-plugin-react-hooks',
-        'eslint-plugin-stylable',
         'rimraf',
         'rollup',
         'rollup-plugin-copy',

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/.eslintrc
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/.eslintrc
@@ -8,7 +8,6 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
-    "plugin:stylable/recommended",
     "prettier"
   ],
   "plugins": ["react-hooks"],

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/template.js
@@ -14,7 +14,6 @@ module.exports = {
         'eslint-config-prettier',
         'eslint-plugin-react',
         'eslint-plugin-react-hooks',
-        'eslint-plugin-stylable',
         'eslint',
         'html-webpack-plugin',
         'rimraf',

--- a/packages/create-stylable-app/template/ts-react-webpack/.eslintrc
+++ b/packages/create-stylable-app/template/ts-react-webpack/.eslintrc
@@ -8,7 +8,6 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
-    "plugin:stylable/recommended",
     "prettier"
   ],
   "plugins": ["react-hooks"],

--- a/packages/create-stylable-app/template/ts-react-webpack/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/template.js
@@ -14,7 +14,6 @@ module.exports = {
         'eslint-config-prettier',
         'eslint-plugin-react',
         'eslint-plugin-react-hooks',
-        'eslint-plugin-stylable',
         'eslint',
         'html-webpack-plugin',
         'rimraf',


### PR DESCRIPTION
Our introduction of `.d.ts` file generation in our `create-stylable-app` templates have made the use of our `eslint-stylable-plugin` redundant. TypeScript provides a better experience out of the box.