### PR TITLE
Support Rollup version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rimraf": "^3.0.2",
-        "rollup": "^2.79.1",
+        "rollup": "^3.1.0",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.1",
@@ -5877,14 +5877,15 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.1.0.tgz",
+      "integrity": "sha512-GEvr+COcXicr4nuih6mpt2Eydq5lZ72z0RrKx1H4/Q2ouT34OHrIIJ9OUj2sZqUhq7QL8Hp8Q8BoWbjL/6ccRQ==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -7473,7 +7474,7 @@
         "node": ">=14.14.0"
       },
       "peerDependencies": {
-        "rollup": "^2.70.0"
+        "rollup": "^2.70.0 || ^3.0.0"
       }
     },
     "packages/rollup-plugin/node_modules/mime": {
@@ -12023,9 +12024,9 @@
       }
     },
     "rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.1.0.tgz",
+      "integrity": "sha512-GEvr+COcXicr4nuih6mpt2Eydq5lZ72z0RrKx1H4/Q2ouT34OHrIIJ9OUj2sZqUhq7QL8Hp8Q8BoWbjL/6ccRQ==",
       "requires": {
         "fsevents": "~2.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.79.1",
+    "rollup": "^3.1.0",
     "source-map": "^0.7.4",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.1",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -7,7 +7,7 @@
     "test": "mocha \"dist/test/**/*.spec.js\""
   },
   "peerDependencies": {
-    "rollup": "^2.70.0"
+    "rollup": "^2.70.0 || ^3.0.0"
   },
   "dependencies": {
     "@stylable/build-tools": "^5.2.1",

--- a/pleb.config.mjs
+++ b/pleb.config.mjs
@@ -1,4 +1,3 @@
 export default {
   // pinnedPackages: [{ name: 'name', reason: 'reason' }],
-  pinnedPackages: [{ name: 'rollup', reason: 'WIP to support v3' }],
 };


### PR DESCRIPTION
This PR upgrades Rollup to version 3. The `@stylable/rollup-plugin` package is now tested with the new version, but the peer dependency is set to both `^2.70.0` or `^3.0.0` because I can't see any breaking change that might fail the plugin (and all tests are passing 😏).

@barak007 can you take a look at the [release notes](https://github.com/rollup/rollup/releases/tag/v3.0.0) and see if you can think of any issues that might we need to take under consideration? what about this one: `Rollup will no longer fix assets added directly to the bundle by adding the type: "asset" field`?