### PR TITLE
fix: dev inherit check with global selector

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -237,6 +237,14 @@ export function namespaceClass(
         node.value = namespaceEscape(symbol.name, meta.namespace);
     }
 }
+function getNamespacedClass(meta: StylableMeta, symbol: StylableSymbol) {
+    if (`-st-global` in symbol && symbol[`-st-global`]) {
+        const selector = symbol[`-st-global`];
+        return stringifySelectorAst(selector as any);
+    } else {
+        return '.' + namespaceEscape(symbol.name, meta.namespace);
+    }
+}
 
 export function addDevRules({ getResolvedSymbols, meta }: FeatureTransformContext) {
     const resolvedSymbols = getResolvedSymbols(meta);
@@ -246,11 +254,11 @@ export function addDevRules({ getResolvedSymbols, meta }: FeatureTransformContex
             const b = resolved[resolved.length - 1];
             meta.targetAst!.append(
                 createWarningRule(
-                    b.symbol.name,
-                    namespaceEscape(b.symbol.name, b.meta.namespace),
+                    '.' + b.symbol.name,
+                    getNamespacedClass(b.meta, b.symbol),
                     basename(b.meta.source),
-                    a.symbol.name,
-                    namespaceEscape(a.symbol.name, a.meta.namespace),
+                    '.' + a.symbol.name,
+                    getNamespacedClass(a.meta, a.symbol),
                     basename(a.meta.source),
                     true
                 )
@@ -268,9 +276,9 @@ export function createWarningRule(
     extendingFile: string,
     useScoped = false
 ) {
-    const message = `"class extending component '.${extendingNode} => ${scopedExtendingNode}' in stylesheet '${extendingFile}' was set on a node that does not extend '.${extendedNode} => ${scopedExtendedNode}' from stylesheet '${extendedFile}'" !important`;
+    const message = `"class extending component '${extendingNode} => ${scopedExtendingNode}' in stylesheet '${extendingFile}' was set on a node that does not extend '${extendedNode} => ${scopedExtendedNode}' from stylesheet '${extendedFile}'" !important`;
     return postcss.rule({
-        selector: `.${useScoped ? scopedExtendingNode : extendingNode}:not(.${
+        selector: `${useScoped ? scopedExtendingNode : extendingNode}:not(${
             useScoped ? scopedExtendedNode : extendedNode
         })::before`,
         nodes: [

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -259,8 +259,7 @@ export function addDevRules({ getResolvedSymbols, meta }: FeatureTransformContex
                     basename(b.meta.source),
                     '.' + a.symbol.name,
                     getNamespacedClass(a.meta, a.symbol),
-                    basename(a.meta.source),
-                    true
+                    basename(a.meta.source)
                 )
             );
         }
@@ -273,14 +272,11 @@ export function createWarningRule(
     extendedFile: string,
     extendingNode: string,
     scopedExtendingNode: string,
-    extendingFile: string,
-    useScoped = false
+    extendingFile: string
 ) {
     const message = `"class extending component '${extendingNode} => ${scopedExtendingNode}' in stylesheet '${extendingFile}' was set on a node that does not extend '${extendedNode} => ${scopedExtendedNode}' from stylesheet '${extendedFile}'" !important`;
     return postcss.rule({
-        selector: `${useScoped ? scopedExtendingNode : extendingNode}:not(${
-            useScoped ? scopedExtendedNode : extendedNode
-        })::before`,
+        selector: `${scopedExtendingNode}:not(${scopedExtendedNode})::before`,
         nodes: [
             postcss.decl({
                 prop: 'content',

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -34,45 +34,6 @@ export function isInConditionalGroup(node: postcss.Rule | postcss.AtRule, includ
     );
 }
 
-export function createWarningRule(
-    extendedNode: string,
-    scopedExtendedNode: string,
-    extendedFile: string,
-    extendingNode: string,
-    scopedExtendingNode: string,
-    extendingFile: string,
-    useScoped = false
-) {
-    const message = `"class extending component '.${extendingNode} => ${scopedExtendingNode}' in stylesheet '${extendingFile}' was set on a node that does not extend '.${extendedNode} => ${scopedExtendedNode}' from stylesheet '${extendedFile}'" !important`;
-    return postcss.rule({
-        selector: `.${useScoped ? scopedExtendingNode : extendingNode}:not(.${
-            useScoped ? scopedExtendedNode : extendedNode
-        })::before`,
-        nodes: [
-            postcss.decl({
-                prop: 'content',
-                value: message,
-            }),
-            postcss.decl({
-                prop: 'display',
-                value: `block !important`,
-            }),
-            postcss.decl({
-                prop: 'font-family',
-                value: `monospace !important`,
-            }),
-            postcss.decl({
-                prop: 'background-color',
-                value: `red !important`,
-            }),
-            postcss.decl({
-                prop: 'color',
-                value: `white !important`,
-            }),
-        ],
-    });
-}
-
 export function createSubsetAst<T extends postcss.Root | postcss.AtRule>(
     root: postcss.Root | postcss.AtRule,
     selectorPrefix: string,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -637,25 +637,20 @@ export class StylableTransformer {
     }
     private addDevRules(meta: StylableMeta) {
         const resolvedSymbols = this.getResolvedSymbols(meta);
-        for (const [className, resolved] of Object.entries(resolvedSymbols.class)) {
-            if (resolved.length > 1) {
-                meta.targetAst!.walkRules(
-                    '.' + namespaceEscape(className, meta.namespace),
-                    (rule) => {
-                        const a = resolved[0];
-                        const b = resolved[resolved.length - 1];
-                        rule.after(
-                            createWarningRule(
-                                b.symbol.name,
-                                namespaceEscape(b.symbol.name, b.meta.namespace),
-                                basename(b.meta.source),
-                                a.symbol.name,
-                                namespaceEscape(a.symbol.name, a.meta.namespace),
-                                basename(a.meta.source),
-                                true
-                            )
-                        );
-                    }
+        for (const resolved of Object.values(resolvedSymbols.class)) {
+            const a = resolved[0];
+            if (resolved.length > 1 && a.symbol['-st-extends']) {
+                const b = resolved[resolved.length - 1];
+                meta.targetAst!.append(
+                    createWarningRule(
+                        b.symbol.name,
+                        namespaceEscape(b.symbol.name, b.meta.namespace),
+                        basename(b.meta.source),
+                        a.symbol.name,
+                        namespaceEscape(a.symbol.name, a.meta.namespace),
+                        basename(a.meta.source),
+                        true
+                    )
                 );
             }
         }

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -1,6 +1,5 @@
 import isVendorPrefixed from 'is-vendor-prefixed';
 import cloneDeep from 'lodash.clonedeep';
-import { basename } from 'path';
 import * as postcss from 'postcss';
 import type { FileProcessor } from './cached-process-file';
 import { createDiagnosticReporter, Diagnostics } from './diagnostics';
@@ -16,7 +15,7 @@ import {
     CompoundSelector,
     splitCompoundSelectors,
 } from '@tokey/css-selector-parser';
-import { createWarningRule, isChildOfAtRule } from './helpers/rule';
+import { isChildOfAtRule } from './helpers/rule';
 import { getOriginDefinition } from './helpers/resolve';
 import { ClassSymbol, ElementSymbol, FeatureTransformContext, STNamespace } from './features';
 import type { StylableMeta } from './stylable-meta';
@@ -41,7 +40,6 @@ import {
     createSymbolResolverWithCache,
 } from './stylable-resolver';
 import { validateCustomPropertyName } from './helpers/css-custom-property';
-import { namespaceEscape } from './helpers/escape';
 import type { ModuleResolver } from './types';
 import { getRuleScopeSelector } from './deprecated/postcss-ast-extension';
 
@@ -268,7 +266,7 @@ export class StylableTransformer {
         });
 
         if (!mixinTransform && meta.targetAst && this.mode === 'development') {
-            this.addDevRules(meta);
+            CSSClass.addDevRules(transformContext);
         }
 
         const lastPassParams = {
@@ -633,26 +631,6 @@ export class StylableTransformer {
             context.additionalSelectors.push(
                 lazyCreateSelector(customAstSelectors[i], selectorNode, nodeIndex)
             );
-        }
-    }
-    private addDevRules(meta: StylableMeta) {
-        const resolvedSymbols = this.getResolvedSymbols(meta);
-        for (const resolved of Object.values(resolvedSymbols.class)) {
-            const a = resolved[0];
-            if (resolved.length > 1 && a.symbol['-st-extends']) {
-                const b = resolved[resolved.length - 1];
-                meta.targetAst!.append(
-                    createWarningRule(
-                        b.symbol.name,
-                        namespaceEscape(b.symbol.name, b.meta.namespace),
-                        basename(b.meta.source),
-                        a.symbol.name,
-                        namespaceEscape(a.symbol.name, a.meta.namespace),
-                        basename(a.meta.source),
-                        true
-                    )
-                );
-            }
         }
     }
 }

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -375,11 +375,11 @@ describe(`features/css-class`, () => {
             const devActual = devEntry.targetAst!.toString().replace(/\s\s+/g, ' ');
             const prodActual = prodEntry.targetAst?.toString().replace(/\s\s+/g, ' ');
             const expected = CSSClass.createWarningRule(
-                'root',
-                'deep__root',
+                '.root',
+                '.deep__root',
                 'deep.st.css',
-                'root',
-                'entry__root',
+                '.root',
+                '.entry__root',
                 'entry.st.css',
                 true
             )
@@ -415,6 +415,44 @@ describe(`features/css-class`, () => {
 
             expect((meta.targetAst!.nodes[0] as postcss.Rule).selector).to.equal('.entry__root');
             expect(meta.targetAst!.nodes.length).to.equal(1);
+        });
+        it('should use -st-global in inherit check', () => {
+            const { sheets } = testStylableCore(
+                {
+                    '/x.st.css': `
+                        .root {
+                            -st-global: ".y";
+                        }
+                    `,
+                    '/entry.st.css': `
+                        @st-import X from './x.st.css';
+                        .root {
+                            -st-extends: X;
+                        }
+                    `,
+                },
+                {
+                    stylableConfig: { mode: 'development' },
+                }
+            );
+
+            const { meta } = sheets['/entry.st.css'];
+
+            const actual = meta.targetAst!.toString().replace(/\s\s+/g, ' ');
+            const expected = CSSClass.createWarningRule(
+                '.root',
+                '.y',
+                'x.st.css',
+                '.root',
+                '.entry__root',
+                'entry.st.css',
+                true
+            )
+                .toString()
+                .replace('!important\n', '!important;\n')
+                .replace(/\s\s+/g, ' ');
+
+            expect(actual).to.contain(expected);
         });
     });
     describe(`st-import`, () => {

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -380,8 +380,7 @@ describe(`features/css-class`, () => {
                 'deep.st.css',
                 '.root',
                 '.entry__root',
-                'entry.st.css',
-                true
+                'entry.st.css'
             )
                 .toString()
                 .replace('!important\n', '!important;\n')
@@ -445,8 +444,7 @@ describe(`features/css-class`, () => {
                 'x.st.css',
                 '.root',
                 '.entry__root',
-                'entry.st.css',
-                true
+                'entry.st.css'
             )
                 .toString()
                 .replace('!important\n', '!important;\n')

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -1,5 +1,4 @@
 import { STImport, CSSClass, STSymbol } from '@stylable/core/dist/features';
-import { createWarningRule } from '@stylable/core/dist/helpers/rule';
 import {
     testStylableCore,
     shouldReportNoDiagnostics,
@@ -375,7 +374,7 @@ describe(`features/css-class`, () => {
 
             const devActual = devEntry.targetAst!.toString().replace(/\s\s+/g, ' ');
             const prodActual = prodEntry.targetAst?.toString().replace(/\s\s+/g, ' ');
-            const expected = createWarningRule(
+            const expected = CSSClass.createWarningRule(
                 'root',
                 'deep__root',
                 'deep.st.css',

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-import type * as postcss from 'postcss';
 import { testStylableCore, generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
 
 describe('Stylable postcss transform (Scoping)', () => {
@@ -183,46 +181,6 @@ describe('Stylable postcss transform (Scoping)', () => {
             });
 
             testInlineExpects(result);
-        });
-
-        it('should not add a warning rule while in development when apply with mixin', () => {
-            const result = generateStylableRoot({
-                entry: `/entry.st.css`,
-                files: {
-                    '/entry.st.css': {
-                        namespace: 'entry',
-                        content: `
-                        :import {
-                            -st-from: "./variant.st.css";
-                            -st-default: Variant;
-                        }
-                        .root {
-                            -st-mixin: Variant;
-                        }`,
-                    },
-                    '/variant.st.css': {
-                        namespace: 'variant',
-                        content: `
-                            :import {
-                                -st-from: "./comp.st.css";
-                                -st-default: Comp;
-                            }
-                            .root {
-                                -st-extends: Comp;
-                            }
-                        `,
-                    },
-                    '/comp.st.css': {
-                        namespace: 'comp',
-                        content: `
-                        `,
-                    },
-                },
-                mode: 'development',
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__root');
-            expect(result.nodes.length).to.equal(1);
         });
 
         it('class selector that extends root uses pseudo-element after pseudo-class', () => {

--- a/packages/core/test/stylable-transformer/scoping.spec.ts
+++ b/packages/core/test/stylable-transformer/scoping.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
 import { testStylableCore, generateStylableRoot, testInlineExpects } from '@stylable/core-test-kit';
-import { createWarningRule } from '@stylable/core/dist/helpers/rule';
 
 describe('Stylable postcss transform (Scoping)', () => {
     describe('scoped pseudo-classes', () => {
@@ -186,116 +185,6 @@ describe('Stylable postcss transform (Scoping)', () => {
             testInlineExpects(result);
         });
 
-        it('should add a warning rule while in development mode that targets a broken inheritance structure', () => {
-            const result = generateStylableRoot({
-                entry: `/style.st.css`,
-                files: {
-                    '/style.st.css': {
-                        namespace: 'ns',
-                        content: `
-                            :import {
-                                -st-from: "./inner.st.css";
-                                -st-default: Inner;
-                            }
-                            .root {
-                                -st-extends: Inner;
-                            }
-                        `,
-                    },
-                    '/inner.st.css': {
-                        namespace: 'ns1',
-                        content: `
-                        `,
-                    },
-                },
-                mode: 'development',
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns__root');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.ns__root:not(.ns1__root)::before'
-            );
-
-            (
-                createWarningRule(
-                    'root',
-                    'ns1__root',
-                    'inner.st.css',
-                    'root',
-                    'ns__root',
-                    'style.st.css'
-                ).nodes as postcss.Declaration[]
-            ).forEach((decl: postcss.Declaration, index: number) => {
-                expect(
-                    ((result.nodes[1] as postcss.Rule).nodes[index] as postcss.Declaration).prop
-                ).to.eql(decl.prop);
-                expect(
-                    ((result.nodes[1] as postcss.Rule).nodes[index] as postcss.Declaration).value
-                ).to.eql(decl.value);
-            });
-            expect(result.nodes.length).to.equal(2);
-        });
-
-        it('should add a warning rule while in development mode that targets a broken inheritance structure (deep import)', () => {
-            const result = generateStylableRoot({
-                entry: `/style.st.css`,
-                files: {
-                    '/style.st.css': {
-                        namespace: 'style',
-                        content: `
-                            :import {
-                                -st-from: "./index.st.css";
-                                -st-named: Inner;
-                            }
-                            .root {
-                                -st-extends: Inner;
-                            }
-                        `,
-                    },
-                    '/inner.st.css': {
-                        namespace: 'inner',
-                        content: `
-                        `,
-                    },
-                    '/index.st.css': {
-                        namespace: 'index',
-                        content: `
-                            :import {
-                                -st-from: './inner.st.css';
-                                -st-default: Inner;
-                            }
-                            .root Inner {}
-                        `,
-                    },
-                },
-                mode: 'development',
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.style__root');
-            expect((result.nodes[1] as postcss.Rule).selector).to.equal(
-                '.style__root:not(.inner__root)::before'
-            );
-
-            (
-                createWarningRule(
-                    'root',
-                    'inner__root',
-                    'inner.st.css',
-                    'root',
-                    'style__root',
-                    'style.st.css'
-                ).nodes as postcss.Declaration[]
-            ).forEach((decl: postcss.Declaration, index: number) => {
-                expect(
-                    ((result.nodes[1] as postcss.Rule).nodes[index] as postcss.Declaration).prop
-                ).to.eql(decl.prop);
-                expect(
-                    ((result.nodes[1] as postcss.Rule).nodes[index] as postcss.Declaration).value
-                ).to.eql(decl.value);
-            });
-            expect(result.nodes.length).to.equal(2);
-        });
-
         it('should not add a warning rule while in development when apply with mixin', () => {
             const result = generateStylableRoot({
                 entry: `/entry.st.css`,
@@ -333,38 +222,6 @@ describe('Stylable postcss transform (Scoping)', () => {
             });
 
             expect((result.nodes[0] as postcss.Rule).selector).to.equal('.entry__root');
-            expect(result.nodes.length).to.equal(1);
-        });
-
-        it('should NOT add a warning rule while in production mode', () => {
-            const result = generateStylableRoot({
-                entry: `/style.st.css`,
-                files: {
-                    '/style.st.css': {
-                        namespace: 'ns',
-                        content: `
-                            :import {
-                                -st-from: "./inner.st.css";
-                                -st-named: root1;
-                            }
-                            .root {
-                                -st-extends: root1;
-                            }
-                        `,
-                    },
-                    '/inner.st.css': {
-                        namespace: 'ns1',
-                        content: `
-                            .root1 {
-                                color: green;
-                            }
-                        `,
-                    },
-                },
-                mode: 'production',
-            });
-
-            expect((result.nodes[0] as postcss.Rule).selector).to.equal('.ns__root');
             expect(result.nodes.length).to.equal(1);
         });
 

--- a/packages/webpack-plugin/test/e2e/dev-mode-warnings-project.spec.ts
+++ b/packages/webpack-plugin/test/e2e/dev-mode-warnings-project.spec.ts
@@ -45,7 +45,7 @@ describe(`(${project})`, () => {
         expect(values.color).to.eql('rgb(255, 0, 0)');
 
         expect(values.content).to.match(
-            /"class extending component '\.root => comp\d+__root' in stylesheet 'comp\.st\.css' was set on a node that does not extend '\.root => other\d+__root' from stylesheet 'other\.st\.css'"/
+            /"class extending component '\.root => \.comp\d+__root' in stylesheet 'comp\.st\.css' was set on a node that does not extend '\.root => \.other\d+__root' from stylesheet 'other\.st\.css'"/
         );
     });
 });


### PR DESCRIPTION
This PR fix dev inherit rule for parts with `-st-global`. Before this change, the check selector would ignore the global selector and would always fail the check.

In addition this PR refactor the code to make it simpler and move it into the CSS class feature.