### PR TITLE
fix(core): run collect imports deep only on stylable files

### DIFF
--- a/packages/core/src/helpers/import.ts
+++ b/packages/core/src/helpers/import.ts
@@ -604,13 +604,15 @@ export function tryCollectImportsDeep(
 
             if (!imports.has(resolved)) {
                 imports.add(resolved);
-                tryCollectImportsDeep(
-                    resolver,
-                    resolver.analyze(resolved),
-                    imports,
-                    onImport,
-                    depth + 1
-                );
+                if (resolved.endsWith('.st.css')) {
+                    tryCollectImportsDeep(
+                        resolver,
+                        resolver.analyze(resolved),
+                        imports,
+                        onImport,
+                        depth + 1
+                    );
+                }
             }
         } catch {
             /** */


### PR DESCRIPTION
Improve `tryCollectImportsDeep` by filtering only stylable stylesheets imports, preventing unnecessary (handled) throws over JS and other files.