### PR TITLE
fix: remove root validation

### DIFF
--- a/packages/core/src/deprecated/deprecated-selector-utils.ts
+++ b/packages/core/src/deprecated/deprecated-selector-utils.ts
@@ -182,32 +182,6 @@ export function traverseNode(
     }
 }
 
-export function isRootValid(ast: SelectorAstNode, rootName: string) {
-    let isValid = true;
-
-    traverseNode(ast, (node, index, nodes) => {
-        if (node.type === 'nested-pseudo-class') {
-            return true;
-        }
-        if (node.type === 'class' && node.name === rootName) {
-            let isLastScopeGlobal = false;
-            for (let i = 0; i < index; i++) {
-                const part = nodes[i];
-                if (isGlobal(part)) {
-                    isLastScopeGlobal = true;
-                }
-                if (part.type === 'spacing' && !isLastScopeGlobal) {
-                    isValid = false;
-                }
-                if (part.type === 'element' || (part.type === 'class' && part.value !== 'root')) {
-                    isLastScopeGlobal = false;
-                }
-            }
-        }
-        return undefined;
-    });
-    return isValid;
-}
 export function isGlobal(node: SelectorAstNode) {
     return node.type === 'nested-pseudo-class' && node.name === 'global';
 }

--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -127,37 +127,6 @@ export function matchTypeAndValue(
     return a.type === b.type && (a as any).value === (b as any).value;
 }
 
-export function isRootValid(ast: ImmutableSelectorList) {
-    let isValid = true;
-    walk(ast, (node, index, nodes) => {
-        if (node.type === 'pseudo_class') {
-            return walk.skipNested;
-        }
-        if (node.type === 'class' && node.value === `root`) {
-            let isLastScopeGlobal = false;
-            for (let i = 0; i < index; i++) {
-                const part = nodes[i];
-                if (isGlobal(part)) {
-                    isLastScopeGlobal = true;
-                }
-                if (part.type === 'combinator' && !isLastScopeGlobal) {
-                    isValid = false;
-                    return walk.skipCurrentSelector;
-                }
-                if (part.type === 'type' || (part.type === 'class' && part.value !== 'root')) {
-                    isLastScopeGlobal = false;
-                }
-            }
-        }
-        return undefined;
-    });
-    return isValid;
-}
-
-function isGlobal(node: ImmutableSelectorNode) {
-    return node.type === 'pseudo_class' && node.value === 'global';
-}
-
 export function isCompRoot(name: string) {
     return name.charAt(0).match(/[A-Z]/);
 }

--- a/packages/core/src/index-deprecated.ts
+++ b/packages/core/src/index-deprecated.ts
@@ -276,7 +276,6 @@ import {
     matchAtKeyframes as deprecatedMatchAtKeyframes,
     isImport as deprecatedIsImport,
     isSimpleSelector as deprecatedIsSimpleSelector,
-    isRootValid as deprecatedIsRootValid,
     isGlobal as deprecatedIsGlobal,
     createChecker as deprecatedCreateChecker,
     isNested as deprecatedIsNested,
@@ -325,7 +324,7 @@ export const isSimpleSelector = wrapFunctionForDeprecation(deprecatedIsSimpleSel
     name: `isSimpleSelector`,
 });
 /**@deprecated*/
