### PR TITLE
infra(e2e-test-kit): default project runner inner step timeout flakiness

### DIFF
--- a/packages/e2e-test-kit/src/project-runner.ts
+++ b/packages/e2e-test-kit/src/project-runner.ts
@@ -22,6 +22,7 @@ export interface Options {
     watchMode?: boolean;
     useTempDir?: boolean;
     tempDirPath?: string;
+    totalTestTime?: number;
 }
 
 type MochaHook = import('mocha').HookFunction;
@@ -38,7 +39,7 @@ export class ProjectRunner {
         const projectRunner = new this(runnerOptions);
 
         before('bundle and serve project', async function () {
-            this.timeout(40000);
+            this.timeout(runnerOptions.totalTestTime ?? 40000);
             await projectRunner.run();
             await projectRunner.serve();
         });

--- a/packages/webpack-plugin/test/e2e/deep-js.spec.ts
+++ b/packages/webpack-plugin/test/e2e/deep-js.spec.ts
@@ -2,7 +2,6 @@ import { StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { expect } from 'chai';
 import { promises } from 'fs';
 import { dirname, join } from 'path';
-import { waitFor } from 'promise-assist';
 
 const project = 'deep-js';
 const projectDir = dirname(
@@ -37,7 +36,7 @@ describe(`(${project})`, () => {
                     join(projectRunner.testDir, 'src', 'mixin.js'),
                     `module.exports = () => ({ color: 'green' });`
                 ),
-            () =>
+            (waitFor) =>
                 waitFor(
                     async () => {
                         await page.reload();

--- a/packages/webpack-plugin/test/e2e/stc-watched-project.spec.ts
+++ b/packages/webpack-plugin/test/e2e/stc-watched-project.spec.ts
@@ -2,7 +2,6 @@ import { promises } from 'fs';
 import { dirname, join } from 'path';
 import { expect } from 'chai';
 import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
-import { waitFor } from 'promise-assist';
 
 const { writeFile } = promises;
 
@@ -46,7 +45,7 @@ describe(`(${project})`, () => {
                     join(projectRunner.testDir, 'style-source', 'style-b.st.css'),
                     '.b{ color: green; }'
                 ),
-            () =>
+            (waitFor) =>
                 waitFor(() => {
                     expect(projectRunner.getProjectFiles()['style-output/style-b.st.css']).to.eql(
                         '.b{ color: green; }'
@@ -68,7 +67,7 @@ describe(`(${project})`, () => {
                     }
                 `
                 ),
-            () =>
+            (waitFor) =>
                 waitFor(async () => {
                     await page.reload();
                     const styleElements = await page.evaluate(
@@ -90,7 +89,7 @@ describe(`(${project})`, () => {
                     join(projectRunner.testDir, 'style-source', 'style-b.st.css'),
                     '.b{ color: blue; }'
                 ),
-            () =>
+            (waitFor) =>
                 waitFor(
                     async () => {
                         expect(
@@ -108,7 +107,7 @@ describe(`(${project})`, () => {
                             /\.index\d+__root \{ color: blue; z-index: 1; \}/
                         );
                     },
-                    { timeout: 5_000, delay: 0 }
+                    { delay: 0 }
                 )
         );
     });


### PR DESCRIPTION
This PR fixes a flakiness with tests that use the `projectRunner` inner async step `actAndWaitForRecompile` with low default timeout in their validate state (or no timeout handling).

**Changes**
- [x] provides a `waitFor` function to the `validate` hook with high default timeout (15s)
- [x] use the provided waitFor in tests
- [x] wrap `validate` step with a timeout in case inner hook doesn't check timeout
- [x] allow override of `totalTestTime` 



**Could improve in the future**

The solution is not ideal, it would be better to start with a minimal total time and increase the timeout for each async step. But (1) Mocha timeout API doesn't allow changing the timeout during test, and (2) wrapping mocha test with a custom timeout is not simple without wrapping the `it` functions themselves, or adding test lifecycle to the `projectRunner`.