### PR TITLE
feat: css-media

### DIFF
--- a/packages/core/src/features/css-media.ts
+++ b/packages/core/src/features/css-media.ts
@@ -1,0 +1,18 @@
+import { createFeature } from './feature';
+
+// HOOKS
+
+export const hooks = createFeature({
+    transformAtRuleNode({ atRule, context }) {
+        if (atRule.name !== 'media') {
+            return;
+        }
+        atRule.params = context.evaluator.evaluateValue(context, {
+            value: atRule.params,
+            meta: context.meta,
+            node: atRule,
+            passedThrough: context.passedThrough?.slice() || [],
+            initialNode: atRule,
+        }).outputValue;
+    },
+});

--- a/packages/core/src/features/css-media.ts
+++ b/packages/core/src/features/css-media.ts
@@ -11,7 +11,6 @@ export const hooks = createFeature({
             value: atRule.params,
             meta: context.meta,
             node: atRule,
-            passedThrough: context.passedThrough?.slice() || [],
             initialNode: atRule,
         }).outputValue;
     },

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -1,5 +1,9 @@
 import type { StylableMeta } from '../stylable-meta';
-import type { ScopeContext, StylableExports, StylableTransformer } from '../stylable-transformer';
+import type {
+    ScopeContext,
+    StylableExports,
+    StylableTransformer,
+} from '../stylable-transformer';
 import type { StylableResolver, MetaResolvedSymbols } from '../stylable-resolver';
 import type { StylableEvaluator, EvalValueData } from '../functions';
 import type * as postcss from 'postcss';
