### PR TITLE
feat: remove stylable directives at transform

### DIFF
--- a/packages/cli/src/build-single-file.ts
+++ b/packages/cli/src/build-single-file.ts
@@ -101,7 +101,6 @@ export function buildSingleFile({
             {
                 removeComments: true,
                 removeEmptyNodes: true,
-                removeStylableDirectives: true,
                 classNameOptimizations: false,
                 removeUnusedComponents: false,
             },

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -122,6 +122,7 @@ export class StylableTransformer {
     private defaultStVarOverride: Record<string, string>;
     private evaluator: StylableEvaluator = new StylableEvaluator();
     private getResolvedSymbols: ReturnType<typeof createSymbolResolverWithCache>;
+    private directiveNodes: postcss.Declaration[] = [];
     constructor(options: TransformerOptions) {
         this.diagnostics = options.diagnostics;
         this.keepValues = options.keepValues || false;
@@ -269,6 +270,12 @@ export class StylableTransformer {
                 });
             }
 
+            if (this.mode === 'production') {
+                if (decl.prop.startsWith('-st-')) {
+                    this.directiveNodes.push(decl);
+                }
+            }
+
             switch (decl.prop) {
                 case `-st-partial-mixin`:
                 case `-st-mixin`:
@@ -300,6 +307,9 @@ export class StylableTransformer {
         STMixin.hooks.transformLastPass(lastPassParams);
         if (!mixinTransform) {
             STGlobal.hooks.transformLastPass(lastPassParams);
+            for (const node of this.directiveNodes) {
+                node.remove();
+            }
         }
 
         if (metaExports) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,6 @@ export interface ParsedValue {
 
 export interface OptimizeConfig {
     removeComments?: boolean;
-    removeStylableDirectives?: boolean;
     removeUnusedComponents?: boolean;
     classNameOptimizations?: boolean;
     removeEmptyNodes?: boolean;
@@ -35,7 +34,6 @@ export interface IStylableOptimizer {
         jsExports: StylableExports,
         globals: Record<string, boolean>
     ): void;
-    removeStylableDirectives(root: postcss.Root, shouldComment?: boolean): void;
 }
 
 export type ModuleResolver = (directoryPath: string, request: string) => string;

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -130,26 +130,31 @@ describe(`features/css-class`, () => {
         const { sheets } = testStylableCore(`
             /* @rule(simple class) .x */
             .a {
+                /* @transform-remove */
                 -st-global: ".x";
             }
 
             /* @rule(compound classes) .z.zz */
             .b {
+                /* @transform-remove */
                 -st-global: ".z.zz";
             }
 
             /* @rule(no class) [attr=val] */
             .c {
+                /* @transform-remove */
                 -st-global: "[attr=val]";
             }
             
             /* @rule(complex) .y .z */
             .d {
+                /* @transform-remove */
                 -st-global: ".y .z";
             }
 
             /* @rule(not only classes compound) .yy[attr] */
             .e {
+                /* @transform-remove */
                 -st-global: ".yy[attr]";
             }
         `);
@@ -254,11 +259,13 @@ describe(`features/css-class`, () => {
 
             /* @rule(root extend class) .entry__root */
             .root {
+                /* @transform-remove */
                 -st-extends: a;
             }
 
             /* @rule(class extend class) .entry__class */
             .class {
+                /* @transform-remove */
                 -st-extends: a;
             }
         `);
@@ -1090,7 +1097,7 @@ describe(`features/css-class`, () => {
                         @st-import [MixRoot, mixClass] from './enrich.st.css';
 
                         /* 
-                            @rule[0] .entry__a { -st-extends: Base; id: extend-mix; } 
+                            @rule[0] .entry__a { id: extend-mix; } 
                             @rule[1] .entry__a .base__part .extend__part { id: extend-mix-part; } 
                             @rule[2] .entry__a { id: enrich-mixClass; } 
                             @rule[3] .entry__a .base__part .enrich__part { id: enrich-mixClass-part; } 
@@ -1100,9 +1107,9 @@ describe(`features/css-class`, () => {
                         }
 
                         /* 
-                            @rule[0] .entry__a { -st-extends: Base; } 
+                            @rule[0] .entry__a { } 
                             @rule[1] .entry__a .extend__part { id: extend-part; } 
-                            @rule[2] .entry__a .extend__mix { -st-extends: Base; id: extend-mix; } 
+                            @rule[2] .entry__a .extend__mix { id: extend-mix; } 
                             @rule[3] .entry__a .extend__mix .base__part .extend__part { id: extend-mix-part; } 
                             @rule[4] .entry__a .base__part .extend__part { id: extend-root-part; } 
                             @rule[5] .entry__a { id: enrich-MixRoot; }

--- a/packages/core/test/features/css-pseudo-class.spec.ts
+++ b/packages/core/test/features/css-pseudo-class.spec.ts
@@ -35,6 +35,7 @@ describe('features/css-pseudo-class', () => {
         it('should transform boolean state', () => {
             const { sheets } = testStylableCore(`
                 .root {
+                    /* @transform-remove(removed decl) */
                     -st-states: bool,
                                 exBool(boolean);
                 }
@@ -782,7 +783,7 @@ describe('features/css-pseudo-class', () => {
                     @st-import [MixRoot, mixClass] from './enrich.st.css';
 
                     /*
-                        @rule[0] .entry__a { -st-extends: Base; id: extend-mix; }
+                        @rule[0] .entry__a { id: extend-mix; }
                         @rule[1] .entry__a.base--state { id: extend-mix-state; }
                         @rule[2] .entry__a { id: enrich-mixClass; }
                         @rule[3] .entry__a.base--state { id: enrich-mixClass-state; }
@@ -792,8 +793,8 @@ describe('features/css-pseudo-class', () => {
                     }
 
                     /*
-                        @rule[0] .entry__a { -st-extends: Base; }
-                        @rule[1] .entry__a .extend__mix { -st-extends: Base; id: extend-mix; }
+                        @rule[0] .entry__a { }
+                        @rule[1] .entry__a .extend__mix { id: extend-mix; }
                         @rule[2] .entry__a .extend__mix.base--state { id: extend-mix-state; }
                         @rule[3] .entry__a.base--state { id: extend-root-state; }
                         @rule[4] .entry__a { id: enrich-MixRoot; }

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -244,7 +244,7 @@ describe(`features/st-mixin`, () => {
                 color: green;
             }
 
-            /* @rule .entry__root { -st-mixin: "mixA" } */
+            /* @rule .entry__root { } */
             .root {
                 /* @transform-error ${mixinDiagnostics.VALUE_CANNOT_BE_STRING()} */
                 -st-mixin: "mixA";

--- a/packages/experimental-loader/package.json
+++ b/packages/experimental-loader/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "@stylable/core": "^5.5.0",
-    "@stylable/optimizer": "^5.5.0",
     "@stylable/runtime": "^5.5.0",
     "css-loader": "^6.7.3",
     "decache": "^4.6.1",

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -5,7 +5,6 @@ import {
     DiagnosticsMode,
     tryCollectImportsDeep,
 } from '@stylable/core/dist/index-internal';
-import { StylableOptimizer } from '@stylable/optimizer';
 import { Warning, CssSyntaxError } from './warning';
 import { getStylable } from './cached-stylable-factory';
 import { createRuntimeTargetCode } from './create-runtime-target-code';
@@ -47,8 +46,6 @@ interface LoaderImport {
     url: string;
     index: number;
 }
-
-const optimizer = new StylableOptimizer();
 
 const stylableLoader: LoaderDefinition = function (content) {
     const callback = this.async();
@@ -123,10 +120,6 @@ const stylableLoader: LoaderDefinition = function (content) {
             urlHandler: (url: string) => JSON.stringify(this.utils.contextify(this.context, url)),
         }),
     ];
-
-    if (mode !== 'development') {
-        optimizer.removeStylableDirectives(meta.targetAst!);
-    }
 
     postcss(plugins)
         .process(meta.targetAst!, {

--- a/packages/optimizer/src/stylable-optimizer.ts
+++ b/packages/optimizer/src/stylable-optimizer.ts
@@ -8,7 +8,7 @@ import {
 } from '@stylable/core/dist/index-internal';
 import { parseCssSelector, stringifySelectorAst, Selector, walk } from '@tokey/css-selector-parser';
 import csso from 'csso';
-import postcss, { Declaration, Root, Rule, Node, Comment, Container } from 'postcss';
+import postcss, { Root, Rule, Node, Comment, Container } from 'postcss';
 import { NameMapper } from './name-mapper';
 
 const { booleanStateDelimiter } = STCustomState.delimiters;
@@ -54,8 +54,11 @@ export class StylableOptimizer implements IStylableOptimizer {
         if (config.removeComments) {
             this.removeComments(targetAst);
         }
-        if (config.removeStylableDirectives) {
-            this.removeStylableDirectives(targetAst);
+        if ((config as any).removeStylableDirectives !== undefined) {
+            // ToDo(major): remove warning
+            console.warn(
+                `optimizer "removeStylableDirectives" is no longer required as "-st-*" declarations are removed during transformation`
+            );
         }
         if (config.removeUnusedComponents && usageMapping) {
             this.removeUnusedComponents(targetAst, usageMapping);
@@ -125,24 +128,6 @@ export class StylableOptimizer implements IStylableOptimizer {
                     .join(' ');
             }
         });
-    }
-
-    public removeStylableDirectives(root: Root, shouldComment = false) {
-        const toRemove: Node[] = [];
-        root.walkDecls((decl: Declaration) => {
-            if (decl.prop.startsWith('-st-')) {
-                toRemove.push(decl);
-            }
-        });
-        toRemove.forEach(
-            shouldComment
-                ? (node) => {
-                      node.replaceWith(...createLineByLineComment(node));
-                  }
-                : (node) => {
-                      node.remove();
-                  }
-        );
     }
 
     protected rewriteSelector(

--- a/packages/optimizer/test/stylable-optimizer.spec.ts
+++ b/packages/optimizer/test/stylable-optimizer.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as postcss from 'postcss';
-import deindent from 'deindent';
 import { generateStylableResult } from '@stylable/core-test-kit';
 import { removeCommentNodes, StylableOptimizer } from '@stylable/optimizer';
 
@@ -25,33 +24,6 @@ describe('StylableOptimizer', () => {
         removeCommentNodes(ast);
 
         expect(ast.toString().trim()).to.equal(`.a { color: red  green }`);
-    });
-
-    it('removeStylableDirectives', () => {
-        const ast = postcss.parse(deindent`
-                .a {
-                    -st-: 1;
-                    -st-states: 2;
-                }
-                @media (max-width) {
-                    .c {
-                        -st-: 1;
-                    }
-                }
-            `);
-
-        (ast as any).cleanRaws(false);
-
-        new StylableOptimizer().removeStylableDirectives(ast);
-
-        expect(ast.toString()).to.equal(
-            deindent`
-                .a {}
-                @media (max-width) {
-                    .c {}
-                }
-            `.trim()
-        );
     });
 
     it('removeUnusedComponents', () => {

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -75,8 +75,6 @@ interface StylableWebpackPluginOptions {
     optimize?: {
         /* Removes comments from output css */
         removeComments?: boolean;
-        /* Removes all Stylable directives like -st-extends */
-        removeStylableDirectives?: boolean;
         /* Removes unused rules that target unused components */
         removeUnusedComponents?: boolean;
         /* Remove empty css rules */
@@ -160,7 +158,6 @@ new StylableWebpackPlugin({
     diagnosticsMode: 'auto',
     optimize: {
       removeUnusedComponents: true,
-      removeStylableDirectives: true,
       removeComments: false,
       classNameOptimizations: false,
       shortNamespaces: false,
@@ -179,7 +176,6 @@ new StylableWebpackPlugin({
     diagnosticsMode: 'auto',
     optimize: {
       removeUnusedComponents: true,
-      removeStylableDirectives: true,
       removeComments: true,
       classNameOptimizations: true,
       shortNamespaces: true,

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -146,7 +146,6 @@ export interface StylableWebpackPluginOptions {
 
 const defaultOptimizations = (isProd: boolean): Required<OptimizeOptions> => ({
     removeUnusedComponents: true,
-    removeStylableDirectives: true,
     removeComments: isProd,
     classNameOptimizations: isProd,
     shortNamespaces: isProd,

--- a/packages/webpack-plugin/test/e2e/optimizations.spec.ts
+++ b/packages/webpack-plugin/test/e2e/optimizations.spec.ts
@@ -1,4 +1,4 @@
-import { browserFunctions, StylableProjectRunner } from '@stylable/e2e-test-kit';
+import { StylableProjectRunner } from '@stylable/e2e-test-kit';
 import { expect } from 'chai';
 import { dirname } from 'path';
 
@@ -12,7 +12,7 @@ describe(`(${project})`, () => {
         {
             projectDir,
             launchOptions: {
-                // headless: false
+                // headless: false,
             },
         },
         before,
@@ -20,30 +20,11 @@ describe(`(${project})`, () => {
         after
     );
 
-    it('renders css', async () => {
-        const { page } = await projectRunner.openInBrowser();
-        const styleElements = await page.evaluate(browserFunctions.getStyleElementsMetadata, {
-            includeCSSContent: true,
-        });
-
-        expect(styleElements).to.eql([
-            // {
-            //     id: './node_modules/test-components/button.st.css',
-            //     depth: '1',
-            //     css: ''
-            // },
-            // {
-            //     id: './node_modules/test-components/index.st.css',
-            //     depth: '2',
-            //     css: ''
-            // },
-            {
-                id: './src/index.st.css',
-                depth: '3',
-
-                css: '.global1{background:gray}.global1 .global2{background-color:#e4e4e4}.s0.o0--x{font-family:MyFont}.s1{background:#00f}',
-            },
-        ]);
+    it('generate minimal optimized css', () => {
+        const files = projectRunner.getProjectFiles();
+        expect(files['dist/stylable.css']).to.eql(
+            '.global1{background:gray}.global1 .global2{background-color:#e4e4e4}.s0.o0--x{font-family:MyFont}.s1{background:#00f}'
+        );
     });
 
     it('css is working', async () => {

--- a/packages/webpack-plugin/test/e2e/projects/optimizations/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/optimizations/webpack.config.js
@@ -3,7 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
-    mode: 'development',
+    mode: 'production',
     context: __dirname,
     devtool: 'source-map',
     plugins: [
@@ -11,7 +11,6 @@ module.exports = {
             optimize: {
                 removeUnusedComponents: true,
                 removeComments: true,
-                removeStylableDirectives: true,
                 classNameOptimizations: true,
                 shortNamespaces: true,
                 removeEmptyNodes: true,


### PR DESCRIPTION
This PR moves the removal of `-st-*` declarations to be part of the transformation when used with `mode: production`. 

In addition the `removeStylableDirectives` configuration is removed and a `console.warn` with an appropriate deprecation/unrequired message is logged.  