### PR TITLE
fix(webpack): preserve native CSS class names in production

### DIFF
--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -30,6 +30,7 @@ export default function StylableWebpackLoader(this: StylableLoaderContext, sourc
         namespace: meta.namespace,
         urls,
         unusedImports,
+        type: meta.type,
     });
     /**
      * NOTICE: order of replacements is coupled with "webpack-entities.ts"

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -572,23 +572,28 @@ export class StylableWebpackPlugin {
             );
 
             for (const module of sortedModules) {
-                const { css, globals, namespace } = getStylableBuildMeta(module);
+                const { css, globals, namespace, type } = getStylableBuildMeta(module);
 
                 try {
                     const buildData = stylableModules.get(module)!;
-                    const ast = parse(css, { from: module.resource });
+                    let cssOutput = css;
+                    if (type === 'stylable') {
+                        const ast = parse(css, { from: module.resource });
 
-                    optimizer.optimizeAst(
-                        optimizeOptions,
-                        ast,
-                        usageMapping,
-                        buildData.exports,
-                        globals
-                    );
+                        optimizer.optimizeAst(
+                            optimizeOptions,
+                            ast,
+                            usageMapping,
+                            buildData.exports,
+                            globals
+                        );
+
+                        cssOutput = ast.toString();
+                    }
 
                     buildData.css = optimizeOptions.minify
-                        ? optimizer.minifyCSS(ast.toString())
-                        : ast.toString();
+                        ? optimizer.minifyCSS(cssOutput)
+                        : cssOutput;
 
                     if (optimizeOptions.shortNamespaces) {
                         buildData.namespace = namespaceMapping[namespace];

--- a/packages/webpack-plugin/src/types.ts
+++ b/packages/webpack-plugin/src/types.ts
@@ -1,4 +1,4 @@
-import type { Stylable } from '@stylable/core';
+import type { Stylable, StylableMeta } from '@stylable/core';
 import type { DiagnosticsMode, StylableExports } from '@stylable/core/dist/index-internal';
 import type { Chunk, Compilation, Compiler, LoaderContext } from 'webpack';
 
@@ -11,6 +11,7 @@ export interface StylableBuildMeta {
     isUsed: undefined | boolean;
     globals: Record<string, boolean>;
     unusedImports: string[];
+    type: StylableMeta['type'];
 }
 
 export type BuildData = Pick<
@@ -20,7 +21,7 @@ export type BuildData = Pick<
 
 export type LoaderData = Pick<
     StylableBuildMeta,
-    'css' | 'urls' | 'exports' | 'namespace' | 'globals' | 'unusedImports'
+    'css' | 'urls' | 'exports' | 'namespace' | 'globals' | 'unusedImports' | 'type'
 >;
 
 export interface StylableLoaderContext extends LoaderContext<{}> {

--- a/packages/webpack-plugin/test/e2e/native-css.spec.ts
+++ b/packages/webpack-plugin/test/e2e/native-css.spec.ts
@@ -67,3 +67,35 @@ describe(`(${project})`, () => {
         ]);
     });
 });
+
+describe(`(${project}) (production)`, () => {
+    const projectRunner = StylableProjectRunner.mochaSetup(
+        {
+            projectDir,
+            webpackOptions: {
+                mode: 'production',
+            },
+            launchOptions: {
+                // headless: false,
+            },
+        },
+        before,
+        afterEach,
+        after
+    );
+
+    it('include native CSS imports from local and 3rd party', async () => {
+        const { page } = await projectRunner.openInBrowser();
+
+        const { nativeClassProp } = await page.evaluate(() => {
+            const element = document.querySelector('.native-class');
+            const computedStyle = getComputedStyle(element!);
+            return {
+                nativeClassProp: computedStyle.getPropertyValue('--native-class'),
+            };
+        });
+        expect(nativeClassProp, 'un-optimized native class').to.eql(
+            'from local un-optimized class'
+        );
+    });
+});

--- a/packages/webpack-plugin/test/e2e/projects/native-css/src/index.js
+++ b/packages/webpack-plugin/test/e2e/projects/native-css/src/index.js
@@ -1,3 +1,7 @@
 import { classes } from './index.st.css';
 
 document.body.classList.add(...classes.root.split(' '));
+// check that class names are not optimized in production mode
+const classTest = document.createElement('div');
+classTest.classList.add('native-class');
+document.body.appendChild(classTest);

--- a/packages/webpack-plugin/test/e2e/projects/native-css/src/local.css
+++ b/packages/webpack-plugin/test/e2e/projects/native-css/src/local.css
@@ -2,3 +2,6 @@ body {
   --local-color: green;
   --local-side-effect: from local side-effect;
 }
+.native-class {
+  --native-class: from local un-optimized class;
+}


### PR DESCRIPTION
Since native CSS doesn't go through the transform flow, then global class names are not collected to be ignored when running stylable optimization. That caused native CSS class names to be lost in production transformation.

To fix that, this PR exclude native CSS stylesheets from any stylable optimization.