### PR TITLE
feat(lsp): st-import specifier completions

### DIFF
--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -275,7 +275,8 @@ function addDirRelativeCompletions({
                     detail,
                     'a',
                     snippet,
-                    range(context.getPosition(), { deltaStart })
+                    range(context.getPosition(), { deltaStart }),
+                    !!directorySlash // trigger completion
                 )
             );
         }
@@ -342,7 +343,8 @@ function addPackageExportsCompletions({
                         detail,
                         'a',
                         snippet,
-                        range(context.getPosition(), { deltaStart: -deltaStart })
+                        range(context.getPosition(), { deltaStart: -deltaStart }),
+                        true // trigger completion
                     )
                 );
             } else {

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -185,6 +185,10 @@ function addPathRelativeCompletions({
     originFilePath?: string;
     specifierPath: string;
 }) {
+    if (specifierPath.match(/(^\.+$)|(\/\.+$)/)) {
+        // filter out specifier that only contains dots or ends with slash and dots
+        return;
+    }
     const isSpecifierEmpty = !specifierPath;
     const targetPath = isSpecifierEmpty
         ? contextDirPath

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -291,7 +291,7 @@ function addPackageExportsCompletions({
                 (toWildCardIndex !== -1 && to.lastIndexOf('*') !== toWildCardIndex)
             ) {
                 // mapping not valid: bailout
-                continue; // ToDo: test
+                continue;
             }
             if (deltaStart < fromWildCardIndex) {
                 // from path completion

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -1,0 +1,270 @@
+import type * as postcss from 'postcss';
+import { Completion, range, Snippet } from '../../lib/completion-types';
+import type { LangServiceContext } from '../lang-service-context';
+import path from 'path';
+export function getCompletions(context: LangServiceContext): Completion[] {
+    const completions: Completion[] = [];
+    const { node } = context.location.base;
+    if (node.type === 'atrule' && node.name === 'st-import') {
+        completions.push(...getStImportCompletions(context, node));
+    }
+    return completions;
+}
+function getStImportCompletions(context: LangServiceContext, _importNode: postcss.AtRule) {
+    const completions: Completion[] = [];
+    if (context.location.atRuleParams) {
+        const { node, offsetInNode } = context.location.atRuleParams;
+        if (!Array.isArray(node) && node.type === '<string>') {
+            // ToDo: check context better - should come after "from" ?
+            const pathBeforeCaret = node.value.slice(1, offsetInNode);
+            const originFilePath = context.meta.source;
+            addSpecifierCompletions({
+                completions,
+                context,
+                originFilePath,
+                pathBeforeCaret,
+            });
+        }
+    }
+    return completions;
+}
+function addSpecifierCompletions({
+    completions,
+    context,
+    originFilePath,
+    pathBeforeCaret,
+}: {
+    completions: Completion[];
+    context: LangServiceContext;
+    originFilePath: string;
+    pathBeforeCaret: string;
+}) {
+    const originDirPath = path.dirname(originFilePath);
+    let specifier = pathBeforeCaret;
+    // attempt to get mapped specifier
+    try {
+        specifier = context.stylable.resolver.resolvePath(originDirPath, specifier);
+    } catch (e) {
+        /*continue with original specifier*/
+    }
+
+    if (specifier.startsWith('.') || context.fs.isAbsolute(specifier)) {
+        // relative completions
+        addPathRelativeCompletions({
+            completions,
+            context,
+            contextDirPath: originDirPath,
+            originFilePath,
+            specifierPath: specifier,
+        });
+    } else {
+        // package internal completions
+        const packages = getNodeModules({ context, originDirPath });
+        const [packageName, internalPath] = parsePackageSpecifier(specifier);
+        if (internalPath !== undefined) {
+            let packageJsonPath = context.fs.join(packageName, 'package.json');
+            try {
+                packageJsonPath = context.stylable.resolver.resolvePath(
+                    originDirPath,
+                    packageJsonPath
+                );
+            } catch (e) {
+                /**/
+            }
+            const packageJsonStat = context.fs.statSync(packageJsonPath, {
+                throwIfNoEntry: false,
+            });
+            if (packageJsonStat) {
+                const packageJson = context.fs.readJsonFileSync(packageJsonPath)!;
+                if (!isValidPackageJson(packageJson)) {
+                    return;
+                }
+                if ('exports' in packageJson) {
+                    // ToDo: deal with exports
+                } else {
+                    // const packagePath = context.fs.dirname(packageJsonPath);
+                    addPathRelativeCompletions({
+                        completions,
+                        context,
+                        contextDirPath: context.fs.dirname(packageJsonPath),
+                        originFilePath,
+                        specifierPath: internalPath || './',
+                    });
+                }
+            }
+        } else {
+            // package names completions
+            const allowFullCompletions = pathBeforeCaret === '';
+            for (const packageName of packages) {
+                let deltaStart = 0;
+                if (packageName.startsWith(pathBeforeCaret)) {
+                    deltaStart = -pathBeforeCaret.length;
+                } else if (!allowFullCompletions) {
+                    continue;
+                }
+                const label = packageName;
+                const detail = '';
+                const snippet = new Snippet(label);
+                completions.push(
+                    new Completion(
+                        label,
+                        detail,
+                        'a',
+                        snippet,
+                        range(context.getPosition(), { deltaStart })
+                    )
+                );
+            }
+        }
+    }
+}
+// naive check for an actual object
+function isValidPackageJson(obj: any): obj is JSON {
+    return !!obj && !Array.isArray(obj) && typeof obj === 'object';
+}
+function getNodeModules({
+    context: { fs },
+    originDirPath,
+}: {
+    context: LangServiceContext;
+    originDirPath: string;
+}) {
+    const packages = new Set<string>();
+    let dirPath = originDirPath;
+    let searching = true;
+    while (searching) {
+        // search packages
+        const nodeModulesPath = fs.join(dirPath, 'node_modules');
+        const stat = fs.statSync(nodeModulesPath, { throwIfNoEntry: false });
+        if (stat) {
+            const items = fs.readdirSync(nodeModulesPath, { withFileTypes: true });
+            for (const item of items) {
+                if (item.isDirectory()) {
+                    if (item.name[0] === '@') {
+                        const scopedItems = fs.readdirSync(fs.join(nodeModulesPath, item.name), {
+                            withFileTypes: true,
+                        });
+                        for (const scopedItem of scopedItems) {
+                            if (scopedItem.isDirectory()) {
+                                packages.add(item.name + '/' + scopedItem.name);
+                            }
+                        }
+                    } else {
+                        packages.add(item.name);
+                    }
+                }
+            }
+        }
+        if (dirPath === '/') {
+            searching = false;
+        } else {
+            // search up
+            dirPath = fs.join(dirPath, '..');
+        }
+    }
+    return packages;
+}
+function addPathRelativeCompletions({
+    completions,
+    context,
+    contextDirPath,
+    originFilePath,
+    specifierPath,
+}: {
+    completions: Completion[];
+    context: LangServiceContext;
+    contextDirPath: string;
+    originFilePath: string;
+    specifierPath: string;
+}) {
+    const targetPath = context.fs.resolve(contextDirPath, specifierPath);
+    const { dir, name } = specifierPath.endsWith('/')
+        ? { dir: targetPath, name: '' }
+        : context.fs.parse(targetPath);
+    addDirRelativeCompletions({
+        completions,
+        context,
+        targetPath: dir,
+        originFilePath,
+        startWith: name,
+    });
+    if (dir !== targetPath) {
+        addDirRelativeCompletions({
+            completions,
+            context,
+            targetPath,
+            originFilePath,
+            prefix: specifierPath.endsWith('/') ? '' : '/',
+        });
+    }
+}
+function addDirRelativeCompletions({
+    completions,
+    context,
+    targetPath,
+    originFilePath,
+    startWith = '',
+    prefix = '',
+}: {
+    completions: Completion[];
+    context: LangServiceContext;
+    targetPath: string;
+    originFilePath: string;
+    startWith?: string;
+    prefix?: string;
+}) {
+    const stat = context.fs.statSync(targetPath, { throwIfNoEntry: false });
+    if (stat?.isDirectory()) {
+        const files = context.fs.readdirSync(targetPath, { withFileTypes: true });
+        for (const item of files) {
+            const itemPath = context.fs.join(targetPath, item.name);
+            if (itemPath === originFilePath) {
+                continue;
+            }
+            let deltaStart = 0;
+            if (item.name.startsWith(startWith)) {
+                deltaStart = -(startWith.length + prefix.length);
+            } else {
+                continue;
+            }
+            const directorySlash = item.isDirectory() ? '/' : '';
+            const label = prefix + item.name + directorySlash;
+            const detail = '';
+            const snippet = new Snippet(label);
+            completions.push(
+                new Completion(
+                    label,
+                    detail,
+                    'a',
+                    snippet,
+                    range(context.getPosition(), { deltaStart })
+                )
+            );
+        }
+    }
+}
+/**
+ * @example parsePackageSpecifier('react-dom') === ['react-dom']
+ * @example parsePackageSpecifier('react-dom/client') === ['react-dom', 'client']
+ * @example parsePackageSpecifier('@stylable/core') === ['@stylable/core']
+ * @example parsePackageSpecifier('@stylable/core/dist/some-file') === ['@stylable/core', 'dist/some-file']
+ */
+export function parsePackageSpecifier(
+    specifier: string
+): readonly [packageName: string, pathInPackage?: string] {
+    const firstSlashIdx = specifier.indexOf('/');
+    if (firstSlashIdx === -1) {
+        return [specifier];
+    }
+    const isScopedPackage = specifier.startsWith('@');
+    if (isScopedPackage) {
+        const secondSlashIdx = specifier.indexOf('/', firstSlashIdx + 1);
+        return secondSlashIdx === -1 ? [specifier] : splitAtIdx(specifier, secondSlashIdx);
+    } else {
+        return splitAtIdx(specifier, firstSlashIdx);
+    }
+}
+/** @example splitAtIdx('abcde', 2) === ['ab', 'de'] */
+function splitAtIdx(value: string, idx: number) {
+    return [value.slice(0, idx), value.slice(idx + 1)] as const;
+}

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -279,6 +279,10 @@ function addPackageExportsCompletions({
         }
         const fromWildCardIndex = internalFrom.indexOf('*');
         if (fromWildCardIndex !== -1) {
+            if (typeof to !== 'string') {
+                // ignore null and unsupported values
+                continue;
+            }
             // wildcard mapping
             const toWildCardIndex = to.indexOf('*');
             // validate
@@ -318,7 +322,7 @@ function addPackageExportsCompletions({
                     specifierPath: wildCardInput,
                 });
             }
-        } else {
+        } else if (to !== null) {
             // explicit single mapping
             const label = internalFrom;
             const detail = '';

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -273,13 +273,18 @@ function addPackageExportsCompletions({
             continue;
         }
         const internalFrom = from.slice(2);
+        const fromWildCardIndex = internalFrom.indexOf('*');
         let deltaStart = 0;
-        if (internalFrom.startsWith(internalPath)) {
+        const isCurrentPathIncludedInFrom =
+            fromWildCardIndex !== -1 && internalPath.length > internalFrom.length - 1
+                ? internalPath.startsWith(internalFrom.slice(0, internalFrom.length - 2))
+                : internalFrom.startsWith(internalPath);
+        if (isCurrentPathIncludedInFrom) {
             deltaStart = internalPath.length;
         } else {
             continue;
         }
-        const fromWildCardIndex = internalFrom.indexOf('*');
+
         if (fromWildCardIndex !== -1) {
             const resultTo = getExportsRules(to);
             if (typeof resultTo !== 'string') {
@@ -312,7 +317,7 @@ function addPackageExportsCompletions({
                 );
             } else {
                 // internal path completions
-                const wildCardInput = internalPath.slice(deltaStart);
+                const wildCardInput = internalPath.slice(fromWildCardIndex, deltaStart);
                 const toBasePath = resultTo.slice(0, toWildCardIndex);
                 // const fromAfterWildCard = internalFrom.slice(fromWildCardIndex);
                 // const toAfterWildCard = to.slice(toWildCardIndex+1);

--- a/packages/language-service/src/lib-new/lang-service-context.ts
+++ b/packages/language-service/src/lib-new/lang-service-context.ts
@@ -17,6 +17,7 @@ import {
     stringifySelectorAst,
     walk as walkSelector,
 } from '@tokey/css-selector-parser';
+import type { IFileSystem } from '@file-services/types';
 import * as postcss from 'postcss';
 
 type ResolveChainItem = {
@@ -32,7 +33,12 @@ export class LangServiceContext {
     public ambiguousNodes: Map<any, ParseReport[]>;
     public location: ReturnType<typeof getAstNodeAt>;
     public document: TextDocument;
-    constructor(public stylable: Stylable, private fileData: StylableFile, private offset: number) {
+    constructor(
+        public fs: IFileSystem,
+        public stylable: Stylable,
+        private fileData: StylableFile,
+        private offset: number
+    ) {
         const parseResult = parseForEditing(fileData.content, {
             from: fileData.path,
         });

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -52,6 +52,7 @@ import { getAtRuleByPosition, isComment, isDeclaration } from './utils/postcss-a
 import type { CursorPosition } from './utils/selector-analyzer';
 import type { LangServiceContext } from '../lib-new/lang-service-context';
 import * as cssPseudoClass from '../lib-new/features/ls-css-pseudo-class';
+import * as stImport from '../lib-new/features/ls-st-import';
 
 export interface ProviderOptions {
     context: LangServiceContext;
@@ -846,6 +847,12 @@ function maybeResolveImport(
     }
     return resolvedImport;
 }
+
+export const newStImportCompletionProvider: CompletionProvider = {
+    provide({ context }) {
+        return stImport.getCompletions(context);
+    },
+};
 
 export const StImportNamedCompletionProvider: CompletionProvider & {
     resolveImport: (

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -50,6 +50,7 @@ import {
     ValueCompletionProvider,
     ValueDirectiveProvider,
     StImportNamedCompletionProvider,
+    newStImportCompletionProvider,
 } from './completion-providers';
 import { topLevelDirectives } from './completion-types';
 import type { Completion } from './completion-types';
@@ -86,6 +87,7 @@ function findLast<T>(
 
 export class Provider {
     private providers: CompletionProvider[] = [
+        newStImportCompletionProvider,
         RulesetInternalDirectivesProvider,
         ImportInternalDirectivesProvider,
         TopLevelDirectiveProvider,

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -66,7 +66,7 @@ export class StylableLanguageService {
         const stylableFile = this.readStylableFile(filePath);
 
         if (stylableFile && stylableFile.stat.isFile()) {
-            const context = new LangServiceContext(this.stylable, stylableFile, offset);
+            const context = new LangServiceContext(this.fs, this.stylable, stylableFile, offset);
             return this.getCompletions(context);
         } else {
             return [];

--- a/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
@@ -7,9 +7,9 @@ describe('LS: css-pseudo-class', () => {
                 -st-states: aaa,bbb;
             }
 
-            .root/*^afterRoot*/ {}
+            .root^afterRoot^ {}
 
-            /*^empty*/ {}
+            ^empty^ {}
 
         `);
         const entryCarets = carets['/entry.st.css'];
@@ -32,8 +32,8 @@ describe('LS: css-pseudo-class', () => {
                 }
 
 
-                @st-scope .root/*^afterRoot*/ {}
-                @st-scope /*^empty*/ {}
+                @st-scope .root^afterRoot^ {}
+                @st-scope ^empty^ {}
 
             `);
             const entryCarets = carets['/entry.st.css'];
@@ -56,12 +56,12 @@ describe('LS: css-pseudo-class', () => {
 
 
                 @st-scope .x {
-                    &/*^afterColon*/
+                    &^afterColon^
                 }
 
                 @st-scope .x {
                     @media (max-width<500) {
-                        &/*^afterColonInMedia*/
+                        &^afterColonInMedia^
                     }
                 }
             `);
@@ -87,12 +87,12 @@ describe('LS: css-pseudo-class', () => {
 
 
                 @st-scope .x {
-                    /*^afterColon*/
+                    ^afterColon^
                 }
 
                 @st-scope .x {
                     @media (max-width<500) {
-                        /*^afterColonInMedia*/
+                        ^afterColonInMedia^
                     }
                 }
             `);
@@ -122,12 +122,12 @@ describe('LS: css-pseudo-class', () => {
 
 
                 @st-scope .x {
-                    :/*^afterColon*/
+                    :^afterColon^
                 }
 
                 @st-scope .x {
                     @media (max-width<500) {
-                        :/*^afterColonInMedia*/
+                        :^afterColonInMedia^
                     }
                 }
             `);

--- a/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
@@ -115,7 +115,7 @@ describe('LS: css-pseudo-class', () => {
             // in the same compound selector as the nesting selector and it's a bit weird to
             // keep the context after the nesting descendant combinator, but that's the way the transformer
             // work currently - ToDo: think about changing this behavior.
-            const { service, carets, assertCompletions } = testLangService(`
+            const { service, carets, assertCompletions, textEditContext } = testLangService(`
                 .x {
                     -st-states: aaa,bbb;
                 }
@@ -132,17 +132,40 @@ describe('LS: css-pseudo-class', () => {
                 }
             `);
             const entryCarets = carets['/entry.st.css'];
+            const { replaceText } = textEditContext('/entry.st.css');
 
             assertCompletions({
                 message: 'after colon',
                 actualList: service.onCompletion('/entry.st.css', entryCarets.afterColon),
-                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+                expectedList: [
+                    {
+                        label: ':aaa',
+                        textEdit: replaceText(entryCarets.afterColon, ':aaa', { deltaStart: -1 }),
+                    },
+                    {
+                        label: ':bbb',
+                        textEdit: replaceText(entryCarets.afterColon, ':bbb', { deltaStart: -1 }),
+                    },
+                ],
             });
 
             assertCompletions({
                 message: 'after colon in media',
                 actualList: service.onCompletion('/entry.st.css', entryCarets.afterColonInMedia),
-                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+                expectedList: [
+                    {
+                        label: ':aaa',
+                        textEdit: replaceText(entryCarets.afterColonInMedia, ':aaa', {
+                            deltaStart: -1,
+                        }),
+                    },
+                    {
+                        label: ':bbb',
+                        textEdit: replaceText(entryCarets.afterColonInMedia, ':bbb', {
+                            deltaStart: -1,
+                        }),
+                    },
+                ],
             });
         });
     });

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -261,7 +261,32 @@ describe('LS: st-import', () => {
                     unexpectedList: [{ label: 'red.js' }],
                 });
             });
-            // ToDo: map to exports field
+            it('should suggest package exports', () => {
+                const { service, carets, assertCompletions } = testLangService({
+                    node_modules: {
+                        x: {
+                            'private.js': '',
+                            'package.json': `{
+                                "exports": {
+                                    "./inner-a": "./src/inner-a.js",
+                                    "./inner-b": "./src/inner-b.js"
+                                }
+                            }`,
+                        },
+                    },
+                    'entry.st.css': `
+                        @st-import from 'x//*^*/';
+                    `,
+                });
+                const entryCarets = carets['/entry.st.css'];
+
+                assertCompletions({
+                    message: 'scoped root',
+                    actualList: service.onCompletion('/entry.st.css', entryCarets[0]),
+                    expectedList: [{ label: 'inner-a' }, { label: 'inner-b' }],
+                    unexpectedList: [{ label: 'private.js' }, { label: 'package.json' }],
+                });
+            });
         });
         describe('custom resolve', () => {
             it('should suggest from custom mapped', () => {

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -218,13 +218,17 @@ describe('LS: st-import', () => {
                                 package: {
                                     dist: { 'file.js': `` },
                                     src: { 'file.ts': `` },
-                                    'package.json': `{}`,
+                                    'package.json': `{
+                                        "main": "./dist/file.js"
+                                    }`,
                                 },
                             },
                             'flat-package': {
                                 esm: { 'file.js': `` },
                                 lib: { 'file.ts': `` },
-                                'package.json': `{}`,
+                                'package.json': `{
+                                    "main": "./esm/file.js"
+                                }`,
                             },
                         },
                         'entry.st.css': `
@@ -493,7 +497,7 @@ describe('LS: st-import', () => {
                     {
                         node_modules: {
                             x: {
-                                'red.js': `{}`,
+                                'yellow.js': `{}`,
                                 'package.json': `{}`,
                             },
                         },
@@ -530,11 +534,17 @@ describe('LS: st-import', () => {
                 const defaultResolveModule = createDefaultResolver(fs, {});
                 const entryPath = fs.join(tempDir.path, 'src', 'entry.st.css');
                 const entryCarets = carets[entryPath];
-
+                /**
+                 * mapping like this cannot override the original resolved package
+                 * and combine suggestions from both locations.
+                 */
                 assertCompletions({
                     actualList: service.onCompletion(entryPath, entryCarets[0]),
-                    expectedList: [{ label: 'green.js' }, { label: 'package.json' }],
-                    unexpectedList: [{ label: 'red.js' }],
+                    expectedList: [
+                        { label: 'green.js' },
+                        { label: 'yellow.js' },
+                        { label: 'package.json' },
+                    ],
                 });
             });
         });

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -1,5 +1,8 @@
 import { createDefaultResolver } from '@stylable/core';
 import { testLangService, createTempDirectorySync } from '../../test-kit/test-lang-service';
+import { Command } from 'vscode-languageserver';
+
+const triggerCompletion = Command.create('additional', 'editor.action.triggerSuggest');
 
 describe('LS: st-import', () => {
     let tempDir: ReturnType<typeof createTempDirectorySync>;
@@ -40,9 +43,10 @@ describe('LS: st-import', () => {
                 message: 'same dir',
                 actualList: service.onCompletion(entryPath, entryCarets.sameDir),
                 expectedList: [
-                    { label: 'c.st.css' },
+                    { label: 'c.st.css', command: undefined },
                     {
                         label: 'inner/',
+                        command: triggerCompletion,
                     },
                 ],
                 unexpectedList: [{ label: 'entry.st.css' }],
@@ -329,6 +333,9 @@ describe('LS: st-import', () => {
                                     anyof: {
                                         'c-file.js': '',
                                         'd-file.js': '',
+                                        inner: {
+                                            'e-file.js': '',
+                                        },
                                         internal: {
                                             'x-file.js': '',
                                         },
@@ -368,7 +375,9 @@ describe('LS: st-import', () => {
                         { label: 'wild/internal' },
                         { label: 'internal' },
                         { label: 'package.json' },
-                        { label: 'invalid-1/' },
+                        {
+                            label: 'invalid-1/',
+                        },
                         { label: 'invalid-2/' },
                     ],
                 });
@@ -376,7 +385,11 @@ describe('LS: st-import', () => {
                 assertCompletions({
                     message: 'wild card at end',
                     actualList: service.onCompletion(entryPath, entryCarets.wildCardAtEnd),
-                    expectedList: [{ label: 'c-file.js' }, { label: 'd-file.js' }],
+                    expectedList: [
+                        { label: 'c-file.js', command: undefined },
+                        { label: 'd-file.js', command: undefined },
+                        { label: 'inner/', command: triggerCompletion },
+                    ],
                     unexpectedList: [
                         // { label: 'internal' }, // ToDo: handle exclude patterns
                         { label: 'inner-a' },
@@ -392,6 +405,7 @@ describe('LS: st-import', () => {
                     expectedList: [{ label: 'c-file.js' }],
                     unexpectedList: [
                         { label: 'd-file.js' },
+                        { label: 'inner/' },
                         // { label: 'internal' }, // ToDo: handle exclude patterns
                         { label: 'inner-a' },
                         { label: 'inner-b' },

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -1,0 +1,310 @@
+import { createDefaultResolver } from '@stylable/core';
+import { testLangService } from '../../test-kit/test-lang-service';
+
+describe('LS: st-import', () => {
+    describe('specifier completion', () => {
+        it('should suggest relative paths', () => {
+            const { service, carets, assertCompletions } = testLangService({
+                'a.st.css': ``,
+                'b.js': ``,
+                src: {
+                    'c.st.css': ``,
+                    inner: {
+                        'd.st.css': ``,
+                    },
+                    'entry.st.css': `
+                        @st-import from './/*^sameDir*/';
+                        @st-import from '..//*^upDir*/';
+                        @st-import from './inner//*^nestedDir*/';
+                    `,
+                },
+            });
+            const entryCarets = carets['/src/entry.st.css'];
+
+            assertCompletions({
+                message: 'same dir',
+                actualList: service.onCompletion('/src/entry.st.css', entryCarets.sameDir),
+                expectedList: [
+                    { label: 'c.st.css' },
+                    {
+                        label: 'inner/',
+                    },
+                ],
+                unexpectedList: [{ label: 'entry.st.css' }],
+            });
+
+            assertCompletions({
+                message: 'up dir',
+                actualList: service.onCompletion('/src/entry.st.css', entryCarets.upDir),
+                expectedList: [{ label: 'a.st.css' }, { label: 'b.js' }, { label: 'src/' }],
+            });
+
+            assertCompletions({
+                message: 'nested dir',
+                actualList: service.onCompletion('/src/entry.st.css', entryCarets.nestedDir),
+                expectedList: [{ label: 'd.st.css' }],
+            });
+        });
+        it('should suggest from both relative directory and base', () => {
+            const { service, carets, assertCompletions, textEditContext } = testLangService({
+                'file.st.css': ``,
+                files: {
+                    'a.st.css': ``,
+                },
+                fil: {
+                    'b.st.css': ``,
+                },
+                'not-start-with-fil.st.css': ``,
+                'entry.st.css': `
+                    @st-import from './fil/*^*/';
+                `,
+            });
+            const entryCarets = carets['/entry.st.css'];
+            const { replaceText } = textEditContext('/entry.st.css');
+
+            assertCompletions({
+                actualList: service.onCompletion('/entry.st.css', entryCarets[0]),
+                expectedList: [
+                    {
+                        label: 'file.st.css',
+                        textEdit: replaceText(entryCarets[0], 'file.st.css', { deltaStart: -3 }),
+                    },
+                    {
+                        label: 'files/',
+                        textEdit: replaceText(entryCarets[0], 'files/', { deltaStart: -3 }),
+                    },
+                    {
+                        label: 'fil/',
+                        textEdit: replaceText(entryCarets[0], 'fil/', { deltaStart: -3 }),
+                    },
+                    { label: '/b.st.css' },
+                ],
+                unexpectedList: [{ label: 'entry.st.css' }, { label: 'not-start-with-fil.st.css' }],
+            });
+        });
+        // ToDo: support project root path
+        describe('node_modules', () => {
+            it('should suggest picked up node_modules package names', () => {
+                const { service, carets, assertCompletions, textEditContext } = testLangService({
+                    node_modules: {
+                        '@scoped-a': {
+                            pack1: {},
+                            pack2: {},
+                        },
+                        'package-a': {},
+                    },
+                    src: {
+                        node_modules: {
+                            '@scoped-a': {
+                                pack3: {},
+                            },
+                        },
+                        'entry.st.css': `
+                            @st-import from '/*^empty*/';
+                            @st-import from 'p/*^startWithP*/';
+                            @st-import from '@/*^startWithAt*/';
+                        `,
+                    },
+                });
+                const entryCarets = carets['/src/entry.st.css'];
+                const { replaceText } = textEditContext('/src/entry.st.css');
+
+                assertCompletions({
+                    message: 'empty',
+                    actualList: service.onCompletion('/src/entry.st.css', entryCarets.empty),
+                    expectedList: [
+                        { label: '@scoped-a/pack1' },
+                        { label: '@scoped-a/pack2' },
+                        { label: '@scoped-a/pack3' },
+                        { label: 'package-a' },
+                    ],
+                });
+
+                assertCompletions({
+                    message: 'start with p',
+                    actualList: service.onCompletion('/src/entry.st.css', entryCarets.startWithP),
+                    expectedList: [
+                        {
+                            label: 'package-a',
+                            textEdit: replaceText(entryCarets.startWithP, 'package-a', {
+                                deltaStart: -1,
+                            }),
+                        },
+                    ],
+                    unexpectedList: [
+                        { label: '@scoped-a/pack1' },
+                        { label: '@scoped-a/pack2' },
+                        { label: '@scoped-a/pack3' },
+                    ],
+                });
+
+                assertCompletions({
+                    message: 'start with @',
+                    actualList: service.onCompletion('/src/entry.st.css', entryCarets.startWithAt),
+                    expectedList: [
+                        {
+                            label: '@scoped-a/pack1',
+                            textEdit: replaceText(entryCarets.startWithAt, '@scoped-a/pack1', {
+                                deltaStart: -1,
+                            }),
+                        },
+                        {
+                            label: '@scoped-a/pack2',
+                            textEdit: replaceText(entryCarets.startWithAt, '@scoped-a/pack2', {
+                                deltaStart: -1,
+                            }),
+                        },
+                        {
+                            label: '@scoped-a/pack3',
+                            textEdit: replaceText(entryCarets.startWithAt, '@scoped-a/pack3', {
+                                deltaStart: -1,
+                            }),
+                        },
+                    ],
+                    unexpectedList: [{ label: 'package-a' }],
+                });
+            });
+            it('should suggest package relative content (no exports field)', () => {
+                const { service, carets, assertCompletions, textEditContext } = testLangService({
+                    node_modules: {
+                        '@scoped': {
+                            package: {
+                                dist: { 'file.js': `` },
+                                src: { 'file.ts': `` },
+                                'package.json': `{}`,
+                            },
+                        },
+                        'flat-package': {
+                            esm: { 'file.js': `` },
+                            lib: { 'file.ts': `` },
+                            'package.json': `{}`,
+                        },
+                    },
+                    'entry.st.css': `
+                        @st-import from '@scoped/package//*^scopedRoot*/';
+                        @st-import from 'flat-package//*^flatRoot*/';
+                        @st-import from '@scoped/package/dist/fi/*^scopedInternal*/';
+                        @st-import from 'flat-package/esm/fi/*^flatInternal*/';
+                    `,
+                });
+                const entryCarets = carets['/entry.st.css'];
+                const { replaceText } = textEditContext('/entry.st.css');
+
+                assertCompletions({
+                    message: 'scoped root',
+                    actualList: service.onCompletion('/entry.st.css', entryCarets.scopedRoot),
+                    expectedList: [
+                        { label: 'dist/' },
+                        { label: 'src/' },
+                        { label: 'package.json' },
+                    ],
+                });
+
+                assertCompletions({
+                    message: 'flat root',
+                    actualList: service.onCompletion('/entry.st.css', entryCarets.flatRoot),
+                    expectedList: [{ label: 'esm/' }, { label: 'lib/' }, { label: 'package.json' }],
+                });
+
+                assertCompletions({
+                    message: 'scoped internal',
+                    actualList: service.onCompletion('/entry.st.css', entryCarets.scopedInternal),
+                    expectedList: [
+                        {
+                            label: 'file.js',
+                            textEdit: replaceText(entryCarets.scopedInternal, 'file.js', {
+                                deltaStart: -2,
+                            }),
+                        },
+                    ],
+                });
+
+                assertCompletions({
+                    message: 'flat internal',
+                    actualList: service.onCompletion('/entry.st.css', entryCarets.flatInternal),
+                    expectedList: [
+                        {
+                            label: 'file.js',
+                            textEdit: replaceText(entryCarets.flatInternal, 'file.js', {
+                                deltaStart: -2,
+                            }),
+                        },
+                    ],
+                });
+            });
+            it('should suggest closer resolved package', () => {
+                const { service, carets, assertCompletions } = testLangService({
+                    node_modules: {
+                        x: {
+                            'red.js': `{}`,
+                            'package.json': `{}`,
+                        },
+                    },
+                    src: {
+                        node_modules: {
+                            x: {
+                                'green.js': `{}`,
+                                'package.json': `{}`,
+                            },
+                        },
+                        'entry.st.css': `
+                            @st-import from 'x//*^*/';
+                        `,
+                    },
+                });
+                const entryCarets = carets['/src/entry.st.css'];
+
+                assertCompletions({
+                    message: 'empty',
+                    actualList: service.onCompletion('/src/entry.st.css', entryCarets[0]),
+                    expectedList: [{ label: 'green.js' }, { label: 'package.json' }],
+                    unexpectedList: [{ label: 'red.js' }],
+                });
+            });
+            // ToDo: map to exports field
+        });
+        describe('custom resolve', () => {
+            it('should suggest from custom mapped', () => {
+                const { service, carets, assertCompletions, fs } = testLangService(
+                    {
+                        node_modules: {
+                            x: {
+                                'red.js': `{}`,
+                                'package.json': `{}`,
+                            },
+                        },
+                        src: {
+                            mapped: {
+                                x: {
+                                    'green.js': `{}`,
+                                    'package.json': `{}`,
+                                },
+                            },
+                            'entry.st.css': `
+                                @st-import from 'x//*^*/';
+                            `,
+                        },
+                    },
+                    {
+                        stylableConfig: {
+                            resolveModule: (contextPath: string, specifier: string) => {
+                                if (specifier.startsWith('x/')) {
+                                    return specifier.replace('x/', '/src/mapped/x/');
+                                }
+                                return defaultResolveModule(contextPath, specifier);
+                            },
+                        },
+                    }
+                );
+                const defaultResolveModule = createDefaultResolver(fs, {});
+                const entryCarets = carets['/src/entry.st.css'];
+
+                assertCompletions({
+                    actualList: service.onCompletion('/src/entry.st.css', entryCarets[0]),
+                    expectedList: [{ label: 'green.js' }, { label: 'package.json' }],
+                    unexpectedList: [{ label: 'red.js' }],
+                });
+            });
+        });
+    });
+});

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -21,8 +21,10 @@ describe('LS: st-import', () => {
                             'd.st.css': ``,
                         },
                         'entry.st.css': `
+                            @st-import from '.^justDot^';
                             @st-import from './^sameDir^';
                             @st-import from '../^upDir^';
+                            @st-import from '..^upDirNoSlash^';
                             @st-import from './inner/^nestedDir^';
                         `,
                     },
@@ -56,6 +58,28 @@ describe('LS: st-import', () => {
                 message: 'nested dir',
                 actualList: service.onCompletion(entryPath, entryCarets.nestedDir),
                 expectedList: [{ label: 'd.st.css' }],
+            });
+
+            assertCompletions({
+                message: 'just dot without slash',
+                actualList: service.onCompletion(entryPath, entryCarets.justDot),
+                unexpectedList: [
+                    { label: '/c.st.css' },
+                    { label: '/inner/' },
+                    { label: '/entry.st.css' },
+                ],
+            });
+
+            assertCompletions({
+                message: 'up dir without slash',
+                actualList: service.onCompletion(entryPath, entryCarets.upDirNoSlash),
+                unexpectedList: [
+                    { label: '/a.st.css' },
+                    { label: '/b.js' },
+                    { label: '/c.st.css' },
+                    { label: '/inner/' },
+                    { label: '/entry.st.css' },
+                ],
             });
         });
         it('should suggest from both relative directory and base', () => {

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -267,10 +267,10 @@ describe('LS: st-import', () => {
                             'private.js': '',
                             src: {
                                 anyof: {
-                                    'c.js': '',
-                                    'd.js': '',
+                                    'c-file.js': '',
+                                    'd-file.js': '',
                                     internal: {
-                                        'x.js': '',
+                                        'x-file.js': '',
                                     },
                                 },
                             },
@@ -313,7 +313,7 @@ describe('LS: st-import', () => {
                 assertCompletions({
                     message: 'wild card at end',
                     actualList: service.onCompletion('/entry.st.css', entryCarets.wildCardAtEnd),
-                    expectedList: [{ label: 'c.js' }, { label: 'd.js' }],
+                    expectedList: [{ label: 'c-file.js' }, { label: 'd-file.js' }],
                     unexpectedList: [
                         // { label: 'internal' }, // ToDo: handle exclude patterns
                         { label: 'inner-a' },
@@ -329,9 +329,9 @@ describe('LS: st-import', () => {
                         '/entry.st.css',
                         entryCarets.wildCardAtEndPartial
                     ),
-                    expectedList: [{ label: 'c.js' }],
+                    expectedList: [{ label: 'c-file.js' }],
                     unexpectedList: [
-                        { label: 'd.js' },
+                        { label: 'd-file.js' },
                         // { label: 'internal' }, // ToDo: handle exclude patterns
                         { label: 'inner-a' },
                         { label: 'inner-b' },
@@ -343,7 +343,7 @@ describe('LS: st-import', () => {
                 assertCompletions({
                     message: 'internal',
                     actualList: service.onCompletion('/entry.st.css', entryCarets.internal),
-                    unexpectedList: [{ label: 'x.js' }],
+                    unexpectedList: [{ label: 'x-file.js' }],
                 });
             });
             it('should handle conditional exports', () => {

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -13,9 +13,9 @@ describe('LS: st-import', () => {
                         'd.st.css': ``,
                     },
                     'entry.st.css': `
-                        @st-import from './/*^sameDir*/';
-                        @st-import from '..//*^upDir*/';
-                        @st-import from './inner//*^nestedDir*/';
+                        @st-import from './^sameDir^';
+                        @st-import from '../^upDir^';
+                        @st-import from './inner/^nestedDir^';
                     `,
                 },
             });
@@ -56,7 +56,7 @@ describe('LS: st-import', () => {
                 },
                 'not-start-with-fil.st.css': ``,
                 'entry.st.css': `
-                    @st-import from './fil/*^*/';
+                    @st-import from './fil^^';
                 `,
             });
             const entryCarets = carets['/entry.st.css'];
@@ -82,7 +82,6 @@ describe('LS: st-import', () => {
                 unexpectedList: [{ label: 'entry.st.css' }, { label: 'not-start-with-fil.st.css' }],
             });
         });
-        // ToDo: support project root path
         describe('node_modules', () => {
             it('should suggest picked up node_modules package names', () => {
                 const { service, carets, assertCompletions, textEditContext } = testLangService({
@@ -100,9 +99,9 @@ describe('LS: st-import', () => {
                             },
                         },
                         'entry.st.css': `
-                            @st-import from '/*^empty*/';
-                            @st-import from 'p/*^startWithP*/';
-                            @st-import from '@/*^startWithAt*/';
+                            @st-import from '^empty^';
+                            @st-import from 'p^startWithP^';
+                            @st-import from '@^startWithAt^';
                         `,
                     },
                 });
@@ -181,10 +180,10 @@ describe('LS: st-import', () => {
                         },
                     },
                     'entry.st.css': `
-                        @st-import from '@scoped/package//*^scopedRoot*/';
-                        @st-import from 'flat-package//*^flatRoot*/';
-                        @st-import from '@scoped/package/dist/fi/*^scopedInternal*/';
-                        @st-import from 'flat-package/esm/fi/*^flatInternal*/';
+                        @st-import from '@scoped/package/^scopedRoot^';
+                        @st-import from 'flat-package/^flatRoot^';
+                        @st-import from '@scoped/package/dist/fi^scopedInternal^';
+                        @st-import from 'flat-package/esm/fi^flatInternal^';
                     `,
                 });
                 const entryCarets = carets['/entry.st.css'];
@@ -248,7 +247,7 @@ describe('LS: st-import', () => {
                             },
                         },
                         'entry.st.css': `
-                            @st-import from 'x//*^*/';
+                            @st-import from 'x/^^';
                         `,
                     },
                 });
@@ -289,10 +288,10 @@ describe('LS: st-import', () => {
                         },
                     },
                     'entry.st.css': `
-                        @st-import from 'x//*^packageRoot*/';
-                        @st-import from 'x/wild//*^wildCardAtEnd*/';
-                        @st-import from 'x/wild/c/*^wildCardAtEndPartial*/';
-                        @st-import from 'x/wild/internal/*^internal*/';
+                        @st-import from 'x/^packageRoot^';
+                        @st-import from 'x/wild/^wildCardAtEnd^';
+                        @st-import from 'x/wild/c^wildCardAtEndPartial^';
+                        @st-import from 'x/wild/internal^internal^';
                     `,
                 });
                 const entryCarets = carets['/entry.st.css'];
@@ -396,9 +395,9 @@ describe('LS: st-import', () => {
                         },
                     },
                     'entry.st.css': `
-                        @st-import from 'topLevelConditions//*^topLevelConditions*/';
-                        @st-import from 'nestedConditions//*^nestedConditions*/';
-                        @st-import from 'nestedConditions/give-me//*^nestedSubpathConditions*/';
+                        @st-import from 'topLevelConditions/^topLevelConditions^';
+                        @st-import from 'nestedConditions/^nestedConditions^';
+                        @st-import from 'nestedConditions/give-me/^nestedSubpathConditions^';
                     `,
                 });
                 const entryCarets = carets['/entry.st.css'];
@@ -449,7 +448,7 @@ describe('LS: st-import', () => {
                                 },
                             },
                             'entry.st.css': `
-                                @st-import from 'x//*^*/';
+                                @st-import from 'x/^^';
                             `,
                         },
                     },

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -281,7 +281,9 @@ describe('LS: st-import', () => {
                                     "./inner-b": "./src/inner-b.js",
                                     "./wild/*": "./src/anyof/*",
                                     "./wild/internal/*": null,
-                                    "./internal": null
+                                    "./internal": null,
+                                    "./invalid-1/*/*": "./src/anyof/*",
+                                    "./invalid-2/*": "./src/anyof/*/*"
                                 }
                             }`,
                         },
@@ -304,6 +306,8 @@ describe('LS: st-import', () => {
                         { label: 'wild/internal' },
                         { label: 'internal' },
                         { label: 'package.json' },
+                        { label: 'invalid-1/' },
+                        { label: 'invalid-2/' },
                     ],
                 });
 

--- a/packages/language-service/test/test-kit/completions-asserters.ts
+++ b/packages/language-service/test/test-kit/completions-asserters.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs from 'fs';
+import fs from '@file-services/node';
 import { expect } from 'chai';
 import type { ProviderRange } from '@stylable/language-service/dist/lib/completion-providers';
 import { Completion, Snippet } from '@stylable/language-service/dist/lib/completion-types';
@@ -70,6 +70,7 @@ export function getCompletions(fileName: string, prefix = '') {
     const stat = fs.statSync(fullPath);
     const offset = src.indexOf('|') + prefix.length;
     const context = new LangServiceContext(
+        fs,
         stylableLSP.getStylable(),
         {
             path: fullPath,
@@ -98,6 +99,7 @@ export function getStylableAndCssCompletions(fileName: string) {
     const stat = fs.statSync(fullPath);
     const offset = src.indexOf('|');
     const context = new LangServiceContext(
+        fs,
         stylableLSP.getStylable(),
         {
             path: fullPath,

--- a/packages/language-service/test/test-kit/test-lang-service.ts
+++ b/packages/language-service/test/test-kit/test-lang-service.ts
@@ -42,7 +42,7 @@ export function testLangService(
     const allSheets = fs.findFilesSync(`/`, { filterFile: ({ path }) => path.endsWith(`.st.css`) });
     for (const path of allSheets) {
         let source = deindent(fs.readFileSync(path, { encoding: 'utf-8' }));
-        const posComments = source.match(/\/\*\^([^*]*)\*\//g);
+        const posComments = source.match(/\^([^^]*)\^/g);
         if (posComments) {
             const sheetPositions: Record<string | number, number> = {};
             let unNamedCounter = 0;
@@ -50,8 +50,8 @@ export function testLangService(
                 const offset = source.indexOf(comment);
                 source = source.slice(0, offset) + source.slice(offset + comment.length);
                 const positionName =
-                    comment.length > 5
-                        ? comment.substring(3, comment.length - 2).trim()
+                    comment.length > 2
+                        ? comment.substring(1, comment.length - 1).trim()
                         : unNamedCounter++;
                 if (sheetPositions[positionName] !== undefined) {
                     throw new Error(`debug position "${positionName}" override in ${path}`);

--- a/packages/language-service/test/test-kit/test-lang-service.ts
+++ b/packages/language-service/test/test-kit/test-lang-service.ts
@@ -3,7 +3,10 @@ import type { IDirectoryContents, IFileSystem } from '@file-services/types';
 import { Stylable, StylableConfig } from '@stylable/core';
 import { deindent } from '@stylable/core-test-kit';
 import { StylableLanguageService } from '@stylable/language-service';
-import type { CompletionItem } from 'vscode-languageserver';
+import { range } from '@stylable/language-service/dist/lib/completion-types';
+import { CompletionItem, TextEdit } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-css-languageservice';
+import { URI } from 'vscode-uri';
 import { expect } from 'chai';
 
 export interface TestOptions {
@@ -67,6 +70,24 @@ export function testLangService(
         service,
         carets,
         assertCompletions,
+        textEditContext(filePath: string) {
+            const document = TextDocument.create(
+                URI.file(filePath).toString(),
+                'stylable',
+                1,
+                fs.readFileSync(filePath, { encoding: 'utf-8' })
+            );
+            return {
+                replaceText(
+                    offset: number,
+                    text: string,
+                    replaceOffsets?: Parameters<typeof range>[1]
+                ) {
+                    const position = document.positionAt(offset);
+                    return TextEdit.replace(range(position, replaceOffsets), text);
+                },
+            };
+        },
     };
 }
 


### PR DESCRIPTION
This PR adds path completions to the `@st-import` specifier.

- [x] relative paths
- [x] custom module resolver (returns both the resolved and original specifier to allow nested paths to be suggested)
- [x] package names (including scoped packages)
- [x] relative paths into packages with no exports field
- [x] naive exports field completions 
    - complete wild card with no filtering after
    - default hard coded accepted conditional fields with simple dfs rule finding ("import", "require", "node", "browser", "default") 
    - no `null` value filtering from result suggestions