### PR TITLE
fix: imported element transform to class

### DIFF
--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -62,7 +62,11 @@ export const hooks = createFeature<{
         // native node does not resolve e.g. div
         if (resolved && resolved.length > 1) {
             const { symbol, meta } = getOriginDefinition(resolved);
-            CSSClass.namespaceClass(meta, symbol, node, selectorContext.originMeta);
+            if (symbol._kind === 'class') {
+                CSSClass.namespaceClass(meta, symbol, node, selectorContext.originMeta);
+            } else {
+                node.value = symbol.name;
+            }
         }
     },
 });


### PR DESCRIPTION
This PR fixes an edge case of an imported element type selector (originally defined as type and not class) being transformed as a class selector:

```css
/* origin.st.css */
Part {} /* defined as an "custom" element selector*/
```
```css
/* entry.st.css */
@st-import [Part as ImportedPart] from './origin.st.css';

ImportedPart {} /* should transfrom to "Part", but wrongly changes to ".origin__Part" */
```

> Notice that selectors like this are not namespaced and should be discouraged.