### PR TITLE
fix(language-service): st-global in at-rules definition

### DIFF
--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -64,6 +64,7 @@ export class CssService {
 
     public createSanitizedDocument(ast: postcss.Root, filePath: string, version: number) {
         let cleanContentAst = this.cleanValuesInMediaQuery(ast);
+        cleanContentAst = this.cleanStGlobalFromAtRules(cleanContentAst);
         cleanContentAst = this.cleanStScopes(cleanContentAst);
 
         return TextDocument.create(
@@ -93,6 +94,39 @@ export class CssService {
                     atRule.params.substr(0, closingParenthesisIndex) +
                     ' ' +
                     atRule.params.substr(closingParenthesisIndex + 1);
+            }
+        });
+
+        return ast;
+    }
+    // cleaning strategy: replace the "st-global(*)" syntax with spaces,
+    // without touching the inner content (*)
+    // by removing the function from the params,
+    // the css-service will consider it a valid ident
+    private cleanStGlobalFromAtRules(ast: postcss.Root): postcss.Root {
+        const stGlobalMatch = 'st-global(';
+
+        ast.walkAtRules((atRule) => {
+            if (
+                (atRule.name === 'property' ||
+                    atRule.name === 'keyframes' ||
+                    atRule.name === 'layer') &&
+                atRule.params.includes(stGlobalMatch)
+            ) {
+                while (atRule.params.includes(stGlobalMatch)) {
+                    const currentValueIndex = atRule.params.indexOf(stGlobalMatch);
+                    const closingParenthesisIndex = atRule.params.indexOf(')', currentValueIndex);
+
+                    atRule.params = atRule.params.replace(
+                        stGlobalMatch,
+                        ' '.repeat(stGlobalMatch.length)
+                    );
+
+                    atRule.params =
+                        atRule.params.substr(0, closingParenthesisIndex) +
+                        ' ' +
+                        atRule.params.substr(closingParenthesisIndex + 1);
+                }
             }
         });
 

--- a/packages/language-service/test/lib/completions/custom-property.spec.ts
+++ b/packages/language-service/test/lib/completions/custom-property.spec.ts
@@ -3,15 +3,27 @@ import { createDiagnostics } from '../../test-kit/diagnostics-setup';
 import deindent from 'deindent';
 
 describe('custom property', () => {
-    it('should ignore native css lsp diagnostics unknown @property at-rule', () => {
-        // remove once css lsp supports is added or we implement the complete lsp ourselves
+    it('should ignore native css lsp diagnostics for @property body', () => {
         const filePath = '/style.st.css';
 
         const diagnostics = createDiagnostics(
             {
                 [filePath]: deindent`
                     @property --x;
-                    @property --y {
+                `,
+            },
+            filePath
+        );
+
+        expect(diagnostics).to.eql([]);
+    });
+    it('should clear st-global from ident to allow css-lsp to function', () => {
+        const filePath = '/style.st.css';
+
+        const diagnostics = createDiagnostics(
+            {
+                [filePath]: deindent`
+                    @property st-global(--y) {
                         syntax: '<color>';
                         inherits: true; 
                         initial-value: green;

--- a/packages/language-service/test/lib/completions/keyframes.spec.ts
+++ b/packages/language-service/test/lib/completions/keyframes.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { createDiagnostics } from '../../test-kit/diagnostics-setup';
+import deindent from 'deindent';
+
+describe('keyframes', () => {
+    it('should clear st-global from ident to allow css-lsp to function', () => {
+        const filePath = '/style.st.css';
+
+        const diagnostics = createDiagnostics(
+            {
+                [filePath]: deindent`
+                    @keyframes st-global(abc) {}
+                `,
+            },
+            filePath
+        );
+
+        expect(diagnostics).to.eql([]);
+    });
+});

--- a/packages/language-service/test/lib/completions/layer.spec.ts
+++ b/packages/language-service/test/lib/completions/layer.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { createDiagnostics } from '../../test-kit/diagnostics-setup';
+import deindent from 'deindent';
+
+describe('layer', () => {
+    it('should clear st-global from ident to allow css-lsp to function', () => {
+        const filePath = '/style.st.css';
+
+        const diagnostics = createDiagnostics(
+            {
+                [filePath]: deindent`
+                    @layer aaa, st-global(bbb), ccc, st-global(ddd);
+                `,
+            },
+            filePath
+        );
+
+        expect(diagnostics).to.eql([]);
+    });
+});


### PR DESCRIPTION
This PR "hides" the `st-global()` in `@keyframes/@layer/@property` from the native CSS LSP that doesn't expect it to be there and fails on "identifier expected".

fixes: #2785 