### PR TITLE
feat(core) transition from native `@namespace` - v4

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -338,6 +338,8 @@ npx -p @stylable/cli stc-codemod --help
 
 - `st-global-custom-property-to-at-property` - Convert deprecated `@st-global-custom-property *;` to `@property st-global(*);` syntax.
 
+- `namespace-to-st-namespace` - Converts `@namespace` that would have been used as Stylable namespace configuration to `@st-namespace`.
+
 ### Provide an external codemod
 
 Codemods are transformation operations for code based on AST.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,7 +154,7 @@ export class Generator extends Base {
     }    
     protected generateIndexSource(indexFileTargetPath: string) {
         const source = super.generateIndexSource(indexFileTargetPath);
-        return '@namespace "INDEX";\n' + source;
+        return '@st-namespace "INDEX";\n' + source;
     }
 }
 ```

--- a/packages/cli/src/code-mods/load-codemods.ts
+++ b/packages/cli/src/code-mods/load-codemods.ts
@@ -4,10 +4,12 @@ import type { Log } from '../logger';
 // Builtin codemods
 import { stImportToAtImport } from './st-import-to-at-import';
 import { stGlobalCustomPropertyToAtProperty } from './st-global-custom-property-to-at-property';
+import { namespaceToStNamespace } from './namespace-to-st-namespace';
 
 export const registeredMods: Map<string, CodeMod> = new Map([
     ['st-import-to-at-import', stImportToAtImport],
     ['st-global-custom-property-to-at-property', stGlobalCustomPropertyToAtProperty],
+    ['namespace-to-st-namespace', namespaceToStNamespace],
 ]);
 
 export function loadBuiltInCodemods(

--- a/packages/cli/src/code-mods/namespace-to-st-namespace.ts
+++ b/packages/cli/src/code-mods/namespace-to-st-namespace.ts
@@ -1,0 +1,29 @@
+import { parseNamespace } from '@stylable/core/dist/features/st-namespace';
+import type * as postcss from 'postcss';
+import type { CodeMod } from './types';
+
+export const namespaceToStNamespace: CodeMod = ({ ast }) => {
+    let changed = false;
+    let foundStNamespace = false;
+    const nodesToMod: postcss.AtRule[] = [];
+    ast.walkAtRules((atRule) => {
+        if (atRule.name === 'namespace') {
+            const namespace = parseNamespace(atRule);
+            if (namespace) {
+                nodesToMod.push(atRule);
+            }
+        } else if (atRule.name === 'st-namespace') {
+            foundStNamespace = true;
+        }
+    });
+    if (!foundStNamespace) {
+        for (const atRule of nodesToMod) {
+            atRule.name = 'st-namespace';
+            changed = true;
+        }
+    }
+
+    return {
+        changed,
+    };
+};

--- a/packages/cli/test/codemods/namespace-to-st-namespace.spec.ts
+++ b/packages/cli/test/codemods/namespace-to-st-namespace.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import {
+    populateDirectorySync,
+    loadDirSync,
+    runCliCodeMod,
+    createTempDirectory,
+    ITempDirectory,
+} from '@stylable/e2e-test-kit';
+
+describe('CLI Codemods namespace-to-st-namespace', () => {
+    let tempDir: ITempDirectory;
+
+    beforeEach(async () => {
+        tempDir = await createTempDirectory();
+    });
+    afterEach(async () => {
+        await tempDir.remove();
+    });
+
+    it('should replace @namespace with @st-namespace', () => {
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            'style.st.css': `@namespace "button";`,
+        });
+
+        runCliCodeMod(['--rootDir', tempDir.path, '--mods', 'namespace-to-st-namespace']);
+
+        const dirContent = loadDirSync(tempDir.path);
+
+        expect(dirContent['style.st.css']).equal('@st-namespace "button";');
+    });
+    it('should not replace @namespace when @st-namespace already exist', () => {
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            'style.st.css': `@namespace "button"; @st-namespace "comp";`,
+        });
+
+        runCliCodeMod(['--rootDir', tempDir.path, '--mods', 'namespace-to-st-namespace']);
+
+        const dirContent = loadDirSync(tempDir.path);
+
+        expect(dirContent['style.st.css']).equal('@namespace "button"; @st-namespace "comp";');
+    });
+    it('should not replace @namespace that would not be used as @st-namespace', () => {
+        populateDirectorySync(tempDir.path, {
+            'package.json': `{"name": "test", "version": "0.0.0"}`,
+            'style.st.css': `@namespace "http://button"; @namespace prefix "btn";`,
+        });
+
+        runCliCodeMod(['--rootDir', tempDir.path, '--mods', 'namespace-to-st-namespace']);
+
+        const dirContent = loadDirSync(tempDir.path);
+
+        expect(dirContent['style.st.css']).equal(
+            '@namespace "http://button"; @namespace prefix "btn";'
+        );
+    });
+});

--- a/packages/cli/test/fixtures/named-exports-generator.ts
+++ b/packages/cli/test/fixtures/named-exports-generator.ts
@@ -4,8 +4,9 @@ export class Generator extends Base {
     public generateReExports(filePath: string): ReExports {
         return reExportsAllSymbols(filePath, this);
     }
+
     protected generateIndexSource(indexFileTargetPath: string) {
         const source = super.generateIndexSource(indexFileTargetPath);
-        return '@namespace "INDEX";\n' + source;
+        return '@st-namespace "INDEX";\n' + source;
     }
 }

--- a/packages/cli/test/generate-index.spec.ts
+++ b/packages/cli/test/generate-index.spec.ts
@@ -202,8 +202,7 @@ describe('build index', () => {
             ':import {-st-from: "./comp-A.st.css";-st-default:Style0;}\n.root Style0{}'
         );
     });
-
-    it('should create index file using a custom generator with named exports generation and @namespace', async () => {
+    it('should create index file using a custom generator with named exports generation and @st-namespace', async () => {
         const fs = createMemoryFs({
             '/comp-A.st.css': `
                 :vars {
@@ -241,7 +240,7 @@ describe('build index', () => {
 
         expect(res.trim()).to.equal(
             [
-                '@namespace "INDEX";',
+                '@st-namespace "INDEX";',
                 ':import {-st-from: "./comp-A.st.css";-st-default:CompA;-st-named: a as CompA__a, color1 as CompA__color1, --color2 as --CompA__color2, keyframes(X as CompA__X);}',
                 '.root CompA{}',
                 '.root .CompA__a{}',

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -47,6 +47,7 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
     }) => SelectorWalkReturn;
     analyzeDeclaration: (options: { context: FeatureContext; decl: postcss.Declaration }) => void;
     prepareAST: (options: {
+        meta: StylableMeta;
         node: postcss.ChildNode;
         toRemove: Array<postcss.Node | (() => void)>;
     }) => void;

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -6,6 +6,8 @@ export type { StylableSymbol } from './st-symbol';
 export * as STImport from './st-import';
 export type { ImportSymbol, Imported } from './st-import';
 
+export * as STNamespace from './st-namespace';
+
 export * as STGlobal from './st-global';
 
 export * as STScope from './st-scope';

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -1,0 +1,78 @@
+import path from 'path';
+import { createFeature, FeatureContext } from './feature';
+import { plugableRecord } from '../helpers/plugable-record';
+import { filename2varname } from '../helpers/string';
+import { stripQuotation } from '../helpers/string';
+import { murmurhash3_32_gc } from '../murmurhash';
+
+export const diagnostics = {
+    INVALID_NAMESPACE_DEF: () => 'invalid @namespace',
+    EMPTY_NAMESPACE_DEF: () => '@namespace must contain at least one character or digit',
+    INVALID_NAMESPACE_REFERENCE: () => 'st-namespace-reference dose not have any value', // ToDo: add test
+};
+
+const dataKey = plugableRecord.key<string[]>('namespace');
+
+// HOOKS
+
+export const hooks = createFeature({
+    metaInit({ meta }) {
+        plugableRecord.set(meta.data, dataKey, []);
+    },
+    analyzeAtRule({ context, atRule }) {
+        const match = atRule.params.match(/["'](.*?)['"]/);
+        if (match) {
+            const collected = plugableRecord.getUnsafe(context.meta.data, dataKey);
+            if (match[1].trim()) {
+                collected.push(match[1]);
+            } else {
+                context.diagnostics.error(atRule, diagnostics.EMPTY_NAMESPACE_DEF());
+            }
+        } else {
+            context.diagnostics.error(atRule, diagnostics.INVALID_NAMESPACE_DEF());
+        }
+    },
+    prepareAST({ node, toRemove }) {
+        if (node.type === 'atrule' && node.name === `namespace`) {
+            toRemove.push(node);
+        }
+    },
+});
+
+// API
+
+export function defaultProcessNamespace(namespace: string, origin: string, _source?: string) {
+    return namespace + murmurhash3_32_gc(origin); // .toString(36);
+}
+
+export function setMetaNamespace(
+    context: FeatureContext,
+    resolveNamespace: typeof defaultProcessNamespace
+): void {
+    const meta = context.meta;
+    // resolve namespace
+    const collected = plugableRecord.getUnsafe(meta.data, dataKey);
+    const namespace =
+        collected[collected.length - 1] || filename2varname(path.basename(meta.source)) || 's';
+    // resolve path origin
+    let pathToSource: string | undefined;
+    let length = meta.ast.nodes.length;
+    while (length--) {
+        const node = meta.ast.nodes[length];
+        if (node.type === 'comment' && node.text.includes('st-namespace-reference')) {
+            const i = node.text.indexOf('=');
+            if (i === -1) {
+                context.diagnostics.error(node, diagnostics.INVALID_NAMESPACE_REFERENCE());
+            } else {
+                pathToSource = stripQuotation(node.text.slice(i + 1));
+            }
+            break;
+        }
+    }
+    // generate final namespace
+    meta.namespace = resolveNamespace(
+        namespace,
+        pathToSource ? path.resolve(path.dirname(meta.source), pathToSource) : meta.source,
+        meta.source
+    );
+}

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -16,13 +16,15 @@ export const diagnostics = {
     INVALID_NAMESPACE_VALUE: () => '@st-namespace must contain only letters, numbers or dashes',
 };
 
-const dataKey = plugableRecord.key<string[]>('namespace');
+const dataKey = plugableRecord.key<{ namespaces: string[]; usedNativeNamespace: string[] }>(
+    'namespace'
+);
 
 // HOOKS
 
 export const hooks = createFeature({
     metaInit({ meta }) {
-        plugableRecord.set(meta.data, dataKey, []);
+        plugableRecord.set(meta.data, dataKey, { namespaces: [], usedNativeNamespace: [] });
     },
     analyzeAtRule({ context, atRule }) {
         const isSTNamespace = atRule.name === 'st-namespace';
@@ -33,12 +35,24 @@ export const hooks = createFeature({
         const diag = isSTNamespace ? context.diagnostics : undefined;
         const match = parseNamespace(atRule, diag);
         if (match) {
-            const collected = plugableRecord.getUnsafe(context.meta.data, dataKey);
-            collected.push(match);
+            const { namespaces, usedNativeNamespace } = plugableRecord.getUnsafe(
+                context.meta.data,
+                dataKey
+            );
+            namespaces.push(match);
+            if (isNamespace) {
+                usedNativeNamespace.push(atRule.params);
+            }
         }
     },
-    prepareAST({ node, toRemove }) {
-        if (node.type === 'atrule' && (node.name === `st-namespace` || node.name === `namespace`)) {
+    prepareAST({ meta, node, toRemove }) {
+        // remove @st-namespace or @namespace that was used as @st-namespace
+        const { usedNativeNamespace } = plugableRecord.getUnsafe(meta.data, dataKey);
+        if (
+            node.type === 'atrule' &&
+            (node.name === 'st-namespace' ||
+                (node.name === 'namespace' && usedNativeNamespace.includes(node.params)))
+        ) {
             toRemove.push(node);
         }
     },
@@ -119,9 +133,9 @@ export function setMetaNamespace(
 ): void {
     const meta = context.meta;
     // resolve namespace
-    const collected = plugableRecord.getUnsafe(meta.data, dataKey);
+    const { namespaces } = plugableRecord.getUnsafe(meta.data, dataKey);
     const namespace =
-        collected[collected.length - 1] || filename2varname(path.basename(meta.source)) || 's';
+        namespaces[namespaces.length - 1] || filename2varname(path.basename(meta.source)) || 's';
     // resolve path origin
     let pathToSource: string | undefined;
     let length = meta.ast.nodes.length;

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -72,7 +72,7 @@ export const hooks = createFeature({
 
 // API
 
-function parseNamespace(node: AtRule, diag?: Diagnostics): string | undefined {
+export function parseNamespace(node: AtRule, diag?: Diagnostics): string | undefined {
     const { nodes } = valueParser(node.params);
     if (!nodes.length) {
         // empty params (not even empty quotes)

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -16,15 +16,21 @@ export const diagnostics = {
     INVALID_NAMESPACE_VALUE: () => '@st-namespace must contain only letters, numbers or dashes',
 };
 
-const dataKey = plugableRecord.key<{ namespaces: string[]; usedNativeNamespace: string[] }>(
-    'namespace'
-);
+const dataKey = plugableRecord.key<{
+    namespaces: string[];
+    usedNativeNamespace: string[];
+    foundStNamespace: boolean;
+}>('namespace');
 
 // HOOKS
 
 export const hooks = createFeature({
     metaInit({ meta }) {
-        plugableRecord.set(meta.data, dataKey, { namespaces: [], usedNativeNamespace: [] });
+        plugableRecord.set(meta.data, dataKey, {
+            namespaces: [],
+            usedNativeNamespace: [],
+            foundStNamespace: false,
+        });
     },
     analyzeAtRule({ context, atRule }) {
         const isSTNamespace = atRule.name === 'st-namespace';
@@ -32,16 +38,22 @@ export const hooks = createFeature({
         if (!isSTNamespace && !isNamespace) {
             return;
         }
+        const data = plugableRecord.getUnsafe(context.meta.data, dataKey);
+        if (data.foundStNamespace && isNamespace) {
+            // ignore @namespace once @st-namespace was found
+            return;
+        }
         const diag = isSTNamespace ? context.diagnostics : undefined;
         const match = parseNamespace(atRule, diag);
         if (match) {
-            const { namespaces, usedNativeNamespace } = plugableRecord.getUnsafe(
-                context.meta.data,
-                dataKey
-            );
-            namespaces.push(match);
+            data.namespaces.push(match);
             if (isNamespace) {
-                usedNativeNamespace.push(atRule.params);
+                data.usedNativeNamespace.push(atRule.params);
+            } else {
+                // clear @namespace matches once @st-namespace if found
+                data.usedNativeNamespace.length = 0;
+                // mark to prevent any further @namespace collection
+                data.foundStNamespace = true;
             }
         }
     },

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -8,7 +8,7 @@ import { murmurhash3_32_gc } from '../murmurhash';
 export const diagnostics = {
     INVALID_NAMESPACE_DEF: () => 'invalid @namespace',
     EMPTY_NAMESPACE_DEF: () => '@namespace must contain at least one character or digit',
-    INVALID_NAMESPACE_REFERENCE: () => 'st-namespace-reference dose not have any value', // ToDo: add test
+    INVALID_NAMESPACE_REFERENCE: () => 'st-namespace-reference dose not have any value',
 };
 
 const dataKey = plugableRecord.key<string[]>('namespace');

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -3,12 +3,17 @@ import { createFeature, FeatureContext } from './feature';
 import { plugableRecord } from '../helpers/plugable-record';
 import { filename2varname } from '../helpers/string';
 import { stripQuotation } from '../helpers/string';
+import valueParser from 'postcss-value-parser';
 import { murmurhash3_32_gc } from '../murmurhash';
+import type { Diagnostics } from '../diagnostics';
+import type { AtRule } from 'postcss';
 
 export const diagnostics = {
-    INVALID_NAMESPACE_DEF: () => 'invalid @namespace',
-    EMPTY_NAMESPACE_DEF: () => '@namespace must contain at least one character or digit',
+    INVALID_NAMESPACE_DEF: () => 'invalid @st-namespace',
+    EMPTY_NAMESPACE_DEF: () => '@st-namespace must contain at least one character or digit',
     INVALID_NAMESPACE_REFERENCE: () => 'st-namespace-reference dose not have any value',
+    EXTRA_DEFINITION: () => '@st-namespace must contain a single string definition',
+    INVALID_NAMESPACE_VALUE: () => '@st-namespace must contain only letters, numbers or dashes',
 };
 
 const dataKey = plugableRecord.key<string[]>('namespace');
@@ -20,19 +25,16 @@ export const hooks = createFeature({
         plugableRecord.set(meta.data, dataKey, []);
     },
     analyzeAtRule({ context, atRule }) {
-        if (atRule.name !== 'st-namespace' && atRule.name !== 'namespace') {
+        const isSTNamespace = atRule.name === 'st-namespace';
+        const isNamespace = atRule.name === 'namespace';
+        if (!isSTNamespace && !isNamespace) {
             return;
         }
-        const match = atRule.params.match(/["'](.*?)['"]/);
+        const diag = isSTNamespace ? context.diagnostics : undefined;
+        const match = parseNamespace(atRule, diag);
         if (match) {
             const collected = plugableRecord.getUnsafe(context.meta.data, dataKey);
-            if (match[1].trim()) {
-                collected.push(match[1]);
-            } else {
-                context.diagnostics.error(atRule, diagnostics.EMPTY_NAMESPACE_DEF());
-            }
-        } else {
-            context.diagnostics.error(atRule, diagnostics.INVALID_NAMESPACE_DEF());
+            collected.push(match);
         }
     },
     prepareAST({ node, toRemove }) {
@@ -43,6 +45,69 @@ export const hooks = createFeature({
 });
 
 // API
+
+function parseNamespace(node: AtRule, diag?: Diagnostics): string | undefined {
+    const { nodes } = valueParser(node.params);
+    if (!nodes.length) {
+        // empty params (not even empty quotes)
+        diag?.error(node, diagnostics.EMPTY_NAMESPACE_DEF());
+        return;
+    }
+    let isInvalid = false;
+    let namespace: string | undefined = undefined;
+    for (const valueNode of nodes) {
+        switch (valueNode.type) {
+            case 'string': {
+                if (namespace === undefined) {
+                    // first namespace
+                    if (!isInvalid) {
+                        namespace = stripQuotation(valueNode.value);
+                    }
+                } else {
+                    // extra definition - mark as invalid and clear namespace
+                    diag?.error(node, diagnostics.EXTRA_DEFINITION(), {
+                        word: valueParser.stringify(valueNode),
+                    });
+                    isInvalid = true;
+                    namespace = undefined;
+                }
+                break;
+            }
+            case 'comment':
+            case 'space':
+                // do nothing
+                break;
+            default: {
+                // invalid definition - mark as invalid and clear namespace
+                diag?.error(node, diagnostics.EXTRA_DEFINITION(), {
+                    word: valueParser.stringify(valueNode),
+                });
+                isInvalid = true;
+                namespace = undefined;
+            }
+        }
+    }
+    if (namespace === undefined) {
+        // no namespace found
+        diag?.error(node, diagnostics.INVALID_NAMESPACE_DEF());
+        return;
+    }
+    if (namespace !== undefined && namespace.trim() === '') {
+        // empty namespace found
+        diag?.error(node, diagnostics.EMPTY_NAMESPACE_DEF());
+        return;
+    }
+    // ident like - without escapes
+    // eslint-disable-next-line no-control-regex
+    if (!namespace.match(/^([a-zA-Z-_]|[^\x00-\x7F]+)([a-zA-Z-_0-9]|[^\x00-\x7F])*$/)) {
+        // empty namespace found
+        diag?.error(node, diagnostics.INVALID_NAMESPACE_VALUE(), {
+            word: namespace,
+        });
+        return;
+    }
+    return namespace;
+}
 
 export function defaultProcessNamespace(namespace: string, origin: string, _source?: string) {
     return namespace + murmurhash3_32_gc(origin); // .toString(36);

--- a/packages/core/src/features/st-namespace.ts
+++ b/packages/core/src/features/st-namespace.ts
@@ -20,6 +20,9 @@ export const hooks = createFeature({
         plugableRecord.set(meta.data, dataKey, []);
     },
     analyzeAtRule({ context, atRule }) {
+        if (atRule.name !== 'st-namespace' && atRule.name !== 'namespace') {
+            return;
+        }
         const match = atRule.params.match(/["'](.*?)['"]/);
         if (match) {
             const collected = plugableRecord.getUnsafe(context.meta.data, dataKey);
@@ -33,7 +36,7 @@ export const hooks = createFeature({
         }
     },
     prepareAST({ node, toRemove }) {
-        if (node.type === 'atrule' && node.name === `namespace`) {
+        if (node.type === 'atrule' && (node.name === `st-namespace` || node.name === `namespace`)) {
             toRemove.push(node);
         }
     },

--- a/packages/core/src/stylable-meta.ts
+++ b/packages/core/src/stylable-meta.ts
@@ -18,6 +18,7 @@ import { setFieldForDeprecation } from './helpers/deprecation';
 import {
     STSymbol,
     STImport,
+    STNamespace,
     STGlobal,
     STVar,
     STMixin,
@@ -33,6 +34,7 @@ export const RESERVED_ROOT_NAME = 'root';
 const features = [
     STSymbol,
     STImport,
+    STNamespace,
     STGlobal,
     STVar,
     STMixin,

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -142,7 +142,8 @@ export class StylableProcessor implements FeatureContext {
                     });
                     break;
                 }
-                case 'namespace': {
+                case 'namespace':
+                case 'st-namespace': {
                     STNamespace.hooks.analyzeAtRule({
                         context: this,
                         atRule,

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -469,7 +469,7 @@ export function process(
 export function prepareAST(meta: StylableMeta, ast: postcss.Root) {
     const toRemove: Array<postcss.Node | (() => void)> = [];
     ast.walk((node) => {
-        const input = { node, toRemove };
+        const input = { meta, node, toRemove };
         // namespace
         STNamespace.hooks.prepareAST(input);
         // custom selectors

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -1,8 +1,6 @@
-import path from 'path';
 import * as postcss from 'postcss';
 import { Diagnostics } from './diagnostics';
 import { parseSelector as deprecatedParseSelector } from './deprecated/deprecated-selector-utils';
-import { murmurhash3_32_gc } from './murmurhash';
 import { knownPseudoClassesWithNestedSelectors } from './native-reserved-lists';
 import { StylableMeta } from './stylable-meta';
 import {
@@ -18,6 +16,7 @@ import {
     FeatureContext,
     STSymbol,
     STImport,
+    STNamespace,
     STGlobal,
     STScope,
     CSSClass,
@@ -38,7 +37,6 @@ import { isChildOfAtRule } from './helpers/rule';
 import type { SRule } from './deprecated/postcss-ast-extension';
 import { stValuesMap } from './deprecated/value-mapping';
 import { SBTypesParsers } from './stylable-value-parsers';
-import { stripQuotation, filename2varname } from './helpers/string';
 import { warnOnce } from './helpers/deprecation';
 
 const parseStates = SBTypesParsers[`-st-states`];
@@ -61,16 +59,6 @@ export const processorWarnings = {
     OVERRIDE_TYPED_RULE(key: string, name: string) {
         return `override "${key}" on typed rule "${name}"`;
     },
-    INVALID_NAMESPACE_DEF() {
-        return 'invalid @namespace';
-    },
-    EMPTY_NAMESPACE_DEF() {
-        return '@namespace must contain at least one character or digit';
-    },
-
-    INVALID_NAMESPACE_REFERENCE() {
-        return 'st-namespace-reference dose not have any value';
-    },
     INVALID_NESTING(child: string, parent: string) {
         return `nesting of rules within rules is not supported, found: "${child}" inside "${parent}"`;
     },
@@ -81,7 +69,7 @@ export class StylableProcessor implements FeatureContext {
     private customSelectorData: Record<string, { isScoped: boolean }> = {};
     constructor(
         public diagnostics = new Diagnostics(),
-        private resolveNamespace = processNamespace
+        private resolveNamespace = STNamespace.defaultProcessNamespace
     ) {}
     public process(root: postcss.Root): StylableMeta {
         this.meta = new StylableMeta(root, this.diagnostics);
@@ -127,6 +115,8 @@ export class StylableProcessor implements FeatureContext {
             this.collectUrls(decl);
         });
 
+        STNamespace.setMetaNamespace(this, this.resolveNamespace);
+
         STSymbol.reportRedeclare(this);
 
         prepareAST(this.meta, root);
@@ -135,8 +125,6 @@ export class StylableProcessor implements FeatureContext {
     }
 
     protected handleAtRules(root: postcss.Root) {
-        let namespace = '';
-
         const analyzeRule = (rule: postcss.Rule, { isScoped }: { isScoped: boolean }) => {
             return this.handleRule(rule as SRule, {
                 isScoped,
@@ -155,16 +143,11 @@ export class StylableProcessor implements FeatureContext {
                     break;
                 }
                 case 'namespace': {
-                    const match = atRule.params.match(/["'](.*?)['"]/);
-                    if (match) {
-                        if (match[1].trim()) {
-                            namespace = match[1];
-                        } else {
-                            this.diagnostics.error(atRule, processorWarnings.EMPTY_NAMESPACE_DEF());
-                        }
-                    } else {
-                        this.diagnostics.error(atRule, processorWarnings.INVALID_NAMESPACE_DEF());
-                    }
+                    STNamespace.hooks.analyzeAtRule({
+                        context: this,
+                        atRule,
+                        analyzeRule,
+                    });
                     break;
                 }
                 case 'keyframes':
@@ -211,13 +194,15 @@ export class StylableProcessor implements FeatureContext {
                     break;
                 case 'property':
                 case 'st-global-custom-property': {
-                    CSSCustomProperty.hooks.analyzeAtRule({ context: this, atRule, analyzeRule });
+                    CSSCustomProperty.hooks.analyzeAtRule({
+                        context: this,
+                        atRule,
+                        analyzeRule,
+                    });
                     break;
                 }
             }
         });
-        namespace = namespace || filename2varname(path.basename(this.meta.source)) || 's';
-        this.meta.namespace = this.handleNamespaceReference(namespace);
     }
     private collectUrls(decl: postcss.Declaration) {
         processDeclarationFunctions(
@@ -230,33 +215,6 @@ export class StylableProcessor implements FeatureContext {
             false
         );
     }
-
-    private handleNamespaceReference(namespace: string): string {
-        let pathToSource: string | undefined;
-        let length = this.meta.ast.nodes.length;
-
-        while (length--) {
-            const node = this.meta.ast.nodes[length];
-            if (node.type === 'comment' && node.text.includes('st-namespace-reference')) {
-                const i = node.text.indexOf('=');
-                if (i === -1) {
-                    this.diagnostics.error(node, processorWarnings.INVALID_NAMESPACE_REFERENCE());
-                } else {
-                    pathToSource = stripQuotation(node.text.slice(i + 1));
-                }
-                break;
-            }
-        }
-
-        return this.resolveNamespace(
-            namespace,
-            pathToSource
-                ? path.resolve(path.dirname(this.meta.source), pathToSource)
-                : this.meta.source,
-            this.meta.source
-        );
-    }
-
     protected handleRule(
         rule: SRule,
         { isScoped, reportUnscoped }: { isScoped: boolean; reportUnscoped: boolean }
@@ -499,10 +457,6 @@ export function createEmptyMeta(root: postcss.Root, diagnostics: Diagnostics): S
     return new StylableMeta(root, diagnostics);
 }
 
-export function processNamespace(namespace: string, origin: string, _source?: string) {
-    return namespace + murmurhash3_32_gc(origin); // .toString(36);
-}
-
 export function process(
     root: postcss.Root,
     diagnostics = new Diagnostics(),
@@ -516,9 +470,7 @@ export function prepareAST(meta: StylableMeta, ast: postcss.Root) {
     ast.walk((node) => {
         const input = { node, toRemove };
         // namespace
-        if (node.type === 'atrule' && node.name === `namespace`) {
-            toRemove.push(node);
-        }
+        STNamespace.hooks.prepareAST(input);
         // custom selectors
         if (node.type === 'rule') {
             expandCustomSelectors(node, meta.customSelectors, meta.diagnostics);
@@ -535,3 +487,5 @@ export function prepareAST(meta: StylableMeta, ast: postcss.Root) {
         typeof removeOrNode === 'function' ? removeOrNode() : removeOrNode.remove();
     }
 }
+// ToDo: remove export and reroute import from feature
+export const processNamespace = STNamespace.defaultProcessNamespace;

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -262,7 +262,33 @@ describe('features/st-namespace', () => {
             // JS exports
             expect(exports.classes.x, `JS export`).to.eql('button__x');
         });
-        it.skip('should prefer @st-namespace over @namespace');
+        it('should prefer @st-namespace over @namespace', () => {
+            const { sheets } = testStylableCore({
+                '/entry.st.css': `
+                    @namespace "ns1";
+
+                    /* @transform-remove */
+                    @st-namespace "button";
+
+                    @namespace "ns2";
+    
+                    /* @rule .button__x */
+                    .x {}
+                `,
+            });
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            expect(meta.namespace, 'meta.namespace').to.eql('button');
+            expect(
+                meta.outputAst!.toString(),
+                'not removed because @st-namespace exist'
+            ).to.satisfy((output: string) =>
+                ['@namespace "ns1";', '@namespace "ns2";'].every((def) => output.includes(def))
+            );
+        });
         it('should not use @namespace with prefix, url() or invalid namespace', () => {
             const { sheets } = testStylableCore({
                 '/entry.st.css': `

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -258,8 +258,6 @@ describe('features/st-namespace', () => {
             shouldReportNoDiagnostics(meta);
 
             expect(meta.namespace, 'meta.namespace').to.eql('button');
-            // ToDo: stop removing @namespace
-            // expect(meta.targetAst!.toString(), 'not removed').to.eql('@namespace "button"');
 
             // JS exports
             expect(exports.classes.x, `JS export`).to.eql('button__x');
@@ -283,14 +281,15 @@ describe('features/st-namespace', () => {
             shouldReportNoDiagnostics(meta);
 
             expect(meta.namespace, 'meta.namespace').to.eql('entry');
-            // expect(meta.targetAst!.toString(), 'not removed').to.satisfy((output: string) =>
-            //     [
-            //         '@namespace "http://www.w3.org/1999/xhtml";',
-            //         '@namespace prefix "button"',
-            //         '@namespace url("button")',
-            //         '@namespace prefix url("button")',
-            //     ].every((def) => output.includes(def))
-            // );
+            expect(meta.outputAst!.toString(), 'not removed unused as @st-namespace').to.satisfy(
+                (output: string) =>
+                    [
+                        '@namespace "http://www.w3.org/1999/xhtml";',
+                        '@namespace prefix "button"',
+                        '@namespace url("button")',
+                        '@namespace prefix url("button")',
+                    ].every((def) => output.includes(def))
+            );
 
             // JS exports
             expect(exports.classes.x, `JS export`).to.eql('entry__x');

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -1,11 +1,26 @@
 import chaiSubset from 'chai-subset';
 import { testStylableCore, shouldReportNoDiagnostics } from '@stylable/core-test-kit';
 import chai, { expect } from 'chai';
+import { resolve } from 'path';
+import { STNamespace } from '@stylable/core/dist/features';
 
 chai.use(chaiSubset);
 
+const diagnostics = STNamespace.diagnostics;
+
 describe(`features/st-namespace`, () => {
-    // ToDo: move and add tests when extracting feature
+    it(`should use filename as default namespace`, () => {
+        const { sheets } = testStylableCore({
+            '/a.st.css': ``,
+            '/b.st.css': ``,
+        });
+
+        const AMeta = sheets['/a.st.css'].meta;
+        const BMeta = sheets['/b.st.css'].meta;
+
+        expect(AMeta.namespace, 'a meta.namespace').to.eql('a');
+        expect(BMeta.namespace, 'b meta.namespace').to.eql('b');
+    });
     it(`should override default namespace`, () => {
         const { sheets } = testStylableCore({
             '/other.st.css': `
@@ -21,7 +36,109 @@ describe(`features/st-namespace`, () => {
 
         shouldReportNoDiagnostics(meta);
 
+        expect(meta.namespace, 'meta.namespace').to.eql('button');
+
         // JS exports
         expect(exports.classes.x, `JS export`).to.eql(`button__x`);
+    });
+    it(`should prefer st-namespace-reference path to calculate hash`, () => {
+        // assure namespace generated with st-namespace-reference
+        // is identical between source and dist with the relative correction
+        const { sheets } = testStylableCore(
+            {
+                '/dist/a.st.css': `
+                /* st-namespace-reference="../path/to/a.st.css" */
+            `,
+                '/dist/b.st.css': `
+                @namespace "xxx";
+                /* st-namespace-reference="../path/to/b.st.css" */
+            `,
+            },
+            {
+                stylableConfig: {
+                    // override test util with the default behavior
+                    // that takes the origin sheet path reference into account
+                    resolveNamespace: STNamespace.defaultProcessNamespace,
+                },
+            }
+        );
+
+        const AMeta = sheets['/dist/a.st.css'].meta;
+        const BMeta = sheets['/dist/b.st.css'].meta;
+
+        expect(AMeta.namespace, 'a meta.namespace').to.eql(
+            STNamespace.defaultProcessNamespace('a', resolve('/path/to/a.st.css'))
+        );
+        expect(BMeta.namespace, 'b meta.namespace').to.eql(
+            STNamespace.defaultProcessNamespace('xxx', resolve('/path/to/b.st.css'))
+        );
+    });
+    it(`should collect last namespace definition`, () => {
+        const { sheets } = testStylableCore({
+            '/entry.st.css': `
+                /* @transform-remove */
+                @namespace "a";
+
+                /* @transform-remove */
+                @namespace "b";
+            `,
+        });
+
+        const { meta } = sheets['/entry.st.css'];
+
+        expect(meta.namespace, 'meta.namespace').to.eql('b');
+    });
+    it(`should report non string namespace`, () => {
+        const { sheets } = testStylableCore({
+            '/entry.st.css': `
+                /* 
+                    @transform-remove
+                    @analyze-error ${diagnostics.INVALID_NAMESPACE_DEF()}
+                */
+                @namespace App;
+            `,
+        });
+
+        const { meta } = sheets['/entry.st.css'];
+
+        expect(meta.namespace, 'meta.namespace').to.eql('entry');
+    });
+    it(`should report empty namespace`, () => {
+        const { sheets } = testStylableCore({
+            '/entry.st.css': `
+                /* 
+                    @transform-remove
+                    @analyze-error ${diagnostics.EMPTY_NAMESPACE_DEF()}
+                */
+                @namespace '    ';
+            `,
+        });
+
+        const { meta } = sheets['/entry.st.css'];
+
+        expect(meta.namespace, 'meta.namespace').to.eql('entry');
+    });
+    describe('stylable API', () => {
+        it(`should resolve namespace via resolveNamespace`, () => {
+            const { sheets } = testStylableCore(
+                {
+                    '/a.st.css': ``,
+                    '/b.st.css': `@namespace "x";`,
+                },
+                {
+                    stylableConfig: {
+                        resolveNamespace(namespace) {
+                            return 'test-' + namespace;
+                        },
+                    },
+                }
+            );
+
+            const aMeta = sheets['/a.st.css'].meta;
+            const bMeta = sheets['/b.st.css'].meta;
+
+            expect(aMeta.namespace, 'a meta.namespace').to.eql('test-a');
+            expect(bMeta.namespace, 'b meta.namespace').to.eql('test-x');
+        });
     });
 });

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -8,8 +8,8 @@ chai.use(chaiSubset);
 
 const diagnostics = STNamespace.diagnostics;
 
-describe(`features/st-namespace`, () => {
-    it(`should use filename as default namespace`, () => {
+describe('features/st-namespace', () => {
+    it('should use filename as default namespace', () => {
         const { sheets } = testStylableCore({
             '/a.st.css': ``,
             '/b.st.css': ``,
@@ -21,7 +21,7 @@ describe(`features/st-namespace`, () => {
         expect(AMeta.namespace, 'a meta.namespace').to.eql('a');
         expect(BMeta.namespace, 'b meta.namespace').to.eql('b');
     });
-    it(`should override default namespace`, () => {
+    it('should override default namespace', () => {
         const { sheets } = testStylableCore({
             '/other.st.css': `
                 /* @transform-remove */
@@ -39,9 +39,9 @@ describe(`features/st-namespace`, () => {
         expect(meta.namespace, 'meta.namespace').to.eql('button');
 
         // JS exports
-        expect(exports.classes.x, `JS export`).to.eql(`button__x`);
+        expect(exports.classes.x, `JS export`).to.eql('button__x');
     });
-    it(`should prefer st-namespace-reference path to calculate hash`, () => {
+    it('should prefer st-namespace-reference path to calculate hash', () => {
         // assure namespace generated with st-namespace-reference
         // is identical between source and dist with the relative correction
         const { sheets } = testStylableCore(
@@ -73,7 +73,7 @@ describe(`features/st-namespace`, () => {
             STNamespace.defaultProcessNamespace('xxx', resolve('/path/to/b.st.css'))
         );
     });
-    it(`should collect last namespace definition`, () => {
+    it('should collect last namespace definition', () => {
         const { sheets } = testStylableCore({
             '/entry.st.css': `
                 /* @transform-remove */
@@ -88,7 +88,7 @@ describe(`features/st-namespace`, () => {
 
         expect(meta.namespace, 'meta.namespace').to.eql('b');
     });
-    it(`should report non string namespace`, () => {
+    it('should report non string namespace', () => {
         const { sheets } = testStylableCore({
             '/entry.st.css': `
                 /* 
@@ -103,7 +103,7 @@ describe(`features/st-namespace`, () => {
 
         expect(meta.namespace, 'meta.namespace').to.eql('entry');
     });
-    it(`should report empty namespace`, () => {
+    it('should report empty namespace', () => {
         const { sheets } = testStylableCore({
             '/entry.st.css': `
                 /* 
@@ -118,8 +118,16 @@ describe(`features/st-namespace`, () => {
 
         expect(meta.namespace, 'meta.namespace').to.eql('entry');
     });
+    it('should report invalid namespace reference', () => {
+        testStylableCore({
+            'a.st.css': `
+                /* @analyze-error ${diagnostics.INVALID_NAMESPACE_REFERENCE()} */
+                /* st-namespace-reference */
+            `,
+        });
+    });
     describe('stylable API', () => {
-        it(`should resolve namespace via resolveNamespace`, () => {
+        it('should resolve namespace via resolveNamespace', () => {
             const { sheets } = testStylableCore(
                 {
                     '/a.st.css': ``,

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -47,12 +47,12 @@ describe('features/st-namespace', () => {
         const { sheets } = testStylableCore(
             {
                 '/dist/a.st.css': `
-                /* st-namespace-reference="../path/to/a.st.css" */
-            `,
+                    /* st-namespace-reference="../path/to/a.st.css" */
+                `,
                 '/dist/b.st.css': `
-                @namespace "xxx";
-                /* st-namespace-reference="../path/to/b.st.css" */
-            `,
+                    @namespace "xxx";
+                    /* st-namespace-reference="../path/to/b.st.css" */
+                `,
             },
             {
                 stylableConfig: {
@@ -77,10 +77,10 @@ describe('features/st-namespace', () => {
         const { sheets } = testStylableCore({
             '/entry.st.css': `
                 /* @transform-remove */
-                @namespace "a";
+                @st-namespace "a";
 
                 /* @transform-remove */
-                @namespace "b";
+                @st-namespace "b";
             `,
         });
 
@@ -88,14 +88,91 @@ describe('features/st-namespace', () => {
 
         expect(meta.namespace, 'meta.namespace').to.eql('b');
     });
+    it('should ignore comments and spaces', () => {
+        const { sheets } = testStylableCore({
+            '/other.st.css': `
+                /* @transform-remove */
+                @st-namespace /*c1*//*c2*/ "button"/*c3*/ ;
+
+                /* @rule .button__x */
+                .x {}
+            `,
+        });
+
+        const { meta, exports } = sheets['/other.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+
+        expect(meta.namespace, 'meta.namespace').to.eql('button');
+
+        // JS exports
+        expect(exports.classes.x, `JS export`).to.eql('button__x');
+    });
+    it('should accept ident-like value', () => {
+        const { sheets } = testStylableCore({
+            '/emoji.st.css': `
+                @st-namespace "🤡abc🤡";
+
+                /* ToDo: fix inline expectation issue with emoji comparison */
+                /* skip-rule .🤡abc🤡__x */
+                .x {}
+            `,
+            '/numbers.st.css': `
+                @st-namespace "x123";
+
+                /* @rule .x123__x */
+                .x {}
+            `,
+            '/underscore.st.css': `
+                @st-namespace "_x123_";
+
+                /* @rule ._x123___x */
+                .x {}
+            `,
+            '/dash.st.css': `
+                @st-namespace "---";
+
+                /* x-@rule .\\---__x */
+                .x {}
+            `,
+        });
+        const emojiMeta = sheets['/emoji.st.css'].meta;
+        const numbersMeta = sheets['/numbers.st.css'].meta;
+        const underscoreMeta = sheets['/underscore.st.css'].meta;
+        const dashMeta = sheets['/dash.st.css'].meta;
+
+        shouldReportNoDiagnostics(emojiMeta);
+        expect(emojiMeta.namespace, ' emoji namespace').to.eql('🤡abc🤡');
+
+        shouldReportNoDiagnostics(numbersMeta);
+        expect(numbersMeta.namespace, 'numbers namespace').to.eql('x123');
+
+        shouldReportNoDiagnostics(underscoreMeta);
+        expect(underscoreMeta.namespace, 'underscore namespace').to.eql('_x123_');
+
+        shouldReportNoDiagnostics(dashMeta);
+        expect(dashMeta.namespace, 'dash namespace').to.eql('---');
+    });
     it('should report non string namespace', () => {
         const { sheets } = testStylableCore({
             '/entry.st.css': `
                 /* 
                     @transform-remove
-                    @analyze-error ${diagnostics.INVALID_NAMESPACE_DEF()}
+                    @analyze-error(not string) ${diagnostics.INVALID_NAMESPACE_DEF()}
                 */
-                @namespace App;
+                @st-namespace App;
+
+                /* 
+                    @transform-remove
+                    @analyze-error(multiple strings) word("b") ${diagnostics.EXTRA_DEFINITION()}
+                */
+                @st-namespace "a""b";
+
+                /* 
+                    @transform-remove
+                    @analyze-error(ident+string) word(ident) ${diagnostics.EXTRA_DEFINITION()}
+                */
+                @st-namespace ident "a";
             `,
         });
 
@@ -108,9 +185,42 @@ describe('features/st-namespace', () => {
             '/entry.st.css': `
                 /* 
                     @transform-remove
-                    @analyze-error ${diagnostics.EMPTY_NAMESPACE_DEF()}
+                    @analyze-error(spaced) ${diagnostics.EMPTY_NAMESPACE_DEF()}
                 */
                 @st-namespace '    ';
+                
+                /* 
+                    @transform-remove
+                    @analyze-error(empty) ${diagnostics.EMPTY_NAMESPACE_DEF()}
+                */
+                @st-namespace ;
+            `,
+        });
+
+        const { meta } = sheets['/entry.st.css'];
+
+        expect(meta.namespace, 'meta.namespace').to.eql('entry');
+    });
+    it('should report non valid namespace value', () => {
+        const { sheets } = testStylableCore({
+            '/entry.st.css': `
+                /* 
+                    @transform-remove
+                    @analyze-error(dot) word(a.b) ${diagnostics.INVALID_NAMESPACE_VALUE()}
+                */
+                @st-namespace "a.b";
+
+                /* 
+                    @transform-remove
+                    @analyze-error(colon+slash) word(a://b) ${diagnostics.INVALID_NAMESPACE_VALUE()}
+                */
+                @st-namespace "a://b";
+                
+                /* 
+                    @transform-remove
+                    @analyze-error(start with number) word(5abc) ${diagnostics.INVALID_NAMESPACE_VALUE()}
+                */
+                @st-namespace "5abc";
             `,
         });
 
@@ -128,8 +238,8 @@ describe('features/st-namespace', () => {
     });
     describe('legacy @namespace behavior', () => {
         /*
-            @namespace was previously used instead of @namespace
-            to preserve backwards compatibility, @namespace will
+            @namespace was previously used instead of @st-namespace.
+            In order to preserve backwards compatibility, @namespace will
             continue to define the stylable namespace under specific conditions.
         */
         it('should override default namespace with @namespace', () => {
@@ -155,7 +265,36 @@ describe('features/st-namespace', () => {
             expect(exports.classes.x, `JS export`).to.eql('button__x');
         });
         it.skip('should prefer @st-namespace over @namespace');
-        it.skip('should not use @namespace with prefix or url()');
+        it('should not use @namespace with prefix, url() or invalid namespace', () => {
+            const { sheets } = testStylableCore({
+                '/entry.st.css': `
+                    @namespace "http://www.w3.org/1999/xhtml";
+                    @namespace prefix "button";
+                    @namespace url("button");
+                    @namespace prefix url("button");
+    
+                    /* @rule .entry__x */
+                    .x {}
+                `,
+            });
+
+            const { meta, exports } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            expect(meta.namespace, 'meta.namespace').to.eql('entry');
+            // expect(meta.targetAst!.toString(), 'not removed').to.satisfy((output: string) =>
+            //     [
+            //         '@namespace "http://www.w3.org/1999/xhtml";',
+            //         '@namespace prefix "button"',
+            //         '@namespace url("button")',
+            //         '@namespace prefix url("button")',
+            //     ].every((def) => output.includes(def))
+            // );
+
+            // JS exports
+            expect(exports.classes.x, `JS export`).to.eql('entry__x');
+        });
     });
     describe('stylable API', () => {
         it('should resolve namespace via resolveNamespace', () => {

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -21,11 +21,11 @@ describe('features/st-namespace', () => {
         expect(AMeta.namespace, 'a meta.namespace').to.eql('a');
         expect(BMeta.namespace, 'b meta.namespace').to.eql('b');
     });
-    it('should override default namespace', () => {
+    it('should override default namespace with @st-namespace', () => {
         const { sheets } = testStylableCore({
             '/other.st.css': `
                 /* @transform-remove */
-                @namespace "button";
+                @st-namespace "button";
 
                 /* @rule .button__x */
                 .x {}
@@ -41,7 +41,7 @@ describe('features/st-namespace', () => {
         // JS exports
         expect(exports.classes.x, `JS export`).to.eql('button__x');
     });
-    it('should prefer st-namespace-reference path to calculate hash', () => {
+    it('should prefer st-namespace-reference path to calculate hash part of namespace', () => {
         // assure namespace generated with st-namespace-reference
         // is identical between source and dist with the relative correction
         const { sheets } = testStylableCore(
@@ -110,7 +110,7 @@ describe('features/st-namespace', () => {
                     @transform-remove
                     @analyze-error ${diagnostics.EMPTY_NAMESPACE_DEF()}
                 */
-                @namespace '    ';
+                @st-namespace '    ';
             `,
         });
 
@@ -126,12 +126,43 @@ describe('features/st-namespace', () => {
             `,
         });
     });
+    describe('legacy @namespace behavior', () => {
+        /*
+            @namespace was previously used instead of @namespace
+            to preserve backwards compatibility, @namespace will
+            continue to define the stylable namespace under specific conditions.
+        */
+        it('should override default namespace with @namespace', () => {
+            const { sheets } = testStylableCore({
+                '/other.st.css': `
+                    /* @transform-remove */
+                    @namespace "button";
+    
+                    /* @rule .button__x */
+                    .x {}
+                `,
+            });
+
+            const { meta, exports } = sheets['/other.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            expect(meta.namespace, 'meta.namespace').to.eql('button');
+            // ToDo: stop removing @namespace
+            // expect(meta.targetAst!.toString(), 'not removed').to.eql('@namespace "button"');
+
+            // JS exports
+            expect(exports.classes.x, `JS export`).to.eql('button__x');
+        });
+        it.skip('should prefer @st-namespace over @namespace');
+        it.skip('should not use @namespace with prefix or url()');
+    });
     describe('stylable API', () => {
         it('should resolve namespace via resolveNamespace', () => {
             const { sheets } = testStylableCore(
                 {
                     '/a.st.css': ``,
-                    '/b.st.css': `@namespace "x";`,
+                    '/b.st.css': `@st-namespace "x";`,
                 },
                 {
                     stylableConfig: {

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -3,6 +3,7 @@ import chai, { expect } from 'chai';
 import { flatMatch, processSource } from '@stylable/core-test-kit';
 import { processNamespace, processorWarnings } from '@stylable/core';
 import { knownPseudoClassesWithNestedSelectors } from '@stylable/core/dist/native-reserved-lists';
+import { STNamespace } from '@stylable/core/dist/features';
 
 chai.use(flatMatch);
 
@@ -21,7 +22,7 @@ describe('Stylable postcss process', () => {
 
         expect(diagnostics.reports[0]).to.include({
             type: 'error',
-            message: processorWarnings.INVALID_NAMESPACE_DEF(),
+            message: STNamespace.diagnostics.INVALID_NAMESPACE_DEF(),
         });
     });
 
@@ -30,7 +31,7 @@ describe('Stylable postcss process', () => {
 
         expect(diagnostics.reports[0]).to.include({
             type: 'error',
-            message: processorWarnings.EMPTY_NAMESPACE_DEF(),
+            message: STNamespace.diagnostics.EMPTY_NAMESPACE_DEF(),
         });
     });
 

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -3,7 +3,6 @@ import chai, { expect } from 'chai';
 import { flatMatch, processSource } from '@stylable/core-test-kit';
 import { processNamespace, processorWarnings } from '@stylable/core';
 import { knownPseudoClassesWithNestedSelectors } from '@stylable/core/dist/native-reserved-lists';
-import { STNamespace } from '@stylable/core/dist/features';
 
 chai.use(flatMatch);
 
@@ -14,24 +13,6 @@ describe('Stylable postcss process', () => {
         expect(diagnostics.reports[0]).to.include({
             type: 'error',
             message: 'missing source filename',
-        });
-    });
-
-    it('report on invalid namespace', () => {
-        const { diagnostics } = processSource(`@namespace App;`, { from: '/path/to/source' });
-
-        expect(diagnostics.reports[0]).to.include({
-            type: 'error',
-            message: STNamespace.diagnostics.INVALID_NAMESPACE_DEF(),
-        });
-    });
-
-    it('warn on empty-ish namespace', () => {
-        const { diagnostics } = processSource(`@namespace '   ';`, { from: '/path/to/source' });
-
-        expect(diagnostics.reports[0]).to.include({
-            type: 'error',
-            message: STNamespace.diagnostics.EMPTY_NAMESPACE_DEF(),
         });
     });
 
@@ -50,48 +31,6 @@ describe('Stylable postcss process', () => {
             type: 'error',
             message: processorWarnings.INVALID_NESTING('.y', '.x'),
         });
-    });
-
-    it('collect namespace', () => {
-        const from = resolve('/path/to/style.css');
-        const result = processSource(
-            `
-            @namespace "name";
-            @namespace 'anther-name';
-        `,
-            { from }
-        );
-
-        expect(result.namespace).to.equal(processNamespace('anther-name', from));
-    });
-
-    it('resolve namespace hook', () => {
-        const from = resolve('/path/to/style.css');
-        const result = processSource(
-            `
-            @namespace "name";
-        `,
-            { from },
-            (s) => 'Test-' + s
-        );
-
-        expect(result.namespace).to.equal('Test-name');
-    });
-
-    it('use filename as default namespace prefix', () => {
-        const from = resolve('/path/to/style.st.css');
-        const distFrom = resolve('/dist/path/to/style.st.css');
-
-        const result = processSource(
-            `
-            /* st-namespace-reference="../../../path/to/style.st.css" */\n
-        `,
-            { from: distFrom }
-        );
-
-        // assure namespace generated with st-namespace-reference
-        // is identical between source and dist with the relative correction
-        expect(result.namespace).to.eql(processNamespace('style', from));
     });
 
     it('use filename as default namespace prefix (empty)', () => {

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -43,7 +43,7 @@ describe('stylable-resolver', () => {
     it('should resolve extend classes', () => {
         const { fs } = testStylableCore({
             '/button.st.css': `
-                @namespace:'Button';
+                @st-namespace:'Button';
                 .root {
                     color:red;
                 }
@@ -69,7 +69,7 @@ describe('stylable-resolver', () => {
     it('should resolve extend elements', () => {
         const { fs } = testStylableCore({
             '/button.st.css': `
-                @namespace:'Button';
+                @st-namespace:'Button';
                 .root {
                     color:red;
                 }
@@ -94,7 +94,7 @@ describe('stylable-resolver', () => {
     it('should not enter infinite loops even with broken code', () => {
         const { fs } = testStylableCore({
             '/button.st.css': `
-                @namespace: 'Button';
+                @st-namespace: 'Button';
                 :import {
                     -st-from: './extended-button.st.css';
                     -st-default: Button;

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -290,7 +290,7 @@ export const RulesetInternalDirectivesProvider: CompletionProvider & {
 };
 
 // Only top level
-// @namespace may not repeat
+// @st-namespace may not repeat
 export const TopLevelDirectiveProvider: CompletionProvider = {
     provide({
         parentSelector,

--- a/packages/language-service/src/lib/completion-types.ts
+++ b/packages/language-service/src/lib/completion-types.ts
@@ -30,7 +30,7 @@ export const rulesetDirectives = {
 
 export const topLevelDirectives = {
     root: '.root' as const,
-    namespace: '@namespace' as const,
+    namespace: '@st-namespace' as const,
     customSelector: '@custom-selector :--' as const,
     vars: ':vars' as const,
     import: ':import' as const,
@@ -116,7 +116,7 @@ export function topLevelDirective(type: keyof typeof topLevelDirectives, rng: Pr
                 topLevelDirectives.namespace,
                 'Declare a namespace for the file',
                 'a',
-                new Snippet('@namespace "$1";\n'),
+                new Snippet('@st-namespace "$1";\n'),
                 rng
             );
         case topLevelDirectives.customSelector:

--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -136,6 +136,7 @@ export class CssService {
                     diag.code === 'unknownAtRules' &&
                     (atRuleName === '@custom-selector' ||
                         atRuleName === '@st-scope' ||
+                        atRuleName === '@st-namespace' ||
                         atRuleName === '@st-import' ||
                         atRuleName === '@st-global-custom-property')
                 ) {

--- a/packages/language-service/test/fixtures/server-cases/imports/top-level-import-exists.st.css
+++ b/packages/language-service/test/fixtures/server-cases/imports/top-level-import-exists.st.css
@@ -1,4 +1,4 @@
-@namespace "moshe";
+@st-namespace "moshe";
 
 :import {
     -st-from: "./import-from-here.st.css";

--- a/packages/language-service/test/lib/completions/namespace-directive.spec.ts
+++ b/packages/language-service/test/lib/completions/namespace-directive.spec.ts
@@ -1,9 +1,12 @@
 import { createRange } from '@stylable/language-service/dist/lib/completion-providers';
 import { topLevelDirectives } from '@stylable/language-service/dist/lib/completion-types';
 import * as asserters from '../../test-kit/completions-asserters';
+import { expect } from 'chai';
+import { createDiagnostics } from '../../test-kit/diagnostics-setup';
+import deindent from 'deindent';
 
 describe('Namespace Directive', () => {
-    describe('should complete @namespace at top level ', () => {
+    describe('should complete @st-namespace at top level ', () => {
         topLevelDirectives.namespace.split('').map((_c, i) => {
             const prefix = topLevelDirectives.namespace.slice(0, i);
             it(' with Prefix: ' + prefix + ' ', () => {
@@ -15,23 +18,37 @@ describe('Namespace Directive', () => {
         });
     });
 
-    it('should not complete @namespace if exists', () => {
+    it('should not complete @st-namespace if exists', () => {
         const asserter = asserters.getCompletions('imports/top-level-import-exists.st.css');
         asserter.notSuggested([asserters.namespaceDirectiveCompletion(createRange(0, 0, 0, 0))]);
     });
 
-    it('should not complete @namespace inside rulesets', () => {
+    it('should not complete @st-namespace inside rulesets', () => {
         const asserter = asserters.getCompletions('imports/inside-ruleset.st.css');
         asserter.notSuggested([asserters.namespaceDirectiveCompletion(createRange(0, 0, 0, 0))]);
     });
 
-    it('should not complete @namespace inside selectors', () => {
+    it('should not complete @st-namespace inside selectors', () => {
         const asserter = asserters.getCompletions('imports/before-selector.st.css');
         asserter.notSuggested([asserters.namespaceDirectiveCompletion(createRange(0, 0, 0, 0))]);
     });
 
-    it('should not complete @namespace inside media query', () => {
+    it('should not complete @st-namespace inside media query', () => {
         const asserter = asserters.getCompletions('imports/media-query.st.css');
         asserter.notSuggested([asserters.namespaceDirectiveCompletion(createRange(0, 0, 0, 0))]);
+    });
+    it('should ignore native css lsp diagnostics unknown @st-namespace atrule', () => {
+        const filePath = '/style.st.css';
+
+        const diagnostics = createDiagnostics(
+            {
+                [filePath]: deindent`
+                    @st-namespace "comp";
+                `,
+            },
+            filePath
+        );
+
+        expect(diagnostics).to.eql([]);
     });
 });

--- a/packages/language-service/test/test-kit/completions-asserters.ts
+++ b/packages/language-service/test/test-kit/completions-asserters.ts
@@ -130,10 +130,10 @@ export const stScopeDirectiveCompletion: (rng: ProviderRange) => Partial<Complet
 };
 export const namespaceDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
-        label: '@namespace',
+        label: '@st-namespace',
         detail: 'Declare a namespace for the file',
         sortText: 'a',
-        insertText: '@namespace "$1";\n',
+        insertText: '@st-namespace "$1";\n',
         range: rng,
     };
 };

--- a/packages/webpack-plugin/test/e2e/projects/3rd-party-standalone/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/3rd-party-standalone/src/index.st.css
@@ -1,4 +1,4 @@
-@namespace "SRCIndex";
+@st-namespace "SRCIndex";
 
 :import {
     -st-from: "test-components/index.st.css";

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/src/index.st.css
@@ -1,4 +1,4 @@
-@namespace "mainIndex";
+@st-namespace "mainIndex";
 
 :import {
     -st-from: "test-components/index.st.css";

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/index.st.css
@@ -1,4 +1,4 @@
-@namespace "X";
+@st-namespace "X";
 
 .root {
     color: red;

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/same-index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace-warning/src/same-index.st.css
@@ -1,4 +1,4 @@
-@namespace "X";
+@st-namespace "X";
 
 .root {
     color: red;

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace/src/index.st.css
@@ -1,4 +1,4 @@
-@namespace "X";
+@st-namespace "X";
 
 .root {
     color: red;

--- a/packages/webpack-plugin/test/e2e/projects/duplicate-namespace/src/same-index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/duplicate-namespace/src/same-index.st.css
@@ -1,4 +1,4 @@
-@namespace "X";
+@st-namespace "X";
 
 .root {
     color: red;


### PR DESCRIPTION
This PR adds support for `@st-namespace` that was added in v5 to v4

- added to v5 in #2624 