### PR TITLE
fix(jest): process output matches new api

### DIFF
--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -33,7 +33,7 @@ export interface StylableJestConfig {
 }
 
 export const createTransformer = (options?: StylableJestConfig) => {
-    const process = stylableModuleFactory(
+    const moduleFactory = stylableModuleFactory(
         {
             fileSystem: fs,
             requireModule: require,
@@ -45,6 +45,15 @@ export const createTransformer = (options?: StylableJestConfig) => {
         // this allows @stylable/jest to be used as part of a globally installed CLI
         { runtimePath: stylableRuntimePath }
     );
+
+    const process = (source: string, path: string) => {
+        const res = new String(moduleFactory(source, path));
+
+        // v28+ Jest transformer API expects a `code` property with the transformed source
+        (res as string & { code: string }).code = res.toString();
+
+        return res as string & { code: string };
+    };
 
     return {
         process,

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -47,12 +47,7 @@ export const createTransformer = (options?: StylableJestConfig) => {
     );
 
     const process = (source: string, path: string) => {
-        const res = new String(moduleFactory(source, path));
-
-        // v28+ Jest transformer API expects a `code` property with the transformed source
-        (res as string & { code: string }).code = res.toString();
-
-        return res as string & { code: string };
+        return { code: moduleFactory(source, path) };
     };
 
     return {

--- a/packages/jest/test/jest.spec.ts
+++ b/packages/jest/test/jest.spec.ts
@@ -34,18 +34,4 @@ describe('jest process', () => {
         expect(module.classes.root).to.equal(`test-custom__root`);
         expect(module.classes.test).to.equal(`test-custom__test`);
     });
-
-    it('should maintain compatibility with previous string based transformers', () => {
-        const filename = require.resolve('@stylable/jest/test/fixtures/test.st.css');
-        const content = readFileSync(filename, 'utf8');
-        const transformer = stylableTransformer.createTransformer();
-
-        const code = transformer.process(content, filename).code;
-
-        expect(typeof code).to.equal('string');
-
-        const module = nodeEval(code, filename) as RuntimeStylesheet;
-
-        expect(module.classes.root).to.equal(`${module.namespace}__root`);
-    });
 });

--- a/packages/jest/test/jest.spec.ts
+++ b/packages/jest/test/jest.spec.ts
@@ -11,7 +11,7 @@ describe('jest process', () => {
         const transformer = stylableTransformer.createTransformer();
 
         const module = nodeEval(
-            transformer.process(content, filename),
+            transformer.process(content, filename).code,
             filename
         ) as RuntimeStylesheet;
 
@@ -27,11 +27,25 @@ describe('jest process', () => {
         });
 
         const module = nodeEval(
-            transformer.process(content, filename),
+            transformer.process(content, filename).code,
             filename
         ) as RuntimeStylesheet;
 
         expect(module.classes.root).to.equal(`test-custom__root`);
         expect(module.classes.test).to.equal(`test-custom__test`);
+    });
+
+    it('should maintain compatibility with previous string based transformers', () => {
+        const filename = require.resolve('@stylable/jest/test/fixtures/test.st.css');
+        const content = readFileSync(filename, 'utf8');
+        const transformer = stylableTransformer.createTransformer();
+
+        const code = transformer.process(content, filename).code;
+
+        expect(typeof code).to.equal('string');
+
+        const module = nodeEval(code, filename) as RuntimeStylesheet;
+
+        expect(module.classes.root).to.equal(`${module.namespace}__root`);
     });
 });


### PR DESCRIPTION
Jest have changed their [transformer API](https://jestjs.io/docs/code-transformation#writing-custom-transformers) in v28, so that it now expects an object to be returned (instead of a string), with the `code` field holding the transformed source.

This approach has been long supported on Jest, but not required, and so we're now moving to the new response structure.

This PR has been tested to work with versions as old as jest v22, and requires no change from our users.

Fixes: #2707