@@ -21,6 +25,7 @@ export interface FeatureTransformContext extends FeatureContext {
     resolver: StylableResolver;
     evaluator: StylableEvaluator;
     getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols;
+    passedThrough?: string[];
 }
 
 export interface NodeTypes {

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -41,3 +41,5 @@ export type { LayerSymbol } from './css-layer';
 
 export * as CSSContains from './css-contains';
 export type { ContainerSymbol } from './css-contains';
+
+export * as CSSMedia from './css-media';

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -174,11 +174,11 @@ export class StylablePublicApi {
 
     public getComputed(meta: StylableMeta) {
         const topLevelDiagnostics = new Diagnostics();
-        const evaluator = new StylableEvaluator();
         const getResolvedSymbols = createSymbolResolverWithCache(
             this.stylable.resolver,
             topLevelDiagnostics
         );
+        const evaluator = new StylableEvaluator({ getResolvedSymbols });
 
         const { var: stVars } = getResolvedSymbols(meta);
 
@@ -188,7 +188,6 @@ export class StylablePublicApi {
             const diagnostics = new Diagnostics();
             const { outputValue, topLevelType, runtimeValue } = evaluator.evaluateValue(
                 {
-                    getResolvedSymbols,
                     resolver: this.stylable.resolver,
                     evaluator,
                     meta,
@@ -394,8 +393,8 @@ function evaluateValueCall(
                 }
             }
 
-            parsedNode.resolvedValue = data.valueHook
-                ? data.valueHook(outputValue, varName, true, passedThrough)
+            parsedNode.resolvedValue = context.evaluator.valueHook
+                ? context.evaluator.valueHook(outputValue, varName, true, passedThrough)
                 : outputValue;
         } else if (possibleNonSTVarSymbol) {
             const type = resolvedSymbols.mainNamespace[varName];
@@ -403,8 +402,8 @@ function evaluateValueCall(
                 const deepResolve = resolvedSymbols.js[varName];
                 const importedType = typeof deepResolve.symbol;
                 if (importedType === 'string') {
-                    parsedNode.resolvedValue = data.valueHook
-                        ? data.valueHook(deepResolve.symbol, varName, false, passedThrough)
+                    parsedNode.resolvedValue = context.evaluator.valueHook
+                        ? context.evaluator.valueHook(deepResolve.symbol, varName, false, passedThrough)
                         : deepResolve.symbol;
                 } else if (node) {
                     // unsupported Javascript value

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -338,7 +338,8 @@ function evaluateValueCall(
     parsedNode: ParsedValue,
     data: EvalValueData
 ): void {
-    const { stVarOverride, passedThrough, value, node } = data;
+    const { stVarOverride, value, node } = data;
+    const passedThrough = context.passedThrough || [];
     const parsedArgs = strategies.args(parsedNode).map((x) => x.value);
     const varName = parsedArgs[0];
     const restArgs = parsedArgs.slice(1);
@@ -371,10 +372,9 @@ function evaluateValueCall(
         const possibleNonSTVarSymbol = STSymbol.get(context.meta, varName);
         if (resolvedVarSymbol) {
             const { outputValue, topLevelType, typeError } = context.evaluator.evaluateValue(
-                context,
+                { ...context, passedThrough: passedThrough.concat(refUniqID) },
                 {
                     ...data,
-                    passedThrough: passedThrough.concat(refUniqID),
                     value: stripQuotation(resolvedVarSymbol.text),
                     args: restArgs,
                     node: resolvedVarSymbol.node,
@@ -403,7 +403,12 @@ function evaluateValueCall(
                 const importedType = typeof deepResolve.symbol;
                 if (importedType === 'string') {
                     parsedNode.resolvedValue = context.evaluator.valueHook
-                        ? context.evaluator.valueHook(deepResolve.symbol, varName, false, passedThrough)
+                        ? context.evaluator.valueHook(
+                              deepResolve.symbol,
+                              varName,
+                              false,
+                              passedThrough
+                          )
                         : deepResolve.symbol;
                 } else if (node) {
                     // unsupported Javascript value

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -22,7 +22,6 @@ export interface EvalValueData {
     value: string;
     passedThrough: string[];
     node?: postcss.Node;
-    // valueHook?: replaceValueHook;
     meta: StylableMeta;
     stVarOverride?: Record<string, string> | null;
     cssVarsMapping?: Record<string, string>;

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -22,7 +22,7 @@ export interface EvalValueData {
     value: string;
     passedThrough: string[];
     node?: postcss.Node;
-    valueHook?: replaceValueHook;
+    // valueHook?: replaceValueHook;
     meta: StylableMeta;
     stVarOverride?: Record<string, string> | null;
     cssVarsMapping?: Record<string, string>;
@@ -40,21 +40,29 @@ export interface EvalValueResult {
 
 export class StylableEvaluator {
     public stVarOverride: Record<string, string> | null | undefined;
-    constructor(options: { stVarOverride?: Record<string, string> | null } = {}) {
+    public getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols;
+    public valueHook?: replaceValueHook;
+    constructor(options: {
+        stVarOverride?: Record<string, string> | null;
+        valueHook?: replaceValueHook;
+        getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols;
+    }) {
+        this.valueHook = options.valueHook;
         this.stVarOverride = options.stVarOverride;
+        this.getResolvedSymbols = options.getResolvedSymbols;
     }
     evaluateValue(
-        context: FeatureTransformContext,
-        data: Omit<EvalValueData, 'passedThrough'> & { passedThrough?: string[] }
+        context: Omit<FeatureTransformContext, 'getResolvedSymbols'>,
+        data: Omit<EvalValueData, 'passedThrough' | 'valueHook'> & { passedThrough?: string[] }
     ) {
         return processDeclarationValue(
             context.resolver,
-            context.getResolvedSymbols,
+            this.getResolvedSymbols,
             data.value,
             data.meta,
             data.node,
             data.stVarOverride || this.stVarOverride,
-            data.valueHook,
+            this.valueHook,
             context.diagnostics,
             data.passedThrough,
             data.cssVarsMapping,
@@ -124,7 +132,11 @@ export function processDeclarationValue(
     rootArgument?: string,
     initialNode?: postcss.Node
 ): EvalValueResult {
-    const evaluator = new StylableEvaluator({ stVarOverride: variableOverride });
+    const evaluator = new StylableEvaluator({
+        stVarOverride: variableOverride,
+        valueHook,
+        getResolvedSymbols,
+    });
     const resolvedSymbols = getResolvedSymbols(meta);
     const parsedValue: any = postcssValueParser(value);
     parsedValue.walk((parsedNode: ParsedValue) => {
@@ -143,7 +155,6 @@ export function processDeclarationValue(
                         value,
                         passedThrough,
                         node,
-                        valueHook,
                         meta,
                         stVarOverride: variableOverride,
                         cssVarsMapping,
@@ -178,8 +189,8 @@ export function processDeclarationValue(
                 const formatterArgs = getFormatterArgs(parsedNode);
                 try {
                     parsedNode.resolvedValue = formatter.symbol.apply(null, formatterArgs);
-                    if (valueHook && typeof parsedNode.resolvedValue === 'string') {
-                        parsedNode.resolvedValue = valueHook(
+                    if (evaluator.valueHook && typeof parsedNode.resolvedValue === 'string') {
+                        parsedNode.resolvedValue = evaluator.valueHook(
                             parsedNode.resolvedValue,
                             { name: parsedNode.value, args: formatterArgs },
                             true,
@@ -214,7 +225,6 @@ export function processDeclarationValue(
                         value,
                         passedThrough,
                         node,
-                        valueHook,
                         meta,
                         stVarOverride: variableOverride,
                         cssVarsMapping,

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -20,7 +20,6 @@ import { unbox, CustomValueError } from './custom-values';
 
 export interface EvalValueData {
     value: string;
-    passedThrough: string[];
     node?: postcss.Node;
     meta: StylableMeta;
     stVarOverride?: Record<string, string> | null;
@@ -52,7 +51,7 @@ export class StylableEvaluator {
     }
     evaluateValue(
         context: Omit<FeatureTransformContext, 'getResolvedSymbols'>,
-        data: Omit<EvalValueData, 'passedThrough' | 'valueHook'> & { passedThrough?: string[] }
+        data: Omit<EvalValueData, 'passedThrough' | 'valueHook'>
     ) {
         return processDeclarationValue(
             context.resolver,
@@ -63,7 +62,7 @@ export class StylableEvaluator {
             data.stVarOverride || this.stVarOverride,
             this.valueHook,
             context.diagnostics,
-            data.passedThrough,
+            context.passedThrough,
             data.cssVarsMapping,
             data.args,
             data.rootArgument,
@@ -149,10 +148,10 @@ export function processDeclarationValue(
                         resolver,
                         evaluator,
                         getResolvedSymbols,
+                        passedThrough,
                     },
                     data: {
                         value,
-                        passedThrough,
                         node,
                         meta,
                         stVarOverride: variableOverride,
@@ -219,10 +218,10 @@ export function processDeclarationValue(
                         resolver,
                         evaluator,
                         getResolvedSymbols,
+                        passedThrough,
                     },
                     data: {
                         value,
-                        passedThrough,
                         node,
                         meta,
                         stVarOverride: variableOverride,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -194,7 +194,7 @@ export class StylableTransformer {
             resolver: this.resolver,
             evaluator,
             getResolvedSymbols: this.getResolvedSymbols,
-            passedThrough: path,
+            passedThrough: path.slice(),
         };
         const transformResolveOptions = {
             context: transformContext,
@@ -285,7 +285,6 @@ export class StylableTransformer {
                         value: decl.value,
                         meta,
                         node: decl,
-                        passedThrough: path.slice(),
                         cssVarsMapping,
                     }).outputValue;
             }

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -19,6 +19,7 @@ import { getOriginDefinition } from './helpers/resolve';
 import {
     ClassSymbol,
     CSSContains,
+    CSSMedia,
     ElementSymbol,
     FeatureTransformContext,
     STNamespace,
@@ -120,7 +121,7 @@ export class StylableTransformer {
     public postProcessor: postProcessor | undefined;
     public mode: EnvMode;
     private defaultStVarOverride: Record<string, string>;
-    private evaluator: StylableEvaluator = new StylableEvaluator();
+    private evaluator: StylableEvaluator;
     private getResolvedSymbols: ReturnType<typeof createSymbolResolverWithCache>;
     private directiveNodes: postcss.Declaration[] = [];
     constructor(options: TransformerOptions) {
@@ -138,6 +139,10 @@ export class StylableTransformer {
         this.mode = options.mode || 'production';
         this.defaultStVarOverride = options.stVarOverride || {};
         this.getResolvedSymbols = createSymbolResolverWithCache(this.resolver, this.diagnostics);
+        this.evaluator = new StylableEvaluator({
+            valueHook: this.replaceValueHook,
+            getResolvedSymbols: this.getResolvedSymbols,
+        });
     }
     public transform(meta: StylableMeta): StylableResults {
         const metaExports: StylableExports = {
@@ -156,6 +161,8 @@ export class StylableTransformer {
             resolver: this.resolver,
             evaluator: this.evaluator,
             getResolvedSymbols: this.getResolvedSymbols,
+            replaceValueHook: this.replaceValueHook,
+            path: undefined,
         };
         STImport.hooks.transformInit({ context });
         STGlobal.hooks.transformInit({ context });
@@ -178,19 +185,24 @@ export class StylableTransformer {
         if (meta.type !== 'stylable') {
             return;
         }
-        const prevStVarOverride = this.evaluator.stVarOverride;
-        this.evaluator.stVarOverride = stVarOverride;
+        const { evaluator } = this;
+
+        const prevStVarOverride = evaluator.stVarOverride;
+        evaluator.stVarOverride = stVarOverride;
+
         const transformContext = {
             meta,
             diagnostics: this.diagnostics,
             resolver: this.resolver,
-            evaluator: this.evaluator,
+            evaluator,
             getResolvedSymbols: this.getResolvedSymbols,
+            passedThrough: path,
         };
         const transformResolveOptions = {
             context: transformContext,
         };
         prepareAST(transformContext, ast);
+
         const cssClassResolve = CSSClass.hooks.transformResolve(transformResolveOptions);
         const stVarResolve = STVar.hooks.transformResolve(transformResolveOptions);
         const keyframesResolve = CSSKeyframes.hooks.transformResolve(transformResolveOptions);
@@ -198,24 +210,14 @@ export class StylableTransformer {
         const containsResolve = CSSContains.hooks.transformResolve(transformResolveOptions);
         const cssVarsMapping = CSSCustomProperty.hooks.transformResolve(transformResolveOptions);
 
-        ast.walkRules((rule) => {
-            if (isChildOfAtRule(rule, 'keyframes')) {
-                return;
-            }
-            rule.selector = this.scopeRule(meta, rule, topNestClassName);
-        });
-
-        ast.walkAtRules((atRule) => {
+        const handleAtRule = (atRule: postcss.AtRule) => {
             const { name } = atRule;
             if (name === 'media') {
-                atRule.params = this.evaluator.evaluateValue(transformContext, {
-                    value: atRule.params,
-                    meta,
-                    node: atRule,
-                    valueHook: this.replaceValueHook,
-                    passedThrough: path.slice(),
-                    initialNode: atRule,
-                }).outputValue;
+                CSSMedia.hooks.transformAtRuleNode({
+                    context: transformContext,
+                    atRule,
+                    resolved: {},
+                });
             } else if (name === 'property') {
                 CSSCustomProperty.hooks.transformAtRuleNode({
                     context: transformContext,
@@ -247,9 +249,8 @@ export class StylableTransformer {
                     resolved: containsResolve,
                 });
             }
-        });
-
-        ast.walkDecls((decl) => {
+        };
+        const handleDeclaration = (decl: postcss.Declaration) => {
             if (validateCustomPropertyName(decl.prop)) {
                 CSSCustomProperty.hooks.transformDeclaration({
                     context: transformContext,
@@ -286,10 +287,22 @@ export class StylableTransformer {
                         value: decl.value,
                         meta,
                         node: decl,
-                        valueHook: this.replaceValueHook,
                         passedThrough: path.slice(),
                         cssVarsMapping,
                     }).outputValue;
+            }
+        };
+
+        ast.walk((node) => {
+            if (node.type === 'rule') {
+                if (isChildOfAtRule(node, 'keyframes')) {
+                    return;
+                }
+                node.selector = this.scopeRule(meta, node, topNestClassName);
+            } else if (node.type === 'atrule') {
+                handleAtRule(node);
+            } else if (node.type === 'decl') {
+                handleDeclaration(node);
             }
         });
 
@@ -438,6 +451,8 @@ export class StylableTransformer {
             resolver: this.resolver,
             evaluator: this.evaluator,
             getResolvedSymbols: this.getResolvedSymbols,
+            replaceValueHook: this.replaceValueHook,
+            path: undefined,
         };
         if (node.type === 'class') {
             CSSClass.hooks.transformSelectorNode({

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -161,8 +161,6 @@ export class StylableTransformer {
             resolver: this.resolver,
             evaluator: this.evaluator,
             getResolvedSymbols: this.getResolvedSymbols,
-            replaceValueHook: this.replaceValueHook,
-            path: undefined,
         };
         STImport.hooks.transformInit({ context });
         STGlobal.hooks.transformInit({ context });

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -451,8 +451,6 @@ export class StylableTransformer {
             resolver: this.resolver,
             evaluator: this.evaluator,
             getResolvedSymbols: this.getResolvedSymbols,
-            replaceValueHook: this.replaceValueHook,
-            path: undefined,
         };
         if (node.type === 'class') {
             CSSClass.hooks.transformSelectorNode({


### PR DESCRIPTION
refactor: use only one walk in transform
refactor: move valueHook to evaluator