### PR TITLE
infra: enforce allowed import paths between packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,23 @@
         "@typescript-eslint/restrict-plus-operands": "off",
         "@typescript-eslint/restrict-template-expressions": "off",
         "@typescript-eslint/unbound-method": "off",
-        "@typescript-eslint/no-misused-promises": "off" // ToDo: remove once eslint fix issue
+        "@typescript-eslint/no-misused-promises": "off" // ToDo: remove once eslint fix issue.
+      }
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "excludedFiles": ["packages/*/test/**/*.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "@stylable/*/src/*",
+              "@stylable/*/dist/*",
+              "!@stylable/*/dist/index-internal"
+            ]
+          }
+        ]
       }
     }
   ]

--- a/packages/build-tools/src/process-url-dependencies.ts
+++ b/packages/build-tools/src/process-url-dependencies.ts
@@ -1,7 +1,10 @@
 import type { UrlNode } from 'css-selector-tokenizer';
 import type { StylableMeta } from '@stylable/core';
-import { isAsset, makeAbsolute } from '@stylable/core/dist/index-internal';
-import { processDeclarationFunctions } from '@stylable/core/dist/process-declaration-functions';
+import {
+    isAsset,
+    makeAbsolute,
+    processDeclarationFunctions,
+} from '@stylable/core/dist/index-internal';
 import { dirname } from 'path';
 
 function defaultFilter() {

--- a/packages/cli/src/base-generator.ts
+++ b/packages/cli/src/base-generator.ts
@@ -1,7 +1,7 @@
 import { nodeFs } from '@file-services/node';
 import type { IFileSystem } from '@file-services/types';
 import type { Stylable } from '@stylable/core';
-import { STSymbol } from '@stylable/core/dist/features';
+import { STSymbol } from '@stylable/core/dist/index-internal';
 import camelcase from 'lodash.camelcase';
 import upperfirst from 'lodash.upperfirst';
 import { normalizeRelative, ensureDirectory, tryRun } from './build-tools';

--- a/packages/cli/src/code-mods/namespace-to-st-namespace.ts
+++ b/packages/cli/src/code-mods/namespace-to-st-namespace.ts
@@ -1,4 +1,4 @@
-import { parseNamespace } from '@stylable/core/dist/features/st-namespace';
+import { STNamespace } from '@stylable/core/dist/index-internal';
 import type * as postcss from 'postcss';
 import type { CodeMod } from './types';
 
@@ -8,7 +8,7 @@ export const namespaceToStNamespace: CodeMod = ({ ast }) => {
     const nodesToMod: postcss.AtRule[] = [];
     ast.walkAtRules((atRule) => {
         if (atRule.name === 'namespace') {
-            const namespace = parseNamespace(atRule);
+            const namespace = STNamespace.parseNamespace(atRule);
             if (namespace) {
                 nodesToMod.push(atRule);
             }

--- a/packages/cli/src/code-mods/st-global-custom-property-to-at-property.ts
+++ b/packages/cli/src/code-mods/st-global-custom-property-to-at-property.ts
@@ -1,5 +1,5 @@
 import { CSSVarSymbol, Diagnostics, validateCustomPropertyName } from '@stylable/core';
-import { CSSCustomProperty } from '@stylable/core/dist/features';
+import { CSSCustomProperty } from '@stylable/core/dist/index-internal';
 import type { AtRule } from 'postcss';
 import type { CodeMod } from './types';
 

--- a/packages/cli/src/code-mods/st-import-to-at-import.ts
+++ b/packages/cli/src/code-mods/st-import-to-at-import.ts
@@ -1,4 +1,4 @@
-import { parsePseudoImport, createAtImportProps } from '@stylable/core/dist/helpers/import';
+import { parsePseudoImport, createAtImportProps } from '@stylable/core/dist/index-internal';
 import type { CodeMod } from './types';
 
 export const stImportToAtImport: CodeMod = ({ ast, diagnostics, postcss }) => {

--- a/packages/core/src/index-internal.ts
+++ b/packages/core/src/index-internal.ts
@@ -9,8 +9,25 @@ export {
     ResolvedElement,
 } from './stylable-transformer';
 export { validateDefaultConfig } from './stylable';
-export { STSymbol, STGlobal, STCustomSelector, STCustomState, CSSCustomProperty } from './features';
-export type { MappedStates, StateParsedValue, TemplateStateParsedValue } from './helpers/custom-state';
+export {
+    STSymbol,
+    STImport,
+    STGlobal,
+    STNamespace,
+    STCustomSelector,
+    STCustomState,
+    CSSClass,
+    CSSType,
+    CSSKeyframes,
+    CSSLayer,
+    CSSContains,
+    CSSCustomProperty,
+} from './features';
+export type {
+    MappedStates,
+    StateParsedValue,
+    TemplateStateParsedValue,
+} from './helpers/custom-state';
 export { murmurhash3_32_gc } from './murmurhash';
 export { cssParse } from './parser';
 export type { OptimizeConfig, IStylableOptimizer, ModuleResolver } from './types';
@@ -34,4 +51,6 @@ export { packageNamespaceFactory } from './resolve-namespace-factories';
 export { BoxedValueArray, BoxedValueMap, createCustomValue } from './custom-values';
 export { DiagnosticBase } from './diagnostics';
 export { getAstNodeAt } from './helpers/ast';
-export { tryCollectImportsDeep } from './helpers/import';
+export { tryCollectImportsDeep, parsePseudoImport, createAtImportProps } from './helpers/import';
+export { processDeclarationFunctions } from './process-declaration-functions';
+export { plugableRecord } from './helpers/plugable-record';

--- a/packages/module-utils/src/generate-dts-sourcemaps.ts
+++ b/packages/module-utils/src/generate-dts-sourcemaps.ts
@@ -1,7 +1,7 @@
 import { basename } from 'path';
 import type { ClassSymbol, StylableMeta } from '@stylable/core';
-import { STSymbol, CSSKeyframes, CSSLayer, CSSContains } from '@stylable/core/dist/features';
-import { processDeclarationFunctions } from '@stylable/core/dist/process-declaration-functions';
+import { STSymbol, CSSKeyframes, CSSLayer, CSSContains } from '@stylable/core/dist/index-internal';
+import { processDeclarationFunctions } from '@stylable/core/dist/index-internal';
 import { encode } from 'vlq';
 import {
     ClassesToken,

--- a/packages/runtime/src/index-internal.ts
+++ b/packages/runtime/src/index-internal.ts
@@ -1,0 +1,1 @@
+export { injectStyles } from './inject-styles';

--- a/packages/schema-extract/src/cssdocs.ts
+++ b/packages/schema-extract/src/cssdocs.ts
@@ -1,6 +1,6 @@
 import { extract, parseWithComments } from 'jest-docblock';
 import type { StylableMeta, StylableSymbol } from '@stylable/core';
-import { plugableRecord } from '@stylable/core/dist/helpers/plugable-record';
+import { plugableRecord } from '@stylable/core/dist/index-internal';
 import type { Rule } from 'postcss';
 
 export interface CssDoc {

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -1,5 +1,5 @@
 import { Stylable, StylableMeta } from '@stylable/core';
-import { STSymbol } from '@stylable/core/dist/features';
+import { STSymbol } from '@stylable/core/dist/index-internal';
 import { resolveNamespace } from '@stylable/node';
 import { createMetadataForStylesheet } from './create-metadata-stylesheet';
 import { hashContent } from './hash-content-util';

--- a/packages/webpack-plugin/src/webpack-entities.ts
+++ b/packages/webpack-plugin/src/webpack-entities.ts
@@ -17,8 +17,8 @@ import type {
     StringSortableSet,
     StylableBuildMeta,
 } from './types';
-import { stylesheet } from '@stylable/runtime/dist/runtime';
-import { injectStyles } from '@stylable/runtime/dist/inject-styles';
+import { stylesheet } from '@stylable/runtime';
+import { injectStyles } from '@stylable/runtime/dist/index-internal';
 
 import { getStylableBuildData, replaceMappedCSSAssetPlaceholders } from './plugin-utils';
 import { getReplacementToken } from './loader-utils';


### PR DESCRIPTION
This PR adds a [lint rule](https://eslint.org/docs/latest/rules/no-restricted-imports) to make sure that imports from stylable packages are only requested from the main index or the intended internal-index between packages and not directly into `src/dist` paths.

- allow import from `@stylable/*`
- allow import from `@stylable/*/dist/index-internal` (dist should be removed once we move to package exports)
- allow internal path imports from test files
