### PR TITLE
chore: replace deindent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@types/css-selector-tokenizer": "^0.7.1",
         "@types/cssesc": "^3.0.0",
         "@types/csso": "^5.0.0",
-        "@types/deindent": "^0.1.0",
         "@types/express": "^4.17.15",
         "@types/find-config": "^1.0.1",
         "@types/flat": "^5.0.2",
@@ -531,12 +530,6 @@
       "dependencies": {
         "@types/css-tree": "*"
       }
-    },
-    "node_modules/@types/deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3by89NLVgO0itemyomWio5JoAKDYDtOuLtv562WVQZugsRWd7sjnI+4EaBzYGmN09nY0s5uVIrpM82/bAv+WqQ==",
-      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
@@ -2569,11 +2562,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3SOF3+jbGRpDrvZaojZJ5bfg6ubAfxmXcukRkX1Fd/pD2zK4J8uvADMAwnP0/4pwwwjHHRwsRYW5EkR/d6YAlQ=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -8447,7 +8435,6 @@
         "balanced-match": "^2.0.0",
         "css-selector-tokenizer": "^0.8.0",
         "cssesc": "^3.0.0",
-        "deindent": "^0.1.0",
         "enhanced-resolve": "^5.12.0",
         "is-vendor-prefixed": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
@@ -8990,7 +8977,6 @@
         "balanced-match": "^2.0.0",
         "css-selector-tokenizer": "^0.8.0",
         "cssesc": "^3.0.0",
-        "deindent": "^0.1.0",
         "enhanced-resolve": "^5.12.0",
         "is-vendor-prefixed": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
@@ -9262,12 +9248,6 @@
       "requires": {
         "@types/css-tree": "*"
       }
