### PR TITLE
fix(lsp): `@property` unknown at-rule diagnostic

### DIFF
--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -138,6 +138,7 @@ export class CssService {
                         atRuleName === '@st-scope' ||
                         atRuleName === '@st-namespace' ||
                         atRuleName === '@st-import' ||
+                        atRuleName === '@property' ||
                         atRuleName === '@st-global-custom-property')
                 ) {
                     return false;

--- a/packages/language-service/test/lib/completions/custom-property.spec.ts
+++ b/packages/language-service/test/lib/completions/custom-property.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { createDiagnostics } from '../../test-kit/diagnostics-setup';
+import deindent from 'deindent';
+
+describe('custom property', () => {
+    it('should ignore native css lsp diagnostics unknown @property at-rule', () => {
+        // remove once css lsp supports is added or we implement the complete lsp ourselves
+        const filePath = '/style.st.css';
+
+        const diagnostics = createDiagnostics(
+            {
+                [filePath]: deindent`
+                    @property --x;
+                    @property --y {
+                        syntax: '<color>';
+                        inherits: true; 
+                        initial-value: green;
+                    }
+                `,
+            },
+            filePath
+        );
+
+        expect(diagnostics).to.eql([]);
+    });
+});


### PR DESCRIPTION
This PR adds the `@property` at-rule to the ignore list of `unknown at-rules` coming from the `vscode-css-languageservice`