### PR TITLE
feat(webpack): experimental flag for next 13 app directory

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -144,7 +144,7 @@ export interface StylableWebpackPluginOptions {
     includeGlobalSideEffects?: boolean;
     /**
      * Experimental flag that attaches CSS bundle asset to every chunk that contains references to stylable stylesheets.
-     * The default off mode attaches the only to entry chunks.
+     * The default off mode attaches only to entry chunks.
      */
     experimentalAttachCssToContainingChunks?: boolean;
 }


### PR DESCRIPTION
This PR adds an experimental flag `experimentalAttachCssToContainingChunks` that changes the way the CSS asset is attached to webpack chunks - in the default (off mode), the result generated CSS asset is attached to entrypoint chunks, and when the flag is enabled, it attaches the CSS to every chunk that contains stylable stylesheet.  

This is primarily added to test a fix for Next 13 new experimental [app directory feature](https://beta.nextjs.org/docs/routing/fundamentals#the-app-directory) (raised in #2773). In the default mode Next resolve the attached generated CSS module mistakenly as a JavaScript file and attach it in the HTML as a script tag. 

**Notice 1:** I'm adding this experimental flag that seems to resolve the issue, although unfortunately nor NextJS or Webpack document how chunks are used in a clear way or not at all. So this will probably need more investigations and fixes in the future.    

**Notice 2:** There are no tests for this in this PR as there is no NextJS integration in the Stylable repo - we might want to add a separate repository to test such integrations without adding more dependencies.

also added Stylable.io documentation about this configuration: https://github.com/wixplosives/stylable.io/pull/64