### PR TITLE
test: allow to inline test for empty decl value

### DIFF
--- a/packages/core-test-kit/src/inline-expectation.ts
+++ b/packages/core-test-kit/src/inline-expectation.ts
@@ -310,15 +310,16 @@ function declTest(
         expectation,
         errors: [],
     };
-    let { label, prop, value } = expectation.match(
-        /(?<label>\([^)]*\))*(?<prop>[^:]*)\s*:?\s*(?<value>.*)/
+    // eslint-disable-next-line prefer-const
+    let { label, prop, colon, value } = expectation.match(
+        /(?<label>\([^)]*\))*(?<prop>[^:]*)\s*(?<colon>:?)\s*(?<value>.*)/
     )!.groups!;
     label = label ? label + `: ` : ``;
     prop = prop.trim();
     value = value.trim();
     if (!targetNode) {
         result.errors.push(testInlineExpectsErrors.removedNode(srcNode.type, label));
-    } else if (!prop || !value) {
+    } else if (!prop || !colon) {
         result.errors.push(testInlineExpectsErrors.declMalformed(prop, value, label));
     } else if (targetNode.type === `decl`) {
         if (targetNode.prop !== prop.trim() || targetNode.value !== value) {
@@ -485,10 +486,8 @@ export const testInlineExpectsErrors = {
     declMalformed: (expectedProp: string, expectedLabel: string, label = ``) => {
         if (!expectedProp && !expectedLabel) {
             return `${label}malformed declaration expectation, format should be: "prop: value"`;
-        } else if (!expectedProp) {
-            return `${label}malformed declaration expectation missing prop: "???: ${expectedLabel}"`;
         } else {
-            return `${label}malformed declaration expectation missing value: "${expectedProp}: ???"`;
+            return `${label}malformed declaration expectation missing prop: "???: ${expectedLabel}"`;
         }
     },
     deprecatedRootInputNotSupported: (expectation: string) =>

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -530,9 +530,6 @@ describe('inline-expectations', () => {
                             .root {
                                 /* @decl(only prop) color */
                                 color: red;
-
-                                /* @decl(missing value) color: */
-                                color: red;
                                 
                                 /* @decl(missing prop) : red */
                                 color: red;
@@ -545,7 +542,6 @@ describe('inline-expectations', () => {
             expect(() => testInlineExpects(result)).to.throw(
                 testInlineExpectsErrors.combine([
                     testInlineExpectsErrors.declMalformed(`color`, ``, `(only prop): `),
-                    testInlineExpectsErrors.declMalformed(`color`, ``, `(missing value): `),
                     testInlineExpectsErrors.declMalformed(``, `red`, `(missing prop): `),
                 ])
             );
@@ -590,6 +586,9 @@ describe('inline-expectations', () => {
                                 
                                 /* @decl(all-spaces)  color  :      green */
                                 color: green;
+
+                                /* @decl(empty value) color: */
+                                color: ;
                             }
                             
                         `,


### PR DESCRIPTION
This PR adds the ability to test for empty declaration value within an inline expectation.

A "Malformed declaration expectation" error is still thrown for:
- just a prop: `color`
- missing prop: `: red`