### PR TITLE
infra(cli): clear cli test timeout that hold process

### DIFF
--- a/packages/e2e-test-kit/src/cli-test-kit.ts
+++ b/packages/e2e-test-kit/src/cli-test-kit.ts
@@ -1,6 +1,7 @@
 import { fork, spawnSync, ChildProcess } from 'child_process';
 import { on } from 'events';
 import type { Readable } from 'stream';
+import { sleep } from 'promise-assist';
 
 type ActionResponse = void | { sleep?: number };
 
@@ -63,10 +64,10 @@ export function createCliTester() {
                     });
 
                     if (step.action) {
-                        const { sleep } = (await step.action()) || {};
+                        const { sleep: sleepMs } = (await step.action()) || {};
 
-                        if (typeof sleep === 'number') {
-                            await onTimeout(sleep);
+                        if (typeof sleepMs === 'number') {
+                            await sleep(sleepMs);
                         }
                     }
 


### PR DESCRIPTION
This PR clears the timeout that holds the process open when running the CLI using the CLI test-kit. Until now the timeout would hold the process open for ~10s even when the test succeeded. In vscode on OSX this kept the debug open indefinitely.