### PR TITLE
fix: production mode globals

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -113,6 +113,7 @@ export const hooks = createFeature<{
                         (globalClasses, node) => {
                             if (node.type === `class`) {
                                 globalClasses.push(node.value);
+                                context.meta.globals[node.value] = true;
                             } else {
                                 isOnlyClasses = false;
                             }

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -618,9 +618,12 @@ describe(`features/css-class`, () => {
                     .part {
                         -st-global: .p;
                     }
+                    .extended {
+                        -st-global: .e;
+                    }
                 `,
                 '/entry.st.css': `
-                    @st-import Comp, [root as iRoot, part as iPart] from './comp.st.css';
+                    @st-import Comp, [root as iRoot, part as iPart, extended as iExtended] from './comp.st.css';
 
                     /* @rule .r */
                     Comp {}
@@ -630,6 +633,11 @@ describe(`features/css-class`, () => {
 
                     /* @rule .p */
                     .iPart {}
+
+                    /* @rule .entry__local */
+                    .local {
+                        -st-extends: iExtended;
+                    }
                 `,
             });
 
@@ -647,11 +655,14 @@ describe(`features/css-class`, () => {
             expect(meta.globals).to.eql({
                 r: true,
                 p: true,
+                e: true,
             });
 
             // JS exports
             expect(exports.classes, `no root alias JS export`).to.not.haveOwnProperty(`iRoot`);
             expect(exports.classes.iPart, `class alias JS export`).to.eql(`p`);
+            expect(exports.classes.local, `extending class JS export`).to.eql(`entry__local e`);
+            expect(exports.classes.iExtended, `class alias JS export (2)`).to.eql(`e`);
         });
         it(`should handle -st-extends of imported class `, () => {
             const { sheets } = testStylableCore({

--- a/packages/optimizer/src/stylable-optimizer.ts
+++ b/packages/optimizer/src/stylable-optimizer.ts
@@ -103,7 +103,9 @@ export class StylableOptimizer implements IStylableOptimizer {
                 exported[originName] = exported[originName]
                     .split(' ')
                     .map((renderedNamed) => {
-                        if (classNamespaceOptimizations) {
+                        if (globals[renderedNamed]) {
+                            return renderedNamed;
+                        } else if (classNamespaceOptimizations) {
                             return this.getClassName(renderedNamed);
                         } else if (shortNamespaces) {
                             const namespaceMatch = renderedNamed.match(namespaceRegexp);

--- a/packages/optimizer/test/ast-optimizations.spec.ts
+++ b/packages/optimizer/test/ast-optimizations.spec.ts
@@ -61,6 +61,32 @@ describe('StylableOptimizer className optimizations', () => {
             '.s0{} .namespace--state{} .namespace---otherState-5-value{} .s1{} .s2{} .otherNamespace--state{}'
         );
     });
+    it('should NOT optimize globals', () => {
+        const optimizer = new StylableOptimizer();
+        const ast = parse(`.aaa{} .bbb{} .ccc{}`);
+        const globals = { bbb: true };
+        const exports = {
+            aaa: 'aaa',
+            bbb: 'bbb',
+            ccc: 'ccc bbb',
+        };
+
+        optimizer.optimizeAstAndExports(
+            ast,
+            exports,
+            undefined,
+            { namespace: true },
+            globals,
+            false,
+            true
+        );
+        expect(exports, 'exports rewrite').to.eql({
+            aaa: 's0',
+            bbb: 'bbb',
+            ccc: 's1 bbb',
+        });
+        expect(ast.toString(), 'ast optimized').to.equal('.s0{} .bbb{} .s1{}');
+    });
 });
 
 describe('StylableOptimizer shortNamespaces', () => {

--- a/packages/webpack-plugin/test/e2e/globals.ts
+++ b/packages/webpack-plugin/test/e2e/globals.ts
@@ -1,0 +1,47 @@
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { expect } from 'chai';
+import { dirname } from 'path';
+
+const project = 'globals';
+const projectDir = dirname(
+    require.resolve(`@stylable/webpack-plugin/test/e2e/projects/${project}/webpack.config`)
+);
+
+describe(`(${project})`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            webpackOptions: {
+                mode: 'production',
+            },
+            projectDir,
+            launchOptions: {
+                headless: false,
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('should preserve global classes and custom properties', async () => {
+        const { page } = await projectRunner.openInBrowser();
+
+        const { classList, localGlobal, libGlobal, libMultiGlobal1, libMultiGlobal2 } =
+            await page.evaluate(() => {
+                const win = window as any;
+                const computedStyle = getComputedStyle(win.document.body);
+                return {
+                    classList: win.document.body.getAttribute('class'),
+                    localGlobal: computedStyle.getPropertyValue('--local-global'),
+                    libGlobal: computedStyle.getPropertyValue('--lib-global'),
+                    libMultiGlobal1: computedStyle.getPropertyValue('--lib-multi-global-1'),
+                    libMultiGlobal2: computedStyle.getPropertyValue('--lib-multi-global-2'),
+                };
+            });
+        expect(classList, 'classes').to.eql('s1 loc-glob lib-glob s2 lib1 lib2');
+        expect(localGlobal, 'extend local global').to.eql(' from local global');
+        expect(libGlobal, 'extend lib global').to.eql(' from lib global');
+        expect(libMultiGlobal1, 'extend lib multi global 1').to.eql(' from lib multi global 1');
+        expect(libMultiGlobal2, 'extend lib multi global 2').to.eql(' from lib multi global 2');
+    });
+});

--- a/packages/webpack-plugin/test/e2e/projects/globals/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/globals/src/index.js
@@ -1,0 +1,4 @@
+import { classes } from './index.st.css';
+
+document.body.classList.add(...classes.a.split(' '));
+document.body.classList.add(...classes.b.split(' '));

--- a/packages/webpack-plugin/test/e2e/projects/globals/src/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/globals/src/index.st.css
@@ -1,0 +1,15 @@
+@st-import [lib-global, lib-multi-global] from 'test-components/lib.st.css';
+
+@property st-global(--local-global);
+.local-global {
+    -st-global: '.loc-glob';
+    -st-extends: lib-global;
+    --local-global: from local global;
+}
+
+.a {
+    -st-extends: local-global;
+}
+.b {
+    -st-extends: lib-multi-global;
+}

--- a/packages/webpack-plugin/test/e2e/projects/globals/src/node_modules/test-components/lib.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/globals/src/node_modules/test-components/lib.st.css
@@ -1,0 +1,18 @@
+@property st-global(--lib-global);
+@property st-global(--lib-multi-global-1);
+@property st-global(--lib-multi-global-2);
+.lib-global {
+    -st-global: '.lib-glob';
+    --lib-global: from lib global;
+}
+
+:global(.lib1) {
+    --lib-multi-global-1: from lib multi global 1;
+}
+:global(.lib2) {
+    --lib-multi-global-2: from lib multi global 2;
+}
+
+.lib-multi-global {
+    -st-global: '.lib1.lib2';
+}

--- a/packages/webpack-plugin/test/e2e/projects/globals/src/node_modules/test-components/package.json
+++ b/packages/webpack-plugin/test/e2e/projects/globals/src/node_modules/test-components/package.json
@@ -1,0 +1,4 @@
+{
+  "version": "test",
+  "name": "test-components"
+}

--- a/packages/webpack-plugin/test/e2e/projects/globals/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/globals/webpack.config.js
@@ -1,0 +1,27 @@
+const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+/** @type {import('webpack').Configuration} */
+module.exports = {
+    mode: 'development',
+    context: __dirname,
+    devtool: 'source-map',
+    plugins: [
+        new StylableWebpackPlugin({
+            optimize: {
+                // don't trim custom properties
+                minify: false,
+            },
+            stylableConfig(config) {
+                return {
+                    ...config,
+                    // keep namespace with no hash for test expectations
+                    resolveNamespace(namespace) {
+                        return namespace;
+                    },
+                };
+            },
+        }),
+        new HtmlWebpackPlugin(),
+    ],
+};


### PR DESCRIPTION
This PR fix issues relating to global classes getting lost in production mode.

- keep track of `meta.globals` from an extended class with `-st-global` value
- reserve global mapping for exports while optimizing class names