### PR TITLE
chore: move core to dependencies

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/template.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/template.js
@@ -9,7 +9,6 @@ module.exports = {
         '@rollup/plugin-node-resolve',
         '@rollup/plugin-replace',
         '@rollup/plugin-typescript',
-        '@stylable/core',
         '@stylable/cli',
         '@stylable/rollup-plugin',
         '@stylable/runtime',

--- a/packages/create-stylable-app/template/ts-react-webpack-lean/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack-lean/template.js
@@ -3,7 +3,6 @@
 module.exports = {
     dependencies: ['react', 'react-dom'],
     devDependencies: [
-        '@stylable/core',
         '@stylable/cli',
         '@stylable/runtime',
         '@stylable/webpack-plugin',

--- a/packages/create-stylable-app/template/ts-react-webpack/template.js
+++ b/packages/create-stylable-app/template/ts-react-webpack/template.js
@@ -3,7 +3,6 @@
 module.exports = {
     dependencies: ['react', 'react-dom'],
     devDependencies: [
-        '@stylable/core',
         '@stylable/cli',
         '@stylable/runtime',
         '@stylable/webpack-plugin',

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -7,12 +7,12 @@
     "test": "mocha \"dist/test/**/*.spec.js\""
   },
   "peerDependencies": {
-    "@stylable/core": "^4.13.3",
     "rollup": "^2.70.0"
   },
   "dependencies": {
     "@stylable/build-tools": "^4.13.3",
     "@stylable/cli": "^4.13.3",
+    "@stylable/core": "^4.13.3",
     "@stylable/node": "^4.13.3",
     "@stylable/optimizer": "^4.13.3",
     "@stylable/runtime": "^4.13.3",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -7,12 +7,12 @@
     "test": "mocha \"./dist/test/**/*.spec.js\" --timeout 20000"
   },
   "peerDependencies": {
-    "@stylable/core": "^4.13.3",
     "webpack": "^5.30.0"
   },
   "dependencies": {
     "@stylable/build-tools": "^4.13.3",
     "@stylable/cli": "^4.13.3",
+    "@stylable/core": "^4.13.3",
     "@stylable/module-utils": "^4.13.3",
     "@stylable/node": "^4.13.3",
     "@stylable/optimizer": "^4.13.3",


### PR DESCRIPTION
All packages that used @stylable/core as peer dependency also depends on packages that depend on @stylable/core directly