-export const isRootValid = wrapFunctionForDeprecation(deprecatedIsRootValid, {
+export const isRootValid = wrapFunctionForDeprecation(() => true, {
     name: `isRootValid`,
 });
 /**@deprecated*/

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -30,7 +30,6 @@ import {
     walkSelector,
     isSimpleSelector,
     isInPseudoClassContext,
-    isRootValid,
     parseSelectorWithCache,
     stringifySelector,
 } from './helpers/selector';
@@ -46,9 +45,6 @@ const parseGlobal = SBTypesParsers[`-st-global`];
 const parseExtends = SBTypesParsers[`-st-extends`];
 
 export const processorWarnings = {
-    ROOT_AFTER_SPACING() {
-        return '".root" class cannot be used after native elements or selectors external to the stylesheet';
-    },
     STATE_DEFINITION_IN_ELEMENT() {
         return 'cannot define pseudo states inside a type selector';
     },
@@ -376,10 +372,6 @@ export class StylableProcessor implements FeatureContext {
             rule.selectorType = 'complex';
         }
 
-        // ToDo: check cases of root in nested selectors?
-        if (!isRootValid(selectorAst)) {
-            this.diagnostics.warn(rule, processorWarnings.ROOT_AFTER_SPACING());
-        }
         return locallyScoped;
     }
 

--- a/packages/core/test/diagnostics.spec.ts
+++ b/packages/core/test/diagnostics.spec.ts
@@ -4,11 +4,7 @@ import {
     expectTransformDiagnostics,
     findTestLocations,
 } from '@stylable/core-test-kit';
-import {
-    processorWarnings,
-    transformerWarnings,
-    nativePseudoElements,
-} from '@stylable/core';
+import { processorWarnings, transformerWarnings, nativePseudoElements } from '@stylable/core';
 import { CSSClass, CSSType } from '@stylable/core/dist/features';
 import { generalDiagnostics } from '@stylable/core/dist/features/diagnostics';
 
@@ -284,59 +280,6 @@ describe('diagnostics: warnings and errors', () => {
     });
 
     describe('structure', () => {
-        describe('root', () => {
-            it('should return warning for ".root" after a selector', () => {
-                expectAnalyzeDiagnostics(
-                    `
-                    |.gaga .root|{}
-                `,
-                    [{ message: processorWarnings.ROOT_AFTER_SPACING(), file: 'main.css' }]
-                );
-            });
-
-            it('should return warning for ".root" after global and local classes', () => {
-                expectAnalyzeDiagnostics(
-                    `
-                    |:global(*) .x .root|{}
-                `,
-                    [{ message: processorWarnings.ROOT_AFTER_SPACING(), file: 'main.css' }]
-                );
-            });
-
-            it('should return warning for ".root" after a global and element', () => {
-                expectAnalyzeDiagnostics(
-                    `
-                    |:global(*) div .root|{}
-                `,
-                    [
-                        {
-                            message: CSSType.diagnostics.UNSCOPED_TYPE_SELECTOR('div'),
-                            file: 'main.css',
-                        },
-                        { message: processorWarnings.ROOT_AFTER_SPACING(), file: 'main.css' },
-                    ]
-                );
-            });
-
-            it('should not return warning for ".root" after a global selector', () => {
-                expectAnalyzeDiagnostics(
-                    `
-                    :global(*) .root{}
-                `,
-                    []
-                );
-            });
-
-            it('should not return warning for ".root" after a complex global selector', () => {
-                expectAnalyzeDiagnostics(
-                    `
-                    :global(body[dir="rtl"] > header) .root {}
-                `,
-                    []
-                );
-            });
-        });
-
         describe('-st-extends', () => {
             it('should return warning when defined under complex selector', () => {
                 expectAnalyzeDiagnostics(
@@ -377,10 +320,7 @@ describe('diagnostics: warnings and errors', () => {
                 `,
                     [
                         {
-                            message: processorWarnings.OVERRIDE_TYPED_RULE(
-                                `-st-extends`,
-                                'root'
-                            ),
+                            message: processorWarnings.OVERRIDE_TYPED_RULE(`-st-extends`, 'root'),
                             file: 'main.css',
                         },
                     ]

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -12,18 +12,17 @@ describe('diagnostics', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: '.gaga .root{}',
+                [filePath]: '.root:unknown{}',
             },
             filePath
         );
 
         expect(diagnostics).to.deep.include({
             range: {
-                start: { line: 0, character: 0 },
+                start: { line: 0, character: 6 },
                 end: { line: 0, character: 13 },
             },
-            message:
-                '".root" class cannot be used after native elements or selectors external to the stylesheet',
+            message: 'unknown pseudo-state "unknown"',
             severity: 2,
             source: 'stylable',
         });
@@ -32,7 +31,7 @@ describe('diagnostics', () => {
     it('should not duplicate diagnostics within multiple runs on the same file', () => {
         const filePath = '/style.st.css';
         const files = {
-            [filePath]: '.gaga .root{}',
+            [filePath]: '.root:unknown{}',
         };
         const fs = createMemoryFs(files);
 


### PR DESCRIPTION
Since we really don't know how the stylesheet would be used, we might not want to make assumptions on where the `root` class is location in a selector.

for example portals, where I place the `root` class on known local class like `popover-content` 