### PR TITLE
fix(core): allow value reference in st-map

### DIFF
--- a/packages/core/src/custom-values.ts
+++ b/packages/core/src/custom-values.ts
@@ -154,6 +154,13 @@ export const CustomValueStrategy = {
                     } else {
                         resolvedValue = unbox(getStringValue(valueNode), !boxPrimitive);
                     }
+                } else if (typeof resolvedValue === 'string') {
+                    const parsedArg = postcssValueParser(resolvedValue).nodes[0];
+                    const ct = parsedArg.type === 'function' && parsedArg.value;
+                    resolvedValue =
+                        typeof ct === 'string' && customTypes[ct]
+                            ? customTypes[ct].evalVarAst(parsedArg, customTypes, boxPrimitive)
+                            : unbox(resolvedValue, !boxPrimitive);
                 }
             } else {
                 resolvedValue = unbox(getStringValue(valueNodes), !boxPrimitive);

--- a/packages/core/src/custom-values.ts
+++ b/packages/core/src/custom-values.ts
@@ -143,27 +143,30 @@ export const CustomValueStrategy = {
             let resolvedValue;
             if (valueNodes.length === 0) {
                 // TODO: error
-            } else if (valueNodes.length === 1) {
-                const valueNode = valueNodes[0];
-                resolvedValue = valueNode.resolvedValue;
-
-                if (!resolvedValue) {
-                    const ct = customTypes[valueNode.value];
-                    if (valueNode.type === 'function' && ct) {
-                        resolvedValue = ct.evalVarAst(valueNode, customTypes, boxPrimitive);
-                    } else {
-                        resolvedValue = unbox(getStringValue(valueNode), !boxPrimitive);
-                    }
-                } else if (typeof resolvedValue === 'string') {
-                    const parsedArg = postcssValueParser(resolvedValue).nodes[0];
-                    const ct = parsedArg.type === 'function' && parsedArg.value;
-                    resolvedValue =
-                        typeof ct === 'string' && customTypes[ct]
-                            ? customTypes[ct].evalVarAst(parsedArg, customTypes, boxPrimitive)
-                            : unbox(resolvedValue, !boxPrimitive);
-                }
             } else {
-                resolvedValue = unbox(getStringValue(valueNodes), !boxPrimitive);
+                const nonComments = valueNodes.filter((node) => node.type !== 'comment');
+                if (nonComments.length === 1) {
+                    const valueNode = nonComments[0];
+                    resolvedValue = valueNode.resolvedValue;
+
+                    if (!resolvedValue) {
+                        const ct = customTypes[valueNode.value];
+                        if (valueNode.type === 'function' && ct) {
+                            resolvedValue = ct.evalVarAst(valueNode, customTypes, boxPrimitive);
+                        } else {
+                            resolvedValue = unbox(getStringValue(valueNode), !boxPrimitive);
+                        }
+                    } else if (typeof resolvedValue === 'string') {
+                        const parsedArg = postcssValueParser(resolvedValue).nodes[0];
+                        const ct = parsedArg.type === 'function' && parsedArg.value;
+                        resolvedValue =
+                            typeof ct === 'string' && customTypes[ct]
+                                ? customTypes[ct].evalVarAst(parsedArg, customTypes, boxPrimitive)
+                                : unbox(resolvedValue, !boxPrimitive);
+                    }
+                } else {
+                    resolvedValue = unbox(getStringValue(valueNodes), !boxPrimitive);
+                }
             }
 
             if (resolvedValue) {

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -419,7 +419,6 @@ describe(`features/st-var`, () => {
             ]);
         });
         it(`should support build-in st-map`, () => {
-            // ToDo: fix path to nested reference map
             const { sheets } = testStylableCore(`
                 :vars {
                     shallow: st-map(
@@ -459,7 +458,7 @@ describe(`features/st-var`, () => {
                     /* @decl(deep inline map) prop: Z */
                     prop: value(deep, inline-map, z);
 
-                    /* @ToDo-decl(deep ref map) prop: B */
+                    /* @decl(deep ref map) prop: B */
                     prop: value(deep, ref-map, b);
                 }
             `);
@@ -475,8 +474,7 @@ describe(`features/st-var`, () => {
                 'inline-value': `INLINE-VALUE`,
                 concat: `abc INLINE-VALUE xyz`,
                 'inline-map': { y: `Y`, z: `Z` },
-                // ToDo: fix
-                'ref-map': `st-map(\n                        a A,\n                        b B\n                    )`,
+                'ref-map': { a: 'A', b: 'B' },
             });
         });
         it(`should support extended custom type`, () => {
@@ -1311,13 +1309,14 @@ describe(`features/st-var`, () => {
                     a: red;
                     b: blue;
                     c: st-array(value(a), gold);
+                    d: st-map(x value(b), y silver);
                 }
                 `);
 
                 const { meta } = sheets['/entry.st.css'];
                 const computedVars = stylable.stVar.getComputed(meta);
 
-                expect(Object.keys(computedVars)).to.eql(['a', 'b', 'c']);
+                expect(Object.keys(computedVars)).to.eql(['a', 'b', 'c', 'd']);
                 expect(computedVars.a).to.containSubset({
                     value: 'red',
                     input: {
@@ -1352,6 +1351,25 @@ describe(`features/st-var`, () => {
                                 value: 'gold',
                             },
                         ],
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.d).to.containSubset({
+                    value: { x: 'blue', y: 'silver' },
+                    input: {
+                        type: 'st-map',
+                        value: {
+                            x: {
+                                flatValue: 'blue',
+                                type: 'st-string',
+                                value: 'blue',
+                            },
+                            y: {
+                                flatValue: 'silver',
+                                type: 'st-string',
+                                value: 'silver',
+                            },
+                        },
                     },
                     diagnostics: { reports: [] },
                 });
@@ -1504,6 +1522,7 @@ describe(`features/st-var`, () => {
                     :vars {
                         a: value(imported);
                         b: st-map(a value(imported));
+                        c: st-array(value(imported));
                     }
                     `,
                     'imported.st.css': `
@@ -1516,7 +1535,7 @@ describe(`features/st-var`, () => {
                 const { meta } = sheets['/entry.st.css'];
                 const computedVars = stylable.stVar.getComputed(meta);
 
-                expect(Object.keys(computedVars)).to.eql(['imported', 'a', 'b']);
+                expect(Object.keys(computedVars)).to.eql(['imported', 'a', 'b', 'c']);
                 expect(computedVars.imported).to.containSubset({
                     value: 'red',
                     input: {
@@ -1540,8 +1559,26 @@ describe(`features/st-var`, () => {
                     input: {
                         type: 'st-map',
                         value: {
-                            a: 'red',
+                            a: {
+                                flatValue: 'red',
+                                type: 'st-string',
+                                value: 'red',
+                            },
                         },
+                    },
+                    diagnostics: { reports: [] },
+                });
+                expect(computedVars.c).to.containSubset({
+                    value: ['red'],
+                    input: {
+                        type: 'st-array',
+                        value: [
+                            {
+                                flatValue: 'red',
+                                type: 'st-string',
+                                value: 'red',
+                            },
+                        ],
                     },
                     diagnostics: { reports: [] },
                 });

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -427,16 +427,18 @@ describe(`features/st-var`, () => {
                     );
 
                     str: INLINE-VALUE;
+                    strWithComments: /*c1*/INLINE-VALUE/*c2*/;
 
                     deep: st-map(
                         inline-text INLINE-TEXT,
                         inline-value value(str),
                         concat abc value(str) xyz,
                         inline-map st-map(
-                            y Y, 
+                            y Y,
                             z Z
                         ),
                         ref-map value(shallow),
+                        comments /*c3*/value(strWithComments)/*c4*/,
                     );
                 }
                 .root {
@@ -448,10 +450,10 @@ describe(`features/st-var`, () => {
 
                     /* @decl(deep inline text) prop: INLINE-TEXT */
                     prop: value(deep, inline-text);
-                    
+
                     /* @decl(deep inline value) prop: INLINE-VALUE */
                     prop: value(deep, inline-value);
-                    
+
                     /* @decl(deep concat) prop: abc INLINE-VALUE xyz */
                     prop: value(deep, concat);
 
@@ -460,6 +462,9 @@ describe(`features/st-var`, () => {
 
                     /* @decl(deep ref map) prop: B */
                     prop: value(deep, ref-map, b);
+
+                    /* @decl(deep comments) prop: INLINE-VALUE */
+                    prop: value(deep, comments);
                 }
             `);
 
@@ -475,6 +480,7 @@ describe(`features/st-var`, () => {
                 concat: `abc INLINE-VALUE xyz`,
                 'inline-map': { y: `Y`, z: `Z` },
                 'ref-map': { a: 'A', b: 'B' },
+                comments: 'INLINE-VALUE',
             });
         });
         it(`should support extended custom type`, () => {


### PR DESCRIPTION
This PR fixes a bug that prevented nesting referenced `value()` within a `st-map` var type:

```css
:vars {
  list: st-array(red, green);
  map: st-map(key value(list))
}
.a {
  prop: value(map, key, 1) /* should return "green" */

  /* before fix it evaluated to */
  prop: st-array(red, green);
}
``` 

-----

In addition this also fixes the output from `stylable.stVar.getComputed` to return the unboxed value on the input field instead of the runtime value:

```css
:vars {
  green: green;
  inline: st-map(a red);
  reference: st-map(a value(red));
}
```
So that `stylable.stVar.getComputed(meta)` returns `inline` and `reference` with the same value:

```js
// correct result after fix:
{
  value: { a: 'green' },
  input: {
    type: 'st-map',
    value: {
      a: {
        flatValue: 'green',
        type: 'st-string',
        value: 'green',
    },
  },
}

// previously inline would return the correct result and reference would return:
{
  value: { a: 'green' },
  input: {
    type: 'st-map',
    value: {
      a: 'green',
    },
  },
}
```