-    },
-    "@types/deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3by89NLVgO0itemyomWio5JoAKDYDtOuLtv562WVQZugsRWd7sjnI+4EaBzYGmN09nY0s5uVIrpM82/bAv+WqQ==",
-      "dev": true
     },
     "@types/eslint": {
       "version": "8.4.10",
@@ -10837,11 +10817,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3SOF3+jbGRpDrvZaojZJ5bfg6ubAfxmXcukRkX1Fd/pD2zK4J8uvADMAwnP0/4pwwwjHHRwsRYW5EkR/d6YAlQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/css-selector-tokenizer": "^0.7.1",
     "@types/cssesc": "^3.0.0",
     "@types/csso": "^5.0.0",
-    "@types/deindent": "^0.1.0",
     "@types/express": "^4.17.15",
     "@types/find-config": "^1.0.1",
     "@types/flat": "^5.0.2",

--- a/packages/code-formatter/test/formatter.spec.ts
+++ b/packages/code-formatter/test/formatter.spec.ts
@@ -1,6 +1,6 @@
+import { deindent } from '@stylable/core-test-kit';
 import { getDocumentFormatting } from '@stylable/code-formatter';
 import { expect } from 'chai';
-import deindent from 'deindent';
 
 describe('Formatting', () => {
     it('should format an entire stylesheet with extra spaces', () => {
@@ -30,7 +30,8 @@ describe('Formatting', () => {
         );
 
         expect(res).to.eql(
-            deindent(`/* PRESERVE INDENT */
+            deindent(`
+                /* PRESERVE INDENT */
                 .foo {
                     grid-template:
                         "icon  name name ."    16px
@@ -54,7 +55,8 @@ describe('Formatting', () => {
         );
 
         expect(res).to.eql(
-            deindent(`/* PRESERVE INDENT */
+            deindent(`
+                /* PRESERVE INDENT */
                 .foo {
                     grid:
                         "icon  name name ."    16px

--- a/packages/code-formatter/test/formatter.spec.ts
+++ b/packages/code-formatter/test/formatter.spec.ts
@@ -19,7 +19,6 @@ describe('Formatting', () => {
     it('should preserve grid-template declarations', () => {
         const res = getDocumentFormatting(
             deindent(`
-                /* PRESERVE INDENT */
                 .foo {
                     grid-template:
                         "icon  name name ."    16px
@@ -31,7 +30,6 @@ describe('Formatting', () => {
 
         expect(res).to.eql(
             deindent(`
-                /* PRESERVE INDENT */
                 .foo {
                     grid-template:
                         "icon  name name ."    16px
@@ -44,7 +42,6 @@ describe('Formatting', () => {
     it('should preserve grid declarations', () => {
         const res = getDocumentFormatting(
             deindent(`
-                /* PRESERVE INDENT */
                 .foo {
                     grid:
                         "icon  name name ."    16px
@@ -56,7 +53,6 @@ describe('Formatting', () => {
 
         expect(res).to.eql(
             deindent(`
-                /* PRESERVE INDENT */
                 .foo {
                     grid:
                         "icon  name name ."    16px

--- a/packages/code-formatter/test/tsconfig.json
+++ b/packages/code-formatter/test/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "../dist/test",
     "types": ["node", "externals", "mocha"]
   },
-  "references": [{ "path": "../src" }]
+  "references": [{ "path": "../src" }, { "path": "../../core-test-kit/src" }]
 }

--- a/packages/core-test-kit/src/deindent.ts
+++ b/packages/core-test-kit/src/deindent.ts
@@ -1,8 +1,8 @@
 /**
  * Naive deindent - takes in a string and:
- *  1. find the minimal indentation across all lines with content
+ *  1. finds the minimal indentation across all lines of content
  *  2. removes the minimal whitespace for each line
- *  3. attempt to remove first and last line in case of empty lines to improve usage
+ *  3. attempts to remove first and last line in case of empty lines to improve usage
  *
  * NOTICE: treat tab (\t) as a single character - all lines are expected to be indented in the same format
  */

--- a/packages/core-test-kit/src/deindent.ts
+++ b/packages/core-test-kit/src/deindent.ts
@@ -1,0 +1,29 @@
+/**
+ * Naive deindent - takes in a string and:
+ *  1. find the minimal indentation across all lines with content
+ *  2. removes the minimal whitespace for each line
+ *  3. attempt to remove first and last line in case of empty lines to improve usage
+ *
+ * NOTICE: treat tab (\t) as a single character - all lines are expected to be indented in the same format
+ */
+export function deindent(text: string) {
+    if (!text) {
+        return text;
+    }
+    const lines = text.split('\n');
+    let min = text.length;
+    for (const line of lines) {
+        if (!line || !line.trim()) {
+            continue;
+        }
+        const indent = line.match(/^[\s\t]+/);
+        const indentSize = indent?.[0].length || 0;
+        if (indentSize < min) {
+            min = indentSize;
+        }
+    }
+    return lines
+        .map((line) => line.slice(min))
+        .join('\n')
+        .trim();
+}

--- a/packages/core-test-kit/src/diagnostics.ts
+++ b/packages/core-test-kit/src/diagnostics.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
-import deindent from 'deindent';
 import type { Position } from 'postcss';
 import { Diagnostics, DiagnosticSeverity, StylableMeta, StylableResults } from '@stylable/core';
 import { DiagnosticBase, safeParse, StylableProcessor } from '@stylable/core/dist/index-internal';
+import { deindent } from './deindent';
 import { Config, generateStylableResult } from './generate-test-util';
 
 export interface Diagnostic {
@@ -266,7 +266,7 @@ export function expectTransformDiagnostics(
 
     const locations: Record<string, Location> = {};
     for (const path in config.files) {
-        const source = findTestLocations(deindent(config.files[path].content).trim());
+        const source = findTestLocations(deindent(config.files[path].content));
         config.files[path].content = source.css;
         locations[path] = source;
     }

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -26,3 +26,4 @@ export { matchAllRulesAndDeclarations, matchRuleAndDeclaration } from './match-r
 export { collectAst } from './collect-ast';
 export { testInlineExpects, testInlineExpectsErrors } from './inline-expectation';
 export { testStylableCore } from './test-stylable-core';
+export { deindent } from './deindent';

--- a/packages/core-test-kit/test/deindent.spec.ts
+++ b/packages/core-test-kit/test/deindent.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { deindent } from '@stylable/core-test-kit';
+
+describe('helpers/deindent', () => {
+    it(`should trim single line`, () => {
+        const result = deindent(`   A  `);
+        expect(result, 'empty lines').to.eql(`A`);
+    });
+    it(`should trim first and last empty lines`, () => {
+        const result = deindent(`
+            A
+        `);
+        expect(result, 'empty lines').to.eql(`A`);
+    });
+    it(`should preserve first and last lines with context`, () => {
+        const result = deindent(`X
+            A
+        Y`);
+        expect(result, 'empty lines').to.eql(`X
+            A
+        Y`);
+    });
+    it(`should remove all indentation`, () => {
+        const result = deindent(`
+            A
+            B
+        `);
+        expect(result).to.eql(`A\nB`);
+    });
+    it(`should preserve relative indentation`, () => {
+        const result = deindent(`
+            A
+            	B
+             C
+        `);
+        expect(result).to.eql(`A\n\tB\n C`);
+    });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,6 @@
     "balanced-match": "^2.0.0",
     "css-selector-tokenizer": "^0.8.0",
     "cssesc": "^3.0.0",
-    "deindent": "^0.1.0",
     "enhanced-resolve": "^5.12.0",
     "is-vendor-prefixed": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/core/test/features/css-contains.spec.ts
+++ b/packages/core/test/features/css-contains.spec.ts
@@ -3,8 +3,8 @@ import {
     testStylableCore,
     shouldReportNoDiagnostics,
     diagnosticBankReportToStrings,
+    deindent,
 } from '@stylable/core-test-kit';
-import deindent from 'deindent';
 import { expect } from 'chai';
 
 const diagnostics = diagnosticBankReportToStrings(CSSContains.diagnostics);
@@ -559,9 +559,11 @@ describe('features/css-contains', () => {
                     .entry__mix { id: mix-in-container; }
                     .entry__after { id: after-in-container; }
                 }
-                 .entry__into {
+
+                .entry__into {
                 }
-                 @container (inline-size > 1px) {
+                
+                @container (inline-size > 1px) {
                     .entry__into { id: mix-in-container; }
                 }
             `)
@@ -571,12 +573,12 @@ describe('features/css-contains', () => {
     describe('native css', () => {
         it('should not namespace', () => {
             const { stylable } = testStylableCore({
-                '/native.css': deindent`
+                '/native.css': deindent(`
                     .x {
                         container-name: a;
                     }
                     @container a (inline-size > 100px) {}
-                `,
+                `),
                 '/entry.st.css': `
                     @st-import [container(a)] from './native.css';
 
@@ -592,12 +594,12 @@ describe('features/css-contains', () => {
             shouldReportNoDiagnostics(meta);
 
             expect(nativeMeta.targetAst?.toString().trim(), 'no native transform').to.eql(
-                deindent`
+                deindent(`
                     .x {
                         container-name: a;
                     }
                     @container a (inline-size > 100px) {}
-            `.trim()
+                `)
             );
 
             // JS exports

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -4,9 +4,9 @@ import {
     testStylableCore,
     shouldReportNoDiagnostics,
     diagnosticBankReportToStrings,
+    deindent,
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import deindent from 'deindent';
 
 const stImportDiagnostics = diagnosticBankReportToStrings(STImport.diagnostics);
 const stSymbolDiagnostics = diagnosticBankReportToStrings(STSymbol.diagnostics);
@@ -924,7 +924,7 @@ describe(`features/css-custom-property`, () => {
     describe('native css', () => {
         it('should not namespace', () => {
             const { stylable } = testStylableCore({
-                '/native.css': deindent`
+                '/native.css': deindent(`
                     @property --a {
                         syntax: '<color>';
                         initial-value: green;
@@ -933,7 +933,7 @@ describe(`features/css-custom-property`, () => {
                     .x {
                         --b: var(--c);
                     }
-                `,
+                `),
                 '/entry.st.css': `
                     @st-import [--a, --b, --c] from './native.css';
 
@@ -957,7 +957,7 @@ describe(`features/css-custom-property`, () => {
             shouldReportNoDiagnostics(meta);
 
             expect(nativeMeta.targetAst?.toString().trim(), 'no native transform').to.eql(
-                deindent`
+                deindent(`
                     @property --a {
                         syntax: '<color>';
                         initial-value: green;
@@ -966,7 +966,7 @@ describe(`features/css-custom-property`, () => {
                     .x {
                         --b: var(--c);
                     }
-            `.trim()
+                `)
             );
 
             // JS exports
@@ -978,7 +978,7 @@ describe(`features/css-custom-property`, () => {
         });
         it('should ignore stylable specific transformations', () => {
             const { stylable } = testStylableCore({
-                '/native.css': deindent`
+                '/native.css': deindent(`
                     @st-global-custom-property --a;
                     @property st-global(--a) {
                         syntax: '<color>';
@@ -986,13 +986,13 @@ describe(`features/css-custom-property`, () => {
                         inherits: false;
                     }
                     @property --no-body;
-                `,
+                `),
             });
 
             const { meta: nativeMeta } = stylable.transform('/native.css');
 
             expect(nativeMeta.targetAst?.toString().trim(), 'no native transform').to.eql(
-                deindent`
+                deindent(`
                     @st-global-custom-property --a;
                     @property st-global(--a) {
                         syntax: '<color>';
@@ -1000,7 +1000,7 @@ describe(`features/css-custom-property`, () => {
                         inherits: false;
                     }
                     @property --no-body;
-            `.trim()
+                `)
             );
         });
     });

--- a/packages/core/test/features/css-keyframes.spec.ts
+++ b/packages/core/test/features/css-keyframes.spec.ts
@@ -3,10 +3,10 @@ import {
     testStylableCore,
     shouldReportNoDiagnostics,
     diagnosticBankReportToStrings,
+    deindent,
 } from '@stylable/core-test-kit';
 import chai, { expect } from 'chai';
 import chaiSubset from 'chai-subset';
-import deindent from 'deindent';
 chai.use(chaiSubset);
 
 const mixinDiagnostics = diagnosticBankReportToStrings(STMixin.diagnostics);
@@ -619,12 +619,12 @@ describe(`features/css-keyframes`, () => {
     describe('native css', () => {
         it('should not namespace', () => {
             const { stylable } = testStylableCore({
-                '/native.css': deindent`
+                '/native.css': deindent(`
                     @keyframes jump {}
                     .x {
                         animation: jump;
                     }
-                `,
+                `),
                 '/entry.st.css': `
                     @st-import [keyframes(jump)] from './native.css';
 
@@ -642,12 +642,12 @@ describe(`features/css-keyframes`, () => {
             shouldReportNoDiagnostics(meta);
 
             expect(nativeMeta.targetAst?.toString().trim(), 'no native transform').to.eql(
-                deindent`
+                deindent(`
                     @keyframes jump {}
                     .x {
                         animation: jump;
                     }
-            `.trim()
+                `)
             );
 
             // JS exports

--- a/packages/core/test/features/css-layer.spec.ts
+++ b/packages/core/test/features/css-layer.spec.ts
@@ -3,8 +3,8 @@ import {
     testStylableCore,
     shouldReportNoDiagnostics,
     diagnosticBankReportToStrings,
+    deindent,
 } from '@stylable/core-test-kit';
-import deindent from 'deindent';
 import { expect } from 'chai';
 
 const cssLayerDiagnostics = diagnosticBankReportToStrings(CSSLayer.diagnostics);
@@ -436,9 +436,11 @@ describe('features/css-layer', () => {
                     .entry__mix { id: mix-in-layer; }
                     .entry__after { id: after-in-layer; }
                 }
-                 .entry__into {
+
+                .entry__into {
                 }
-                 @layer entry__x {
+
+                @layer entry__x {
                     .entry__into { id: mix-in-layer; }
                 }
             `)
@@ -544,10 +546,10 @@ describe('features/css-layer', () => {
     describe('native css', () => {
         it('should not namespace', () => {
             const { stylable } = testStylableCore({
-                '/native.css': deindent`
+                '/native.css': deindent(`
                     @layer a, b;
                     @layer c {}
-                `,
+                `),
                 '/entry.st.css': `
                     @st-import [layer(a, b, c)] from './native.css';
 
@@ -563,10 +565,10 @@ describe('features/css-layer', () => {
             shouldReportNoDiagnostics(meta);
 
             expect(nativeMeta.targetAst?.toString().trim(), 'no native transform').to.eql(
-                deindent`
+                deindent(`
                     @layer a, b;
                     @layer c {}
-                `.trim()
+                `)
             );
 
             // JS exports
@@ -578,19 +580,19 @@ describe('features/css-layer', () => {
         });
         it('should ignore stylable specific transformations', () => {
             const { stylable } = testStylableCore({
-                '/native.css': deindent`
+                '/native.css': deindent(`
                     @layer a, st-global(b);
                     @layer st-global(c) {}
-                `,
+                `),
             });
 
             const { meta: nativeMeta } = stylable.transform('/native.css');
 
             expect(nativeMeta.targetAst?.toString().trim(), 'no native transform').to.eql(
-                deindent`
+                deindent(`
                     @layer a, st-global(b);
                     @layer st-global(c) {}
-            `.trim()
+                `)
             );
         });
     });

--- a/packages/core/test/helpers/ast.spec.ts
+++ b/packages/core/test/helpers/ast.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { parse } from 'postcss';
 import { getAstNodeAt } from '@stylable/core/dist/helpers/ast';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 function setupWithCursor(source: string) {
     const deindented = deindent(source);

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -1,6 +1,5 @@
-import { testStylableCore, generateStylableEnvironment } from '@stylable/core-test-kit';
+import { testStylableCore, generateStylableEnvironment, deindent } from '@stylable/core-test-kit';
 import { expect } from 'chai';
-import deindent from 'deindent';
 
 describe('Stylable', () => {
     describe(`analyze (generate meta) `, () => {

--- a/packages/language-service/test/lib/completions/contains.spec.ts
+++ b/packages/language-service/test/lib/completions/contains.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { createDiagnostics } from '../../test-kit/diagnostics-setup';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 describe('CSS contains', () => {
     it('should ignore native css lsp diagnostics unknown container at-rule and declarations', () => {
@@ -9,13 +9,13 @@ describe('CSS contains', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: deindent`
+                [filePath]: deindent(`
                     @container a (inline-size > 100px) {}
                     .root {
                         container-name: a;
                         container: a / normal;
                     }
-                `,
+                `),
             },
             filePath
         );

--- a/packages/language-service/test/lib/completions/custom-property.spec.ts
+++ b/packages/language-service/test/lib/completions/custom-property.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { createDiagnostics } from '../../test-kit/diagnostics-setup';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 describe('custom property', () => {
     it('should ignore native css lsp diagnostics for @property body', () => {
@@ -8,9 +8,9 @@ describe('custom property', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: deindent`
+                [filePath]: deindent(`
                     @property --x;
-                `,
+                `),
             },
             filePath
         );
@@ -22,13 +22,13 @@ describe('custom property', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: deindent`
+                [filePath]: deindent(`
                     @property st-global(--y) {
                         syntax: '<color>';
                         inherits: true; 
                         initial-value: green;
                     }
-                `,
+                `),
             },
             filePath
         );

--- a/packages/language-service/test/lib/completions/keyframes.spec.ts
+++ b/packages/language-service/test/lib/completions/keyframes.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { createDiagnostics } from '../../test-kit/diagnostics-setup';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 describe('keyframes', () => {
     it('should clear st-global from ident to allow css-lsp to function', () => {
@@ -8,9 +8,9 @@ describe('keyframes', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: deindent`
+                [filePath]: deindent(`
                     @keyframes st-global(abc) {}
-                `,
+                `),
             },
             filePath
         );

--- a/packages/language-service/test/lib/completions/layer.spec.ts
+++ b/packages/language-service/test/lib/completions/layer.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { createDiagnostics } from '../../test-kit/diagnostics-setup';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 describe('layer', () => {
     it('should clear st-global from ident to allow css-lsp to function', () => {
@@ -8,9 +8,9 @@ describe('layer', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: deindent`
+                [filePath]: deindent(`
                     @layer aaa, st-global(bbb), ccc, st-global(ddd);
-                `,
+                `),
             },
             filePath
         );

--- a/packages/language-service/test/lib/completions/namespace-directive.spec.ts
+++ b/packages/language-service/test/lib/completions/namespace-directive.spec.ts
@@ -3,7 +3,7 @@ import { topLevelDirectives } from '@stylable/language-service/dist/lib/completi
 import * as asserters from '../../test-kit/completions-asserters';
 import { expect } from 'chai';
 import { createDiagnostics } from '../../test-kit/diagnostics-setup';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 describe('Namespace Directive', () => {
     describe('should complete @st-namespace at top level ', () => {
@@ -42,9 +42,9 @@ describe('Namespace Directive', () => {
 
         const diagnostics = createDiagnostics(
             {
-                [filePath]: deindent`
+                [filePath]: deindent(`
                     @st-namespace "comp";
-                `,
+                `),
             },
             filePath
         );

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -3,7 +3,7 @@ import { Stylable } from '@stylable/core';
 import { safeParse } from '@stylable/core/dist/index-internal';
 import { StylableLanguageService } from '@stylable/language-service';
 import { expect } from 'chai';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 import { createDiagnostics } from '../test-kit/diagnostics-setup';
 
 describe('diagnostics', () => {
@@ -175,7 +175,7 @@ describe('diagnostics', () => {
 
             const diagnostics = createDiagnostics(
                 {
-                    [filePath]: deindent`
+                    [filePath]: deindent(`
                     @st-scope [div=rtl] {
                          .root {}
                     }
@@ -183,7 +183,7 @@ describe('diagnostics', () => {
                     @st-scope * {
                         .root {}
                     }
-                    `,
+                    `),
                 },
                 filePath
             );

--- a/packages/language-service/test/tsconfig.json
+++ b/packages/language-service/test/tsconfig.json
@@ -7,6 +7,7 @@
   "references": [
     { "path": "../src" },
     { "path": "../../core/src" },
-    { "path": "../../code-formatter/src" }
+    { "path": "../../code-formatter/src" },
+    { "path": "../../core-test-kit/src" }
   ]
 }

--- a/packages/module-utils/test/sourcemap.spec.ts
+++ b/packages/module-utils/test/sourcemap.spec.ts
@@ -1,7 +1,6 @@
-import { generateStylableResult } from '@stylable/core-test-kit';
+import { generateStylableResult, deindent } from '@stylable/core-test-kit';
 import { generateDTSSourceMap, generateDTSContent } from '@stylable/module-utils';
 import { expect } from 'chai';
-import deindent from 'deindent';
 import { SourceMapConsumer } from 'source-map';
 
 function getPosition(content: string, query: string) {
@@ -113,7 +112,7 @@ describe('.d.ts source-maps', () => {
             getPosition(dtsText, 'c1":') // source mapping starts after the first double quote
         );
 
-        expect(originalPosition).to.eql({ line: 3, column: 4, source: 'entry.st.css', name: null });
+        expect(originalPosition).to.eql({ line: 2, column: 4, source: 'entry.st.css', name: null });
     });
 
     it('maps the "c1" css variable in the ".d.ts" to its position in the original ".st.css" file', async () => {
@@ -170,10 +169,10 @@ describe('.d.ts source-maps', () => {
                 },
                 '/entry.st.css': {
                     namespace: 'entry',
-                    content: deindent`
+                    content: deindent(`
                         @st-import [layer(L0 as imported-layer)] from "./another.st.css";
                         @layer L1 {}
-                    `,
+                    `),
                 },
             },
         });
@@ -187,13 +186,13 @@ describe('.d.ts source-maps', () => {
             sourceMapConsumer.originalPositionFor(
                 getPosition(dtsText, 'L1":') // source mapping starts after the first double quote
             )
-        ).to.eql({ line: 3, column: 0, source: 'entry.st.css', name: null });
+        ).to.eql({ line: 2, column: 0, source: 'entry.st.css', name: null });
         // imported layer
         expect(
             sourceMapConsumer.originalPositionFor(
                 getPosition(dtsText, 'imported-layer":') // source mapping starts after the first double quote
             )
-        ).to.eql({ line: 2, column: 0, source: 'entry.st.css', name: null });
+        ).to.eql({ line: 1, column: 0, source: 'entry.st.css', name: null });
     });
 
     it('maps the container in the ".d.ts" to its position in the original ".st.css" file', async () => {
@@ -206,12 +205,12 @@ describe('.d.ts source-maps', () => {
                 },
                 '/entry.st.css': {
                     namespace: 'entry',
-                    content: deindent`
+                    content: deindent(`
                         @st-import [container(C1 as imported-container)] from "./another.st.css";
                         .a {
                             container: C2;
                         }
-                    `,
+                    `),
                 },
             },
         });
@@ -225,13 +224,13 @@ describe('.d.ts source-maps', () => {
             sourceMapConsumer.originalPositionFor(
                 getPosition(dtsText, 'C2":') // source mapping starts after the first double quote
             )
-        ).to.eql({ line: 4, column: 4, source: 'entry.st.css', name: null });
+        ).to.eql({ line: 3, column: 4, source: 'entry.st.css', name: null });
         // imported container
         expect(
             sourceMapConsumer.originalPositionFor(
                 getPosition(dtsText, 'imported-container":') // source mapping starts after the first double quote
             )
-        ).to.eql({ line: 2, column: 0, source: 'entry.st.css', name: null });
+        ).to.eql({ line: 1, column: 0, source: 'entry.st.css', name: null });
     });
 
     it('maps states in the ".d.ts" to their positions in the original ".st.css" file', async () => {
@@ -259,13 +258,13 @@ describe('.d.ts source-maps', () => {
         );
 
         expect(state1OriginalPosition).to.eql({
-            line: 2,
+            line: 1,
             column: 8,
             source: 'entry.st.css',
             name: null,
         });
         expect(state2OriginalPosition).to.eql({
-            line: 3,
+            line: 2,
             column: 9,
             source: 'entry.st.css',
             name: null,
@@ -302,19 +301,19 @@ describe('.d.ts source-maps', () => {
         );
 
         expect(state1OriginalPosition).to.eql({
-            line: 2,
+            line: 1,
             column: 8,
             source: 'entry.st.css',
             name: null,
         });
         expect(state2OriginalPosition).to.eql({
-            line: 3,
+            line: 2,
             column: 13,
             source: 'entry.st.css',
             name: null,
         });
         expect(state3OriginalPosition).to.eql({
-            line: 4,
+            line: 3,
             column: 13,
             source: 'entry.st.css',
             name: null,
@@ -344,7 +343,7 @@ describe('.d.ts source-maps', () => {
         );
 
         expect(sameStateOriginalPosition).to.eql({
-            line: 2, // expect .test class (1 based index)
+            line: 1, // expect .test class (1 based index)
             column: 8,
             source: 'entry.st.css',
             name: null,
@@ -414,61 +413,61 @@ describe('.d.ts source-maps', () => {
         );
 
         expect(class1OriginalPosition).to.eql({
-            line: 6,
+            line: 5,
             column: 0,
             source: 'entry.st.css',
             name: null,
         });
         expect(class2OriginalPosition).to.eql({
-            line: 10,
+            line: 9,
             column: 0,
             source: 'entry.st.css',
             name: null,
         });
         expect(stVar1OriginalPosition).to.eql({
-            line: 3,
+            line: 2,
             column: 4,
             source: 'entry.st.css',
             name: null,
         });
         expect(stVar2OriginalPosition).to.eql({
-            line: 4,
+            line: 3,
             column: 4,
             source: 'entry.st.css',
             name: null,
         });
         expect(cssVar1OriginalPosition).to.eql({
-            line: 8,
-            column: 4,
-            source: 'entry.st.css',
-            name: null,
-        });
-        expect(cssVar2OriginalPosition).to.eql({
-            line: 12,
-            column: 4,
-            source: 'entry.st.css',
-            name: null,
-        });
-        expect(state1OriginalPosition).to.eql({
             line: 7,
             column: 4,
             source: 'entry.st.css',
             name: null,
         });
-        expect(state2OriginalPosition).to.eql({
+        expect(cssVar2OriginalPosition).to.eql({
             line: 11,
             column: 4,
             source: 'entry.st.css',
             name: null,
         });
+        expect(state1OriginalPosition).to.eql({
+            line: 6,
+            column: 4,
+            source: 'entry.st.css',
+            name: null,
+        });
+        expect(state2OriginalPosition).to.eql({
+            line: 10,
+            column: 4,
+            source: 'entry.st.css',
+            name: null,
+        });
         expect(keyframes1OriginalPosition).to.eql({
-            line: 14,
+            line: 13,
             column: 0,
             source: 'entry.st.css',
             name: null,
         });
         expect(layer1OriginalPosition).to.eql({
-            line: 15,
+            line: 14,
             column: 0,
             source: 'entry.st.css',
             name: null,
@@ -517,31 +516,31 @@ describe('.d.ts source-maps', () => {
 
         expect(aOriginalPosition).to.eql({
             column: 4,
-            line: 3,
+            line: 2,
             name: null,
             source: 'entry.st.css',
         });
         expect(bOriginalPosition).to.eql({
             column: 14,
-            line: 3,
+            line: 2,
             name: null,
             source: 'entry.st.css',
         });
         expect(cOriginalPosition).to.eql({
             column: 6,
-            line: 6,
+            line: 5,
             name: null,
             source: 'entry.st.css',
         });
         expect(dOriginalPosition).to.eql({
             column: 15,
-            line: 5,
+            line: 4,
             name: null,
             source: 'entry.st.css',
         });
         expect(eOriginalPosition).to.eql({
             column: 15,
-            line: 4,
+            line: 3,
             name: null,
             source: 'entry.st.css',
         });

--- a/packages/rollup-plugin/test/rollup-side-effects.spec.ts
+++ b/packages/rollup-plugin/test/rollup-side-effects.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { rollupRunner } from './test-kit/rollup-runner';
 import { getProjectPath } from './test-kit/test-helpers';
-import deindent from 'deindent';
+import { deindent } from '@stylable/core-test-kit';
 
 describe('StylableRollupPlugin - include all stylesheets with side-effects', function () {
     this.timeout(30000);
@@ -27,7 +27,7 @@ describe('StylableRollupPlugin - include all stylesheets with side-effects', fun
 
         await ready;
 
-        const expected = deindent`
+        const expected = deindent(`
         .native-css {
             color: green;
         }
@@ -46,7 +46,7 @@ describe('StylableRollupPlugin - include all stylesheets with side-effects', fun
             --globalselector-x: green;
         }
         .index__root {}
-        `;
+        `);
         const outputFiles = getOutputFiles();
         expect(outputFiles['stylable.css'].replace(/\s+/g, ''), 'css bundle').to.eql(
             expected.replace(/\s+/g, '')

--- a/packages/rollup-plugin/test/tsconfig.json
+++ b/packages/rollup-plugin/test/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "../../core/src" },
     { "path": "../../cli/src" },
     { "path": "../../e2e-test-kit/src" },
+    { "path": "../../core-test-kit/src" },
     { "path": "../../optimizer/src" },
     { "path": "../src" }
   ]


### PR DESCRIPTION
This PR removed the dependency on `deindent` package. It has several issues, like losing newlines and in some cases spaces, and in addition doesn't trim the first/last empty lines, making it harder to use.

- remove deindent as `@stylable/core` dependency - not sure why it wasn't a dev-dependency as it's only used in tests
- write alternative into `@stylable/core-test-kit`
    - trim empty first/last lines
    - remove indentation based on the minimal length of indentation before content
    - preserve newlines and spaces
- replace all usages - had to add `core-test-kit` as a dependency to several test folders