### PR TITLE
feat(rollup): provide stylable config override

### DIFF
--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -35,8 +35,6 @@ interface StylableRollupPluginOptions {
     inlineAssets?: boolean;
     fileName?: string;
     diagnosticsMode?: 'auto' | 'strict' | 'loose';
-    resolveNamespace?: (namespace: string, source: string) => string;
-    projectRoot?: string; // default is process.cwd()
     /**
      * A function to override Stylable instance default configuration options
      */

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -38,6 +38,10 @@ interface StylableRollupPluginOptions {
     resolveNamespace?: (namespace: string, source: string) => string;
     projectRoot?: string; // default is process.cwd()
     /**
+     * A function to override Stylable instance default configuration options
+     */
+    stylableConfig?: (config: StylableConfig) => StylableConfig;
+    /**
      * Runs "stc" programmatically with the webpack compilation.
      * true - it will automatically detect the closest "stylable.config.js" file and use it.
      * string - it will use the provided string as the "stcConfig" file path.

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'rollup';
 import fs from 'fs';
 import { join, parse } from 'path';
-import { Stylable } from '@stylable/core';
+import { Stylable, StylableConfig } from '@stylable/core';
 import {
     emitDiagnostics,
     DiagnosticsMode,
@@ -34,6 +34,10 @@ export interface StylableRollupPluginOptions {
     diagnosticsMode?: DiagnosticsMode;
     resolveNamespace?: typeof resolveNamespaceNode;
     /**
+     * A function to override Stylable instance default configuration options
+     */
+    stylableConfig?: (config: StylableConfig) => StylableConfig;
+    /**
      * Runs "stc" programmatically with the webpack compilation.
      * true - it will automatically detect the closest "stylable.config.js" file and use it.
      * string - it will use the provided string as the "stcConfig" file path.
@@ -64,6 +68,7 @@ export function stylableRollupPlugin({
     diagnosticsMode = 'strict',
     mode = getDefaultMode(),
     resolveNamespace = resolveNamespaceNode,
+    stylableConfig = (config: StylableConfig) => config,
     stcConfig,
     projectRoot = process.cwd(),
 }: StylableRollupPluginOptions = {}): Plugin {
@@ -82,15 +87,17 @@ export function stylableRollupPlugin({
                 clearRequireCache();
                 stylable.initCache();
             } else {
-                stylable = new Stylable({
-                    fileSystem: fs,
-                    projectRoot,
-                    mode,
-                    resolveNamespace,
-                    optimizer: new StylableOptimizer(),
-                    resolverCache: new Map(),
-                    requireModule,
-                });
+                stylable = new Stylable(
+                    stylableConfig({
+                        fileSystem: fs,
+                        projectRoot,
+                        mode,
+                        resolveNamespace,
+                        optimizer: new StylableOptimizer(),
+                        resolverCache: new Map(),
+                        requireModule,
+                    })
+                );
             }
 
             if (stcConfig) {

--- a/packages/rollup-plugin/test/rollup-js-exports.spec.ts
+++ b/packages/rollup-plugin/test/rollup-js-exports.spec.ts
@@ -11,8 +11,11 @@ describe('StylableRollupPlugin - js exports', function () {
         projectPath: getProjectPath(project),
         entry: './src/index.js',
         pluginOptions: {
-            // keep namespace with no hash for test expectations
-            resolveNamespace: (namespace) => namespace,
+            stylableConfig(config) {
+                // keep namespace with no hash for test expectations
+                config.resolveNamespace = (namespace) => namespace;
+                return config;
+            },
         },
     });
 


### PR DESCRIPTION
This PR adds the option to override the default Stylable configuration from the Rollup plugin.