### PR TITLE
feat: support selector intersection

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -202,8 +202,7 @@ export const hooks = createFeature<{
             // which might not have a definition for the mixed-in class
             { _kind: 'css', meta: originMeta, symbol: { _kind: 'class', name: node.value } },
         ];
-        selectorContext.setCurrentAnchor({ name: node.value, type: 'class', resolved });
-        selectorContext.setNodeResolve(node, resolved);
+        selectorContext.setNextSelectorScope(resolved, node, node.value);
         const { symbol, meta } = getOriginDefinition(resolved);
         if (selectorContext.originMeta === meta && symbol[`-st-states`]) {
             // ToDo: refactor out to transformer validation phase

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -207,6 +207,7 @@ export const hooks = createFeature<{
         if (selectorContext.originMeta === meta && symbol[`-st-states`]) {
             // ToDo: refactor out to transformer validation phase
             validateRuleStateDefinition(
+                selectorContext.selectorStr,
                 selectorContext.rule,
                 context.meta,
                 resolver,

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -208,7 +208,7 @@ export const hooks = createFeature<{
             // ToDo: refactor out to transformer validation phase
             validateRuleStateDefinition(
                 selectorContext.selectorStr,
-                selectorContext.rule,
+                selectorContext.ruleOrAtRule,
                 context.meta,
                 resolver,
                 context.diagnostics

--- a/packages/core/src/features/css-pseudo-class.ts
+++ b/packages/core/src/features/css-pseudo-class.ts
@@ -44,7 +44,7 @@ export const hooks = createFeature({
         if (node.nodes && !foundCustomState) {
             if (node.value === 'global') {
                 // ignore `:st-global` since it is handled after the mixin transformation
-                if (selectorContext.experimentalSelectorResolve) {
+                if (selectorContext.experimentalSelectorInference) {
                     selectorContext.setNextSelectorScope(
                         [
                             {
@@ -73,7 +73,7 @@ export const hooks = createFeature({
                 // change selector inference
                 if (hasSubSelectors && innerSelectors.length) {
                     if (
-                        selectorContext.experimentalSelectorResolve &&
+                        selectorContext.experimentalSelectorInference &&
                         !node.value.match(/not|has/)
                     ) {
                         // set inferred to subject of nested selectors + prev compound

--- a/packages/core/src/features/css-pseudo-class.ts
+++ b/packages/core/src/features/css-pseudo-class.ts
@@ -2,8 +2,6 @@ import { createFeature } from './feature';
 import { nativePseudoClasses } from '../native-reserved-lists';
 import * as STCustomState from './st-custom-state';
 import { createDiagnosticReporter } from '../diagnostics';
-// import * as STCustomSelector from './st-custom-selector';
-// import { parseSelectorWithCache } from '../helpers/selector';
 import type { Selector } from '@tokey/css-selector-parser';
 import isVendorPrefixed from 'is-vendor-prefixed';
 
@@ -19,7 +17,7 @@ export const diagnostics = {
 
 export const hooks = createFeature({
     transformSelectorNode({ context, selectorContext }) {
-        const { inferredSelector, node, rule, scopeSelectorAst } = selectorContext;
+        const { inferredSelector, node, ruleOrAtRule, scopeSelectorAst } = selectorContext;
         if (node.type !== 'pseudo_class') {
             return;
         }
@@ -37,7 +35,7 @@ export const hooks = createFeature({
                     inferredState.meta.namespace,
                     context.resolver,
                     context.diagnostics,
-                    rule
+                    ruleOrAtRule
                 );
             }
         }
@@ -105,7 +103,7 @@ export const hooks = createFeature({
             !selectorContext.isDuplicateStScopeDiagnostic()
         ) {
             context.diagnostics.report(diagnostics.UNKNOWN_STATE_USAGE(node.value), {
-                node: rule,
+                node: ruleOrAtRule,
                 word: node.value,
             });
         }

--- a/packages/core/src/features/css-pseudo-class.ts
+++ b/packages/core/src/features/css-pseudo-class.ts
@@ -46,7 +46,18 @@ export const hooks = createFeature({
         if (node.nodes && !foundCustomState) {
             if (node.value === 'global') {
                 // ignore `:st-global` since it is handled after the mixin transformation
-                // ToDo: reset inferred selector
+                if (selectorContext.experimentalSelectorResolve) {
+                    selectorContext.setNextSelectorScope(
+                        [
+                            {
+                                _kind: 'css',
+                                meta: context.meta,
+                                symbol: { _kind: 'element', name: '*' },
+                            },
+                        ],
+                        node
+                    );
+                }
                 return;
             } else {
                 const hasSubSelectors = node.value.match(

--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -70,8 +70,7 @@ export const hooks = createFeature<{
                 ];
             }
         }
-        selectorContext.setCurrentAnchor({ name: node.value, type: 'element', resolved });
-        selectorContext.setNodeResolve(node, resolved);
+        selectorContext.setNextSelectorScope(resolved, node, node.value);
         // native node does not resolve e.g. div
         if (selectorContext.transform && resolved && resolved.length > 1) {
             const { symbol, meta } = getOriginDefinition(resolved);

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -69,6 +69,8 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
         context: FeatureTransformContext;
         atRule: postcss.AtRule;
         resolved: T['RESOLVED'];
+        // ToDo: move to FeatureTransformContext
+        transformer: StylableTransformer;
     }) => void;
     transformSelectorNode: (options: {
         context: FeatureTransformContext;

--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -74,7 +74,7 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
         context: FeatureTransformContext;
         node: T['SELECTOR'];
         selectorContext: Required<ScopeContext>;
-    }) => void;
+    }) => boolean | void;
     transformDeclaration: (options: {
         context: FeatureTransformContext;
         decl: postcss.Declaration;

--- a/packages/core/src/features/st-custom-selector.ts
+++ b/packages/core/src/features/st-custom-selector.ts
@@ -76,7 +76,7 @@ export const hooks = createFeature({
         }
     },
     prepareAST({ context, node, toRemove }) {
-        // called without experimentalSelectorResolve
+        // called without experimentalSelectorInference
         // split selectors & remove definitions
         if (node.type === 'rule' && node.selector.match(CUSTOM_SELECTOR_RE)) {
             node.selector = transformCustomSelectorInline(context.meta, node.selector, {
@@ -95,7 +95,7 @@ export const hooks = createFeature({
             const mappedSelectorAst = parseSelectorWithCache(customSelector, { clone: true });
             const mappedContext = selectorContext.createNestedContext(mappedSelectorAst);
             selectorContext.scopeSelectorAst(mappedContext);
-            const inferredSelector = selectorContext.experimentalSelectorResolve
+            const inferredSelector = selectorContext.experimentalSelectorInference
                 ? mappedContext.inferredMultipleSelectors
                 : mappedContext.inferredSelector;
             selectorContext.setNextSelectorScope(inferredSelector, node); // doesn't add to the resolved elements

--- a/packages/core/src/features/st-custom-selector.ts
+++ b/packages/core/src/features/st-custom-selector.ts
@@ -1,6 +1,5 @@
 import { plugableRecord } from '../helpers/plugable-record';
 import { createFeature } from './feature';
-import * as STCustomSelector from './st-custom-selector';
 import {
     transformCustomSelectorMap,
     transformCustomSelectors,
@@ -91,7 +90,7 @@ export const hooks = createFeature({
     transformSelectorNode({ context, selectorContext, node }) {
         const customSelector =
             node.value.startsWith('--') &&
-            STCustomSelector.getCustomSelectorExpended(context.meta, node.value.slice(2));
+            getCustomSelectorExpended(context.meta, node.value.slice(2));
         if (customSelector) {
             const mappedSelectorAst = parseSelectorWithCache(customSelector, { clone: true });
             const mappedContext = selectorContext.createNestedContext(mappedSelectorAst);

--- a/packages/core/src/features/st-custom-selector.ts
+++ b/packages/core/src/features/st-custom-selector.ts
@@ -95,12 +95,11 @@ export const hooks = createFeature({
         if (customSelector) {
             const mappedSelectorAst = parseSelectorWithCache(customSelector, { clone: true });
             const mappedContext = selectorContext.createNestedContext(mappedSelectorAst);
-            // ToDo: wrap in :is() to get intersection of selectors
             selectorContext.scopeSelectorAst(mappedContext);
-            if (!mappedContext.inferredSelector.isEmpty()) {
-                // ToDo: support multi selector with: "selectorContext.multiSelectorScope"
-                selectorContext.setNextSelectorScope(mappedContext.inferredSelector, node); // doesn't add to the resolved elements
-            }
+            const inferredSelector = selectorContext.experimentalSelectorResolve
+                ? mappedContext.inferredMultipleSelectors
+                : mappedContext.inferredSelector;
+            selectorContext.setNextSelectorScope(inferredSelector, node); // doesn't add to the resolved elements
             if (selectorContext.transform) {
                 selectorContext.transformIntoMultiSelector(node, mappedSelectorAst);
             }

--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -37,10 +37,37 @@ export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutablePseudoClass }>
         context.meta.scopes.push(atRule);
     },
     prepareAST({ node, toRemove }) {
+        // called without experimentalSelectorResolve
+        // flatten @st-scope before transformation
         if (isStScopeStatement(node)) {
             flattenScope(node);
             toRemove.push(() => node.replaceWith(node.nodes || []));
         }
+    },
+    transformAtRuleNode({ context: { meta }, atRule, transformer }) {
+        if (isStScopeStatement(atRule)) {
+            const { selector, inferredSelector } = transformer.scopeSelector(
+                meta,
+                atRule.params,
+                atRule
+            );
+            // transform selector in params
+            atRule.params = selector;
+            // track selector context for nested selector nodes
+            transformer.containerInferredSelectorMap.set(atRule, inferredSelector);
+        }
+    },
+    transformLastPass({ ast }) {
+        // called with experimentalSelectorResolve=true
+        // flatten @st-scope after transformation
+        const toRemove = [];
+        for (const node of ast.nodes) {
+            if (isStScopeStatement(node)) {
+                flattenScope(node);
+                toRemove.push(() => node.replaceWith(node.nodes || []));
+            }
+        }
+        toRemove.forEach((remove) => remove());
     },
 });
 

--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -37,7 +37,7 @@ export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutablePseudoClass }>
         context.meta.scopes.push(atRule);
     },
     prepareAST({ node, toRemove }) {
-        // called without experimentalSelectorResolve
+        // called without experimentalSelectorInference
         // flatten @st-scope before transformation
         if (isStScopeStatement(node)) {
             flattenScope(node);
@@ -58,7 +58,7 @@ export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutablePseudoClass }>
         }
     },
     transformLastPass({ ast }) {
-        // called with experimentalSelectorResolve=true
+        // called with experimentalSelectorInference=true
         // flatten @st-scope after transformation
         const toRemove = [];
         for (const node of ast.nodes) {

--- a/packages/core/src/helpers/custom-state.ts
+++ b/packages/core/src/helpers/custom-state.ts
@@ -790,7 +790,7 @@ export function validateStateArgument(
 // transform
 
 export function transformPseudoClassToCustomState(
-    states: MappedStates,
+    stateDef: MappedStates[string],
     meta: StylableMeta,
     name: string,
     node: PseudoClass,
@@ -799,8 +799,6 @@ export function transformPseudoClassToCustomState(
     diagnostics: Diagnostics,
     rule?: postcss.Rule
 ) {
-    const stateDef = states[name];
-
     if (stateDef === null) {
         convertToClass(node).value = createBooleanStateClassName(name, namespace);
         delete node.nodes;

--- a/packages/core/src/helpers/custom-state.ts
+++ b/packages/core/src/helpers/custom-state.ts
@@ -692,13 +692,14 @@ export const systemValidators: Record<string, StateParamType> = {
 };
 
 export function validateRuleStateDefinition(
-    rule: postcss.Rule,
+    selector: string,
+    rule: postcss.Rule | postcss.AtRule,
     meta: StylableMeta,
     resolver: StylableResolver,
     diagnostics: Diagnostics
 ) {
     const parentRule = rule;
-    const selectorAst = parseSelectorWithCache(parentRule.selector);
+    const selectorAst = parseSelectorWithCache(selector);
     if (selectorAst.length && selectorAst.length === 1) {
         const singleSelectorAst = selectorAst[0];
         const selectorChunk = singleSelectorAst.nodes;
@@ -757,7 +758,7 @@ export function validateStateArgument(
     value: string,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule?: postcss.Rule,
+    rule?: postcss.Node,
     validateDefinition?: boolean,
     validateValue = true
 ) {
@@ -797,7 +798,7 @@ export function transformPseudoClassToCustomState(
     namespace: string,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule?: postcss.Rule
+    rule?: postcss.Node
 ) {
     if (stateDef === null) {
         convertToClass(node).value = createBooleanStateClassName(name, namespace);
@@ -843,7 +844,7 @@ function convertTemplateState(
     meta: StylableMeta,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule: postcss.Rule | undefined,
+    rule: postcss.Node | undefined,
     node: PseudoClass,
     stateParamDef: TemplateStateParsedValue,
     name: string
@@ -875,7 +876,7 @@ function getParamInput(
     meta: StylableMeta,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule: postcss.Rule | undefined,
+    rule: postcss.Node | undefined,
     node: PseudoClass,
     stateParamDef: StateParsedValue,
     name: string
@@ -901,7 +902,7 @@ function validateParam(
     meta: StylableMeta,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule: postcss.Rule | undefined,
+    rule: postcss.Node | undefined,
     stateParamDef: StateParsedValue,
     resolvedParam: string,
     name: string
@@ -945,7 +946,7 @@ function resolveStateValue(
     meta: StylableMeta,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule: postcss.Rule | undefined,
+    rule: postcss.Node | undefined,
     node: PseudoClass,
     stateParamDef: StateParsedValue,
     name: string,
@@ -980,7 +981,7 @@ function transformMappedStateWithParam({
     template: string;
     param: string;
     node: PseudoClass;
-    rule?: postcss.Rule;
+    rule?: postcss.Node;
     diagnostics: Diagnostics;
 }) {
     const targetSelectorStr = template.replace(/\$0/g, param);
@@ -1049,7 +1050,7 @@ function resolveParam(
     meta: StylableMeta,
     resolver: StylableResolver,
     diagnostics: Diagnostics,
-    rule?: postcss.Rule,
+    rule?: postcss.Node,
     nodeContent?: string
 ) {
     const defaultStringValue = '';

--- a/packages/core/src/helpers/eql.ts
+++ b/packages/core/src/helpers/eql.ts
@@ -1,0 +1,38 @@
+export function isEqual(value1: any, value2: any): boolean {
+    if (value1 === null || value2 === null) {
+        return value1 === value2;
+    }
+
+    if (Array.isArray(value1) && Array.isArray(value2)) {
+        if (value1.length !== value2.length) {
+            return false;
+        }
+
+        for (let i = 0; i < value1.length; i++) {
+            if (!isEqual(value1[i], value2[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (typeof value1 === 'object' && typeof value2 === 'object') {
+        const keys1 = Object.keys(value1);
+        const keys2 = Object.keys(value2);
+
+        if (keys1.length !== keys2.length) {
+            return false;
+        }
+
+        for (const key of keys1) {
+            if (!isEqual(value1[key], value2[key])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    return value1 === value2;
+}

--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -12,6 +12,7 @@ import {
     Invalid,
     ImmutableSelectorList,
     ImmutableSelectorNode,
+    Combinator,
 } from '@tokey/css-selector-parser';
 import cloneDeep from 'lodash.clonedeep';
 
@@ -126,6 +127,20 @@ export function convertToPseudoClass(
         delete castedNode.nodes;
     }
     return castedNode;
+}
+
+export function createCombinatorSelector(partial: Partial<Combinator>): Combinator {
+    const type = partial.combinator || 'space';
+    return {
+        type: `combinator`,
+        combinator: type,
+        value: partial.value ?? (type === 'space' ? ` ` : type),
+        before: partial.before ?? ``,
+        after: partial.after ?? ``,
+        start: partial.start ?? 0,
+        end: partial.end ?? 0,
+        invalid: partial.invalid ?? false,
+    };
 }
 
 export function isInPseudoClassContext(parents: ReadonlyArray<ImmutableSelectorNode>) {

--- a/packages/core/src/index-internal.ts
+++ b/packages/core/src/index-internal.ts
@@ -7,6 +7,7 @@ export {
     StylableExports,
     transformerDiagnostics,
     ResolvedElement,
+    InferredSelector,
 } from './stylable-transformer';
 export { validateDefaultConfig } from './stylable';
 export {

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -102,6 +102,7 @@ export interface TransformerOptions {
     mode?: EnvMode;
     resolverCache?: StylableResolverCache;
     stVarOverride?: Record<string, string>;
+    experimentalSelectorResolve?: boolean;
 }
 
 export const transformerDiagnostics = {
@@ -124,12 +125,14 @@ export class StylableTransformer {
     private evaluator: StylableEvaluator;
     private getResolvedSymbols: ReturnType<typeof createSymbolResolverWithCache>;
     private directiveNodes: postcss.Declaration[] = [];
+    private experimentalSelectorResolve: boolean;
     constructor(options: TransformerOptions) {
         this.diagnostics = options.diagnostics;
         this.keepValues = options.keepValues || false;
         this.fileProcessor = options.fileProcessor;
         this.replaceValueHook = options.replaceValueHook;
         this.postProcessor = options.postProcessor;
+        this.experimentalSelectorResolve = options.experimentalSelectorResolve === true;
         this.resolver = new StylableResolver(
             options.fileProcessor,
             options.requireModule,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -9,6 +9,7 @@ import {
     parseSelectorWithCache,
     stringifySelector,
 } from './helpers/selector';
+import { isEqual } from './helpers/eql';
 import {
     SelectorNode,
     Selector,
@@ -714,12 +715,18 @@ export class InferredSelector {
             if (!existing) {
                 collectedStates[name] = { meta, state };
                 resolvedCount[name] = 1;
-            } else if (
-                meta === existing.meta &&
-                state === existing.state
-                /* ToDo: should this be duck-typed? */
-            ) {
-                resolvedCount[name]++;
+            } else {
+                const isStatesEql = isEqual(existing.state, state);
+                if (
+                    isStatesEql &&
+                    // states from same meta
+                    (existing.meta === meta ||
+                        // global states
+                        typeof state === 'string' ||
+                        state?.type === 'template')
+                ) {
+                    resolvedCount[name]++;
+                }
             }
         };
         // infer states from  multiple resolved selectors

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -724,6 +724,7 @@ export class InferredSelector {
         };
         // infer states from  multiple resolved selectors
         for (const resolvedContext of this.resolveSet.values()) {
+            const resolvedFoundNames = new Set<string>();
             resolved: for (const { symbol, meta } of resolvedContext) {
                 const states = symbol[`-st-states`];
                 if (!states) {
@@ -738,8 +739,11 @@ export class InferredSelector {
                 } else {
                     // get all states
                     for (const [name, state] of Object.entries(states)) {
-                        // track state
-                        addInferredState(name, meta, state);
+                        if (!resolvedFoundNames.has(name)) {
+                            // track state
+                            resolvedFoundNames.add(name);
+                            addInferredState(name, meta, state);
+                        }
                     }
                 }
             }

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -477,13 +477,29 @@ export class StylableTransformer {
             for (const node of [...selector.nodes]) {
                 if (node.type !== `compound_selector`) {
                     if (node.type === 'combinator') {
-                        context.setCurrentInferredSelectorNode(node);
+                        if (this.experimentalSelectorResolve) {
+                            context.setNextSelectorScope(context.inferredSelectorContext, node);
+                        } else {
+                            context.setCurrentInferredSelectorNode(node);
+                        }
                     }
                     continue;
                 }
                 context.compoundSelector = node;
                 // loop over each node in a compound selector
                 for (const compoundNode of node.nodes) {
+                    if (compoundNode.type === 'universal' && this.experimentalSelectorResolve) {
+                        context.setNextSelectorScope(
+                            [
+                                {
+                                    _kind: 'css',
+                                    meta: context.originMeta,
+                                    symbol: { _kind: 'element', name: '*' },
+                                },
+                            ],
+                            node
+                        );
+                    }
                     context.node = compoundNode;
                     // transform node
                     this.handleCompoundNode(context as Required<ScopeContext>);

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -36,11 +36,15 @@ export interface StylableConfig {
     cssParser?: CssParser;
     resolverCache?: StylableResolverCache;
     fileProcessorCache?: Record<string, CacheItem<StylableMeta>>;
-    experimentalSelectorResolve?: boolean;
+    experimentalSelectorInference?: boolean;
 }
 
 // This defines and validates known configs for the defaultConfig in 'stylable.config.js
-const globalDefaultSupportedConfigs = new Set(['resolveModule', 'resolveNamespace']);
+const globalDefaultSupportedConfigs = new Set([
+    'resolveModule',
+    'resolveNamespace',
+    'experimentalSelectorInference',
+]);
 export function validateDefaultConfig(defaultConfigObj: any) {
     if (typeof defaultConfigObj === 'object') {
         for (const configName of Object.keys(defaultConfigObj)) {
@@ -84,9 +88,9 @@ export class Stylable {
     protected resolverCache?: StylableResolverCache;
     // This cache is fragile and should be fresh if onProcess/resolveNamespace/cssParser is different
     protected fileProcessorCache?: Record<string, CacheItem<StylableMeta>>;
-    private experimentalSelectorResolve: boolean;
+    private experimentalSelectorInference: boolean;
     constructor(config: StylableConfig) {
-        this.experimentalSelectorResolve = !!config.experimentalSelectorResolve;
+        this.experimentalSelectorInference = !!config.experimentalSelectorInference;
         this.projectRoot = config.projectRoot;
         this.fileSystem = config.fileSystem;
         this.requireModule =
@@ -162,7 +166,7 @@ export class Stylable {
             replaceValueHook: this.hooks.replaceValueHook,
             resolverCache: this.resolverCache,
             mode: this.mode,
-            experimentalSelectorResolve: this.experimentalSelectorResolve,
+            experimentalSelectorInference: this.experimentalSelectorInference,
             ...options,
         });
     }

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -36,6 +36,7 @@ export interface StylableConfig {
     cssParser?: CssParser;
     resolverCache?: StylableResolverCache;
     fileProcessorCache?: Record<string, CacheItem<StylableMeta>>;
+    experimentalSelectorResolve?: boolean;
 }
 
 // This defines and validates known configs for the defaultConfig in 'stylable.config.js
@@ -83,7 +84,9 @@ export class Stylable {
     protected resolverCache?: StylableResolverCache;
     // This cache is fragile and should be fresh if onProcess/resolveNamespace/cssParser is different
     protected fileProcessorCache?: Record<string, CacheItem<StylableMeta>>;
+    private experimentalSelectorResolve: boolean;
     constructor(config: StylableConfig) {
+        this.experimentalSelectorResolve = !!config.experimentalSelectorResolve;
         this.projectRoot = config.projectRoot;
         this.fileSystem = config.fileSystem;
         this.requireModule =
@@ -159,6 +162,7 @@ export class Stylable {
             replaceValueHook: this.hooks.replaceValueHook,
             resolverCache: this.resolverCache,
             mode: this.mode,
+            experimentalSelectorResolve: this.experimentalSelectorResolve,
             ...options,
         });
     }

--- a/packages/core/test/features/css-pseudo-class.spec.ts
+++ b/packages/core/test/features/css-pseudo-class.spec.ts
@@ -582,6 +582,101 @@ describe('features/css-pseudo-class', () => {
             shouldReportNoDiagnostics(meta);
         });
     });
+    describe('native selector nesting classes', () => {
+        describe('experimentalSelectorInference', () => {
+            it('should infer native selector nesting classes', () => {
+                const { sheets } = testStylableCore(
+                    {
+                        'entry.st.css': `
+                            .x {/*no states*/}
+                            .a { -st-states: shared }
+                            .b { -st-states: shared }
+                            .c { -st-states: shared }
+
+                            /* @rule(compound+nested) .entry__a:is(.entry__b).entry--shared */
+                            .a:is(.b):shared {}
+
+                            /* @rule(compound+nested) .entry__a:is(.entry__b, .entry__c).entry--shared */
+                            .a:is(.b, .c):shared {}
+
+                            /* @compound+nested+comment- tested outside because of comment*/
+                            .a/**/:is(.b, .c):shared {}
+
+                            /* @rule(just nested) .entry__x :is(.entry__a, .entry__b).entry--shared */
+                            .x :is(.a, .b):shared {}
+
+                            /* @rule(where) :where(.entry__a,.entry__b).entry--shared */
+                            :where(.a,.b):shared {}
+
+                            /* @rule(nth) :nth-child(2n + 1 of .entry__a,.entry__b).entry--shared */
+                            :nth-child(2n + 1 of .a,.b):shared {}
+
+                            /* @rule(has - no infer) .entry__a:has(.entry__x).entry--shared */
+                            .a:has(.x):shared {}
+
+                            /* @rule(not - no infer) .entry__a:not(.entry__x).entry--shared */
+                            .a:not(.x):shared {}
+
+                            /* @rule(not - no infer 2) .entry__a:not(.entry__b).entry--shared */
+                            .a:not(.b):shared {}
+                    `,
+                    },
+                    {
+                        stylableConfig: {
+                            experimentalSelectorInference: true,
+                        },
+                    }
+                );
+
+                const { meta } = sheets['/entry.st.css'];
+
+                const ruleWithComment = meta.targetAst?.nodes[9] as postcss.Rule;
+                expect(ruleWithComment.selector, 'compound+nested+comment').to.eql(
+                    '.entry__a/**/:is(.entry__b, .entry__c).entry--shared'
+                );
+
+                shouldReportNoDiagnostics(meta);
+            });
+            it('should filter out states after native selector nesting classes', () => {
+                const { sheets } = testStylableCore(
+                    {
+                        'entry.st.css': `
+                            .x {}
+                            .a { -st-states: shared }
+                            .b { -st-states: shared }
+
+                            /* 
+                                @transform-error(compound missing) word(shared) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE(
+                                    'shared'
+                                )} 
+                                @rule(compound missing) .entry__x:is(.entry__a, .entry__b):shared 
+                            */
+                            .x:is(.a, .b):shared {}
+
+                            /* 
+                                @transform-error(compound+nested+comment) word(shared) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE(
+                                    'shared'
+                                )} 
+                            */
+                            .x/**/:is(.a, .b):shared {}
+                    `,
+                    },
+                    {
+                        stylableConfig: {
+                            experimentalSelectorInference: true,
+                        },
+                    }
+                );
+
+                const { meta } = sheets['/entry.st.css'];
+
+                const ruleWithComment = meta.targetAst?.nodes[6] as postcss.Rule;
+                expect(ruleWithComment.selector, 'compound+nested+comment').to.eql(
+                    '.entry__x/**/:is(.entry__a, .entry__b):shared'
+                );
+            });
+        });
+    });
     describe(`st-var`, () => {
         /* ToDo: consider dropping support for this */
         it('should support value() concatenate value into default', () => {
@@ -747,97 +842,6 @@ describe('features/css-pseudo-class', () => {
                             experimentalSelectorInference: true,
                         },
                     }
-                );
-            });
-            it('should infer native selector nesting classes', () => {
-                const { sheets } = testStylableCore(
-                    {
-                        'entry.st.css': `
-                            .x {/*no states*/}
-                            .a { -st-states: shared }
-                            .b { -st-states: shared }
-                            .c { -st-states: shared }
-
-                            /* @rule(compound+nested) .entry__a:is(.entry__b).entry--shared */
-                            .a:is(.b):shared {}
-
-                            /* @rule(compound+nested) .entry__a:is(.entry__b, .entry__c).entry--shared */
-                            .a:is(.b, .c):shared {}
-
-                            /* @compound+nested+comment- tested outside because of comment*/
-                            .a/**/:is(.b, .c):shared {}
-
-                            /* @rule(just nested) .entry__x :is(.entry__a, .entry__b).entry--shared */
-                            .x :is(.a, .b):shared {}
-
-                            /* @rule(where) :where(.entry__a,.entry__b).entry--shared */
-                            :where(.a,.b):shared {}
-
-                            /* @rule(nth) :nth-child(2n + 1 of .entry__a,.entry__b).entry--shared */
-                            :nth-child(2n + 1 of .a,.b):shared {}
-
-                            /* @rule(has - no infer) .entry__a:has(.entry__x).entry--shared */
-                            .a:has(.x):shared {}
-
-                            /* @rule(not - no infer) .entry__a:not(.entry__x).entry--shared */
-                            .a:not(.x):shared {}
-
-                            /* @rule(not - no infer 2) .entry__a:not(.entry__b).entry--shared */
-                            .a:not(.b):shared {}
-                    `,
-                    },
-                    {
-                        stylableConfig: {
-                            experimentalSelectorInference: true,
-                        },
-                    }
-                );
-
-                const { meta } = sheets['/entry.st.css'];
-
-                const ruleWithComment = meta.targetAst?.nodes[9] as postcss.Rule;
-                expect(ruleWithComment.selector, 'compound+nested+comment').to.eql(
-                    '.entry__a/**/:is(.entry__b, .entry__c).entry--shared'
-                );
-
-                shouldReportNoDiagnostics(meta);
-            });
-            it('should filter out states after native selector nesting classes', () => {
-                const { sheets } = testStylableCore(
-                    {
-                        'entry.st.css': `
-                            .x {}
-                            .a { -st-states: shared }
-                            .b { -st-states: shared }
-
-                            /* 
-                                @transform-error(compound missing) word(shared) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE(
-                                    'shared'
-                                )} 
-                                @rule(compound missing) .entry__x:is(.entry__a, .entry__b):shared 
-                            */
-                            .x:is(.a, .b):shared {}
-
-                            /* 
-                                @transform-error(compound+nested+comment) word(shared) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE(
-                                    'shared'
-                                )} 
-                            */
-                            .x/**/:is(.a, .b):shared {}
-                    `,
-                    },
-                    {
-                        stylableConfig: {
-                            experimentalSelectorInference: true,
-                        },
-                    }
-                );
-
-                const { meta } = sheets['/entry.st.css'];
-
-                const ruleWithComment = meta.targetAst?.nodes[6] as postcss.Rule;
-                expect(ruleWithComment.selector, 'compound+nested+comment').to.eql(
-                    '.entry__x/**/:is(.entry__a, .entry__b):shared'
                 );
             });
         });

--- a/packages/core/test/features/css-pseudo-class.spec.ts
+++ b/packages/core/test/features/css-pseudo-class.spec.ts
@@ -655,7 +655,7 @@ describe('features/css-pseudo-class', () => {
         });
     });
     describe('st-custom-selector', () => {
-        describe('experimentalSelectorResolve', () => {
+        describe('experimentalSelectorInference', () => {
             it('should transform shared state', () => {
                 const { sheets } = testStylableCore(
                     {
@@ -689,7 +689,7 @@ describe('features/css-pseudo-class', () => {
                     },
                     {
                         stylableConfig: {
-                            experimentalSelectorResolve: true,
+                            experimentalSelectorInference: true,
                         },
                     }
                 );
@@ -744,7 +744,7 @@ describe('features/css-pseudo-class', () => {
                     },
                     {
                         stylableConfig: {
-                            experimentalSelectorResolve: true,
+                            experimentalSelectorInference: true,
                         },
                     }
                 );
@@ -788,7 +788,7 @@ describe('features/css-pseudo-class', () => {
                     },
                     {
                         stylableConfig: {
-                            experimentalSelectorResolve: true,
+                            experimentalSelectorInference: true,
                         },
                     }
                 );
@@ -828,7 +828,7 @@ describe('features/css-pseudo-class', () => {
                     },
                     {
                         stylableConfig: {
-                            experimentalSelectorResolve: true,
+                            experimentalSelectorInference: true,
                         },
                     }
                 );

--- a/packages/core/test/features/css-pseudo-class.spec.ts
+++ b/packages/core/test/features/css-pseudo-class.spec.ts
@@ -781,6 +781,9 @@ describe('features/css-pseudo-class', () => {
 
                             /* @rule(not - no infer) .entry__a:not(.entry__x).entry--shared */
                             .a:not(.x):shared {}
+
+                            /* @rule(not - no infer 2) .entry__a:not(.entry__b).entry--shared */
+                            .a:not(.b):shared {}
                     `,
                     },
                     {

--- a/packages/core/test/features/css-pseudo-element.spec.ts
+++ b/packages/core/test/features/css-pseudo-element.spec.ts
@@ -114,6 +114,7 @@ describe('features/css-pseudo-element', () => {
             shouldReportNoDiagnostics(meta);
         });
         it('should transform custom element with multiple selector inside nested pseudo-classes', () => {
+            // ToDo: with experimentalSelectorResolve=true, the nested selector will be transformed inlined
             testStylableCore(`
                 @custom-selector :--part .partA, .partB;
                 @custom-selector :--nestedPart ::part, .partC;

--- a/packages/core/test/features/css-pseudo-element.spec.ts
+++ b/packages/core/test/features/css-pseudo-element.spec.ts
@@ -14,12 +14,16 @@ describe('features/css-pseudo-element', () => {
             const { sheets } = testStylableCore({
                 'comp.st.css': `
                     @custom-selector :--root-icon .root > .icon;
+                    @custom-selector :--root-with-class .root.icon;
                 `,
                 'entry.st.css': `
                     @st-import Comp from './comp.st.css';
 
                     /* @rule .entry__root .comp__root > .comp__icon */
                     .root Comp::root-icon {}
+
+                    /* @rule .entry__root .comp__root.comp__icon */
+                    .root Comp::root-with-class {}
                 `,
             });
 
@@ -73,6 +77,7 @@ describe('features/css-pseudo-element', () => {
             const { sheets } = testStylableCore({
                 'comp.st.css': `
                     @custom-selector :--multi .a, .b;
+                    @custom-selector :--compound-root .root.a, .root.b;
                 `,
                 'entry.st.css': `
                     @st-import Comp from './comp.st.css';
@@ -82,6 +87,9 @@ describe('features/css-pseudo-element', () => {
 
                     /* @rule(nested) .entry__root .comp__root:has(.comp__a,.comp__b) */
                     .root Comp:has(::multi) {}
+
+                    /* @rule(simple) .entry__root .comp__root.comp__a,.entry__root .comp__root.comp__b */
+                    .root Comp::compound-root {}
                 `,
             });
 

--- a/packages/core/test/features/css-pseudo-element.spec.ts
+++ b/packages/core/test/features/css-pseudo-element.spec.ts
@@ -122,7 +122,7 @@ describe('features/css-pseudo-element', () => {
             shouldReportNoDiagnostics(meta);
         });
         it('should transform custom element with multiple selector inside nested pseudo-classes', () => {
-            // ToDo: with experimentalSelectorResolve=true, the nested selector will be transformed inlined
+            // ToDo: with experimentalSelectorInference=true, the nested selector will be transformed inlined
             testStylableCore(`
                 @custom-selector :--part .partA, .partB;
                 @custom-selector :--nestedPart ::part, .partC;
@@ -226,7 +226,7 @@ describe('features/css-pseudo-element', () => {
 
             shouldReportNoDiagnostics(meta);
         });
-        describe('experimentalSelectorResolve', () => {
+        describe('experimentalSelectorInference', () => {
             it('should transform multiple selector intersection', () => {
                 const { sheets } = testStylableCore(
                     {
@@ -256,7 +256,7 @@ describe('features/css-pseudo-element', () => {
                     },
                     {
                         stylableConfig: {
-                            experimentalSelectorResolve: true,
+                            experimentalSelectorInference: true,
                         },
                     }
                 );
@@ -295,7 +295,7 @@ describe('features/css-pseudo-element', () => {
                     },
                     {
                         stylableConfig: {
-                            experimentalSelectorResolve: true,
+                            experimentalSelectorInference: true,
                         },
                     }
                 );

--- a/packages/core/test/features/css-type.spec.ts
+++ b/packages/core/test/features/css-type.spec.ts
@@ -73,6 +73,24 @@ describe(`features/css-type`, () => {
 
         expect(meta.diagnostics.reports.length, `only unscoped diagnostic`).to.equal(1);
     });
+    it('should set element inferred selector to context after native element', () => {
+        testStylableCore({
+            'comp.st.css': ` .part {} `,
+            'entry.st.css': `
+                @st-import Comp from './comp.st.css';
+                .class { -st-states: state('.class-state'); }
+            
+                /* @rule(root state) .entry__class input:state */
+                .class input:state {}
+    
+                /* @rule(unknown comp pseudo-element) .comp__root input::part */
+                Comp input::part {}
+    
+                /* @rule(unknown standalone pseudo-element) .comp__root input::class */
+                Comp input::class {}
+            `,
+        });
+    });
     describe(`st-import`, () => {
         it(`should resolve imported root (default) as element type`, () => {
             const { sheets } = testStylableCore({

--- a/packages/core/test/features/st-custom-selector.spec.ts
+++ b/packages/core/test/features/st-custom-selector.spec.ts
@@ -100,4 +100,71 @@ describe('features/st-custom-selector', () => {
             'only a single unscoped diagnostic for span'
         ).to.eql(1);
     });
+    describe('experimentalSelectorResolve', () => {
+        it('should transform multiple selector intersection', () => {
+            const { sheets } = testStylableCore(
+                {
+                    'base.st.css': `
+                    .shared {}
+                    @custom-selector :--xy .x, .y;
+                `,
+                    'a.st.css': `
+                    @st-import Base from './base.st.css';
+                    .root { -st-extends: Base }
+                `,
+                    'b.st.css': `
+                    @st-import Base from './base.st.css';
+                    .root { -st-extends: Base }
+                `,
+                    'entry.st.css': `
+                        @st-import A from './a.st.css';
+                        @st-import B from './b.st.css';
+                        @custom-selector :--ab A, B;
+
+                        /* @rule(shared-multi) .a__root .base__x, .b__root .base__x,.a__root .base__y, .b__root .base__y */
+                        :--ab::xy {}
+                `,
+                },
+                {
+                    stylableConfig: {
+                        experimentalSelectorResolve: true,
+                    },
+                }
+            );
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
+        it('should filter out elements that do not exist or match', () => {
+            testStylableCore(
+                {
+                    'base.st.css': `
+                `,
+                    'a.st.css': `
+                    @st-import Base from './base.st.css';
+                    .root { -st-extends: Base }
+                    .onlyInA {}
+                `,
+                    'b.st.css': `
+                    @st-import Base from './base.st.css';
+                    .root { -st-extends: Base }
+                `,
+                    'entry.st.css': `
+                        @st-import A from './a.st.css';
+                        @st-import B from './b.st.css';
+                        @custom-selector :--ab A, B;
+            
+                        /* @rule(exist in 1) .a__root::onlyInA, .b__root::onlyInA */
+                        :--ab::onlyInA {}
+                `,
+                },
+                {
+                    stylableConfig: {
+                        experimentalSelectorResolve: true,
+                    },
+                }
+            );
+        });
+    });
 });

--- a/packages/core/test/features/st-custom-selector.spec.ts
+++ b/packages/core/test/features/st-custom-selector.spec.ts
@@ -59,7 +59,7 @@ describe('features/st-custom-selector', () => {
         shouldReportNoDiagnostics(meta);
     });
     it('should handle unknown custom selector', () => {
-        // ToDo: remove diagnostic once experimentalSelectorResolve is the default
+        // ToDo: remove diagnostic once experimentalSelectorInference is the default
         // it will fallback to pseudo-class transform and then to unknown pseudo-class
         testStylableCore(`
             /* @analyze-error(in custom) word(:--unknown) ${customSelectorDiagnostics.UNKNOWN_CUSTOM_SELECTOR(
@@ -100,7 +100,7 @@ describe('features/st-custom-selector', () => {
             'only a single unscoped diagnostic for span'
         ).to.eql(1);
     });
-    describe('experimentalSelectorResolve', () => {
+    describe('experimentalSelectorInference', () => {
         it('should transform multiple selector intersection', () => {
             const { sheets } = testStylableCore(
                 {
@@ -127,7 +127,7 @@ describe('features/st-custom-selector', () => {
                 },
                 {
                     stylableConfig: {
-                        experimentalSelectorResolve: true,
+                        experimentalSelectorInference: true,
                     },
                 }
             );
@@ -161,7 +161,7 @@ describe('features/st-custom-selector', () => {
                 },
                 {
                     stylableConfig: {
-                        experimentalSelectorResolve: true,
+                        experimentalSelectorInference: true,
                     },
                 }
             );

--- a/packages/core/test/features/st-custom-selector.spec.ts
+++ b/packages/core/test/features/st-custom-selector.spec.ts
@@ -59,6 +59,8 @@ describe('features/st-custom-selector', () => {
         shouldReportNoDiagnostics(meta);
     });
     it('should handle unknown custom selector', () => {
+        // ToDo: remove diagnostic once experimentalSelectorResolve is the default
+        // it will fallback to pseudo-class transform and then to unknown pseudo-class
         testStylableCore(`
             /* @analyze-error(in custom) word(:--unknown) ${customSelectorDiagnostics.UNKNOWN_CUSTOM_SELECTOR(
                 ':--unknown'

--- a/packages/core/test/features/st-global.spec.ts
+++ b/packages/core/test/features/st-global.spec.ts
@@ -90,7 +90,7 @@ describe(`features/st-global`, () => {
         expect(actualGlobalRules).to.eql(expectedGlobalRules['global']);
     });
     it('should continue inferred selector after :global()', () => {
-        // ToDo: remove once experimentalSelectorResolve is the default
+        // ToDo: remove once experimentalSelectorInference is the default
         testStylableCore({
             'comp.st.css': `.part {} `,
             'entry.st.css': `
@@ -107,7 +107,7 @@ describe(`features/st-global`, () => {
             `,
         });
     });
-    describe('experimentalSelectorResolve', () => {
+    describe('experimentalSelectorInference', () => {
         it('should set wildcard inferred selector to context after :global()', () => {
             testStylableCore(
                 {
@@ -129,7 +129,7 @@ describe(`features/st-global`, () => {
                         Comp:global(.g) ::class {}
                     `,
                 },
-                { stylableConfig: { experimentalSelectorResolve: true } }
+                { stylableConfig: { experimentalSelectorInference: true } }
             );
         });
     });

--- a/packages/core/test/features/st-global.spec.ts
+++ b/packages/core/test/features/st-global.spec.ts
@@ -89,4 +89,48 @@ describe(`features/st-global`, () => {
         const expectedGlobalRules = collectAst(meta.sourceAst, ['global']);
         expect(actualGlobalRules).to.eql(expectedGlobalRules['global']);
     });
+    it('should continue inferred selector after :global()', () => {
+        // ToDo: remove once experimentalSelectorResolve is the default
+        testStylableCore({
+            'comp.st.css': `.part {} `,
+            'entry.st.css': `
+                @st-import Comp from './comp.st.css';
+                .class { -st-states: state; }
+                /* @rule(state) .entry__class.g.entry--state */
+                .class:global(.g):state {}
+                
+                /* @rule(pseudo-element) .comp__root.g .comp__part */
+                Comp:global(.g)::part {}
+        
+                /* @rule(unknown pseudo-element) .comp__root.g::class */
+                Comp:global(.g)::class {}
+            `,
+        });
+    });
+    describe('experimentalSelectorResolve', () => {
+        it('should set wildcard inferred selector to context after :global()', () => {
+            testStylableCore(
+                {
+                    'comp.st.css': ` .part {} `,
+                    'entry.st.css': `
+                        @st-import Comp from './comp.st.css';
+                        .class { -st-states: state('.class-state'); }
+                    
+                        /* @rule(root state) .entry__class.g:state */
+                        .class:global(.g):state {}
+            
+                        /* @rule(unknown comp pseudo-element) .comp__root.g::part */
+                        Comp:global(.g)::part {}
+            
+                        /* @rule(unknown standalone pseudo-element) .comp__root.g::class */
+                        Comp:global(.g)::class {}
+
+                        /* @rule(standalone pseudo-element) .comp__root.g  .entry__class */
+                        Comp:global(.g) ::class {}
+                    `,
+                },
+                { stylableConfig: { experimentalSelectorResolve: true } }
+            );
+        });
+    });
 });

--- a/packages/core/test/features/st-scope.spec.ts
+++ b/packages/core/test/features/st-scope.spec.ts
@@ -53,7 +53,7 @@ describe(`features/st-scope`, () => {
             expect(STGlobal.getGlobalRules(meta)).to.eql(actualGlobalRules['global']);
         });
     });
-    describe('experimentalSelectorResolve', () => {
+    describe('experimentalSelectorInference', () => {
         it('should infer nested selector', () => {
             const { sheets } = testStylableCore(
                 `
@@ -71,7 +71,7 @@ describe(`features/st-scope`, () => {
                         ::b {}
                     }
                 `,
-                { stylableConfig: { experimentalSelectorResolve: true } }
+                { stylableConfig: { experimentalSelectorInference: true } }
             );
 
             const { meta } = sheets['/entry.st.css'];

--- a/packages/core/test/features/st-scope.spec.ts
+++ b/packages/core/test/features/st-scope.spec.ts
@@ -1,6 +1,6 @@
 import { STGlobal } from '@stylable/core/dist/features';
 import type { StylableMeta } from '@stylable/core';
-import { testStylableCore, collectAst } from '@stylable/core-test-kit';
+import { testStylableCore, collectAst, shouldReportNoDiagnostics } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
 
@@ -51,6 +51,32 @@ describe(`features/st-scope`, () => {
 
             const actualGlobalRules = collectAst(meta.sourceAst, ['global']);
             expect(STGlobal.getGlobalRules(meta)).to.eql(actualGlobalRules['global']);
+        });
+    });
+    describe('experimentalSelectorResolve', () => {
+        it('should infer nested selector', () => {
+            const { sheets } = testStylableCore(
+                `
+                    .a {
+                        -st-states: shared;
+                    }
+                    .b {
+                        -st-states: shared;
+                    }
+                    @st-scope .a, .b {
+                        /* @rule(nest) .entry__a.entry--shared, .entry__b.entry--shared */
+                        &:shared {}
+
+                        /* @rule(context) .entry__a .entry__b, .entry__b .entry__b */
+                        ::b {}
+                    }
+                `,
+                { stylableConfig: { experimentalSelectorResolve: true } }
+            );
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
         });
     });
     describe('stylable API', () => {

--- a/packages/core/test/stylable-transformer/general.spec.ts
+++ b/packages/core/test/stylable-transformer/general.spec.ts
@@ -44,7 +44,7 @@ describe('Stylable postcss transform (General)', () => {
         expect(rule2.nodes[1].toString(), 'color1').to.equal('color: blue');
     });
     it('should continue inferred selector after combinator', () => {
-        // ToDo: remove once experimentalSelectorResolve is the default
+        // ToDo: remove once experimentalSelectorInference is the default
         testStylableCore({
             'comp.st.css': `.part {} `,
             'entry.st.css': `
@@ -63,7 +63,7 @@ describe('Stylable postcss transform (General)', () => {
         });
     });
     it('should continue inferred selector after universal', () => {
-        // ToDo: remove once experimentalSelectorResolve is the default
+        // ToDo: remove once experimentalSelectorInference is the default
         testStylableCore(`
             .root { -st-states: state; }
             .part {}
@@ -76,7 +76,7 @@ describe('Stylable postcss transform (General)', () => {
         `);
     });
 
-    describe('experimentalSelectorResolve', () => {
+    describe('experimentalSelectorInference', () => {
         it('should reset inferred selector after combinator', () => {
             // ToDo: fix extra space before ".entry__class"
             testStylableCore(
@@ -96,7 +96,7 @@ describe('Stylable postcss transform (General)', () => {
                         Comp ::class {}
                     `,
                 },
-                { stylableConfig: { experimentalSelectorResolve: true } }
+                { stylableConfig: { experimentalSelectorInference: true } }
             );
         });
         it('should set inferred selector after universal (to universal)', () => {
@@ -111,7 +111,7 @@ describe('Stylable postcss transform (General)', () => {
                     /* @rule(element) *::part */
                     *::part {}
                 `,
-                { stylableConfig: { experimentalSelectorResolve: true } }
+                { stylableConfig: { experimentalSelectorInference: true } }
             );
         });
     });

--- a/packages/language-service/src/lib-new/features/ls-css-pseudo-class.ts
+++ b/packages/language-service/src/lib-new/features/ls-css-pseudo-class.ts
@@ -31,7 +31,7 @@ export function getCompletions(context: LangServiceContext): Completion[] {
         nodeAtCursor = null,
         fullSelectorAtCursor = '',
         selectorAtCursor = '',
-        lastInferredSelector,
+        inferredSelectorContext,
     } = selectorContext;
 
     if (selectorAtCursor === '::') {
@@ -40,7 +40,7 @@ export function getCompletions(context: LangServiceContext): Completion[] {
     }
 
     const current = resolvedSelectorChain[resolvedSelectorChain.length - 1] || {
-        inferred: lastInferredSelector,
+        inferred: inferredSelectorContext,
     };
     if (current?.inferred) {
         const pos = context.getPosition();

--- a/packages/language-service/src/lib-new/features/ls-css-pseudo-class.ts
+++ b/packages/language-service/src/lib-new/features/ls-css-pseudo-class.ts
@@ -1,4 +1,4 @@
-import type { CSSResolve, StylableMeta } from '@stylable/core';
+import type { StylableMeta } from '@stylable/core';
 import {
     MappedStates,
     nativePseudoClasses,
@@ -31,6 +31,7 @@ export function getCompletions(context: LangServiceContext): Completion[] {
         nodeAtCursor = null,
         fullSelectorAtCursor = '',
         selectorAtCursor = '',
+        lastInferredSelector,
     } = selectorContext;
 
     if (selectorAtCursor === '::') {
@@ -39,15 +40,14 @@ export function getCompletions(context: LangServiceContext): Completion[] {
     }
 
     const current = resolvedSelectorChain[resolvedSelectorChain.length - 1] || {
-        // default to root
-        resolved: context.stylable.resolver.resolveExtends(context.meta, 'root'),
+        inferred: lastInferredSelector,
     };
-    if (current?.resolved) {
+    if (current?.inferred) {
         const pos = context.getPosition();
-        const states = collectStates(current.resolved);
+        const states = current.inferred.getPseudoClasses();
         const isInStateParen = fullSelectorAtCursor.match(/:(.+)\((\w*)$/);
         const inStateParenDef = isInStateParen && states[isInStateParen?.[1]];
-        const enumParamDef = getEnumParamDef(inStateParenDef?.def);
+        const enumParamDef = getEnumParamDef(inStateParenDef?.state);
         if (enumParamDef) {
             // complete enum options
             const currentParam = isInStateParen![2];
@@ -66,6 +66,7 @@ export function getCompletions(context: LangServiceContext): Completion[] {
                 completions.push(
                     stateEnumCompletion(
                         option,
+                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                         normalizeDefinitionSheetLocation(context.meta, inStateParenDef!.meta),
                         range(pos, { deltaStart: -startDelta })
                     )
@@ -77,9 +78,9 @@ export function getCompletions(context: LangServiceContext): Completion[] {
                 nodeAtCursor,
                 selectorAtCursor,
                 states,
-                current.resolved
+                context.meta
             );
-            for (const [name, { def, meta }] of Object.entries(states)) {
+            for (const [name, { state, meta }] of Object.entries(states)) {
                 const isAlreadyUsed = current['pseudo_class']?.find(
                     (exist) => exist.value === name
                 );
@@ -94,8 +95,8 @@ export function getCompletions(context: LangServiceContext): Completion[] {
                 } else if (!completeFullSelector) {
                     continue;
                 }
-                const stateWithParam = !!(def && typeof def === 'object');
-                const stateType = stateWithParam ? def.type : null;
+                const stateWithParam = !!(state && typeof state === 'object');
+                const stateType = stateWithParam ? state.type : null;
                 const originFile = normalizeDefinitionSheetLocation(context.meta, meta);
                 completions.push(
                     stateCompletion(
@@ -129,7 +130,7 @@ function suggestCompleteStates(
     nodeAtCursor: ImmutableSelectorNode | null,
     selectorAtCursor: string,
     states: StatesDefs,
-    resolveElement: CSSResolve[]
+    contextMeta: StylableMeta
 ) {
     return (
         // prev is not a pseudo class
@@ -139,10 +140,7 @@ function suggestCompleteStates(
         // prev is a known custom state
         !!states[selectorAtCursor.slice(1)] ||
         // prev is a known custom selector
-        !!(
-            resolveElement[0] &&
-            STCustomSelector.getCustomSelector(resolveElement[0].meta, selectorAtCursor.slice(3))
-        )
+        !!STCustomSelector.getCustomSelector(contextMeta, selectorAtCursor.slice(3))
     );
 }
 
@@ -157,26 +155,4 @@ function normalizeDefinitionSheetLocation(originMeta: StylableMeta, defMeta: Sty
     return relPath;
 }
 
-type StatesDefs = Record<string, { def: MappedStates['string']; meta: StylableMeta }>;
-
-function collectStates(resolveChain: CSSResolve[]) {
-    return resolveChain.reduce<StatesDefs>((acc, cur) => {
-        const symbol = cur.symbol;
-        if (symbol._kind === 'class') {
-            const symbolStates = symbol[`-st-states`];
-
-            if (symbolStates) {
-                Object.keys(symbolStates).forEach((k) => {
-                    const symbolStates = symbol[`-st-states`];
-                    if (symbolStates && symbolStates[k] !== undefined) {
-                        acc[k] = {
-                            def: symbolStates[k],
-                            meta: cur.meta,
-                        };
-                    }
-                });
-            }
-        }
-        return acc;
-    }, {});
-}
+type StatesDefs = Record<string, { state: MappedStates['string']; meta: StylableMeta }>;

--- a/packages/language-service/src/lib-new/lang-service-context.ts
+++ b/packages/language-service/src/lib-new/lang-service-context.ts
@@ -196,7 +196,7 @@ export class LangServiceContext {
         const parents = collectPostcssParents(this.location.base.node);
         const results: ImmutableSelectorList[] = parents
             .map((node) => {
-                return parseSelectorWithCache(this.getSelectorString(node) || '');
+                return parseSelectorWithCache(this.getSelectorString(node) || '', { clone: true });
             })
             .filter((selectors) => selectors.length !== 0);
         if (this.location.selector) {
@@ -212,7 +212,7 @@ export class LangServiceContext {
             // caret is not on a selector: resolve selector from base node
             const selector = this.getSelectorString(this.location.base.node);
             if (selector) {
-                results.push(parseSelectorWithCache(selector));
+                results.push(parseSelectorWithCache(selector, { clone: true }));
             }
             if (this.isInPotentialEmptySelector()) {
                 // caret is on an empty selector
@@ -227,7 +227,7 @@ function collectPostcssParents(node: postcss.AnyNode) {
     const parents: Array<postcss.AnyNode | postcss.Document> = [];
     let current = node.parent;
     while (current) {
-        parents.push(current as postcss.AnyNode);
+        parents.unshift(current as postcss.AnyNode);
         current = current.parent;
     }
     return parents;

--- a/packages/language-service/src/lib-new/lang-service-context.ts
+++ b/packages/language-service/src/lib-new/lang-service-context.ts
@@ -91,14 +91,14 @@ export class LangServiceContext {
                 postcss.rule({ selector: stringifySelectorAst(selector) })
             );
             if (currentAnchor) {
-                selectorContext.currentAnchor = currentAnchor;
-                selectorContext.nestingSelectorAnchor = currentAnchor;
+                selectorContext.inferredSelector.set(currentAnchor);
+                selectorContext.inferredSelectorContext.set(currentAnchor);
             }
             selectorContext.transform = false;
             selectorContext.selectorAstResolveMap = selectorAstResolveMap;
             transformer.scopeSelectorAst(selectorContext);
-            // ToDo: handle multiple selectors intersection
-            currentAnchor = selectorContext.currentAnchor;
+            // ToDo: handle multiple selectors intersection with "multiSelectorScope"
+            currentAnchor = selectorContext.inferredSelector;
         }
         // reference interest points
         const locationSelector = this.location.selector;

--- a/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
@@ -168,5 +168,30 @@ describe('LS: css-pseudo-class', () => {
                 ],
             });
         });
+        describe('experimentalSelectorResolve', () => {
+            it('should suggest matching intersection states', () => {
+                const { service, carets, assertCompletions } = testLangService(`
+                    .a {
+                        -st-states: shared, onlyA;
+                    }
+                    .b {
+                        -st-states: shared, onlyB;
+                    }
+
+
+                    @st-scope .a, .b {
+                        :^^
+                    }
+
+                `);
+                const entryCarets = carets['/entry.st.css'];
+
+                assertCompletions({
+                    actualList: service.onCompletion('/entry.st.css', entryCarets[0]),
+                    expectedList: [{ label: ':shared' }],
+                    unexpectedList: [{ label: ':onlyA' }, { label: ':onlyB' }],
+                });
+            });
+        });
     });
 });

--- a/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
@@ -24,6 +24,54 @@ describe('LS: css-pseudo-class', () => {
             expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
         });
     });
+    it('should provide nested context', () => {
+        const { service, carets, assertCompletions } = testLangService(`
+            .root {
+                -st-states: rrr;
+            }
+            .a {
+                -st-states: aaa;
+            }
+            .b {
+                -st-states: bbb;
+            }
+
+            .root {
+                &^nestRoot^ {
+                    .a {
+                        &^nestA^ {
+                            .b {
+                                &^nestB^ {}
+                            }
+                        }
+                    }
+                }
+            }
+
+        `);
+        const entryCarets = carets['/entry.st.css'];
+
+        assertCompletions({
+            message: 'nestRoot',
+            actualList: service.onCompletion('/entry.st.css', entryCarets.nestRoot),
+            expectedList: [{ label: ':rrr' }],
+            unexpectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+        });
+
+        assertCompletions({
+            message: 'nestA',
+            actualList: service.onCompletion('/entry.st.css', entryCarets.nestA),
+            expectedList: [{ label: ':aaa' }],
+            unexpectedList: [{ label: ':rrr' }, { label: ':bbb' }],
+        });
+
+        assertCompletions({
+            message: 'nestB',
+            actualList: service.onCompletion('/entry.st.css', entryCarets.nestB),
+            expectedList: [{ label: ':bbb' }],
+            unexpectedList: [{ label: ':rrr' }, { label: ':aaa' }],
+        });
+    });
     describe('st-scope', () => {
         it('should suggest class custom states (in st-scope params)', () => {
             const { service, carets, assertCompletions } = testLangService(`

--- a/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
@@ -49,72 +49,6 @@ describe('LS: css-pseudo-class', () => {
             });
         });
         it('should suggest class custom states with nesting selector', () => {
-            const { service, carets, assertCompletions } = testLangService(`
-                .x {
-                    -st-states: aaa,bbb;
-                }
-
-
-                @st-scope .x {
-                    &^afterColon^
-                }
-
-                @st-scope .x {
-                    @media (max-width<500) {
-                        &^afterColonInMedia^
-                    }
-                }
-            `);
-            const entryCarets = carets['/entry.st.css'];
-
-            assertCompletions({
-                message: 'after colon',
-                actualList: service.onCompletion('/entry.st.css', entryCarets.afterColon),
-                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
-            });
-
-            assertCompletions({
-                message: 'after colon in media',
-                actualList: service.onCompletion('/entry.st.css', entryCarets.afterColonInMedia),
-                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
-            });
-        });
-        it('should suggest class custom states with nesting selector (empty)', () => {
-            const { service, carets, assertCompletions } = testLangService(`
-                .x {
-                    -st-states: aaa,bbb;
-                }
-
-
-                @st-scope .x {
-                    ^afterColon^
-                }
-
-                @st-scope .x {
-                    @media (max-width<500) {
-                        ^afterColonInMedia^
-                    }
-                }
-            `);
-            const entryCarets = carets['/entry.st.css'];
-
-            assertCompletions({
-                message: 'after colon',
-                actualList: service.onCompletion('/entry.st.css', entryCarets.afterColon),
-                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
-            });
-
-            assertCompletions({
-                message: 'after colon in media',
-                actualList: service.onCompletion('/entry.st.css', entryCarets.afterColonInMedia),
-                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
-            });
-        });
-        it('should suggest class custom states after colon (no nesting selector)', () => {
-            // Notice: this is a (design?) quirk in the transformer atm. The final state selector is not
-            // in the same compound selector as the nesting selector and it's a bit weird to
-            // keep the context after the nesting descendant combinator, but that's the way the transformer
-            // work currently - ToDo: think about changing this behavior.
             const { service, carets, assertCompletions, textEditContext } = testLangService(`
                 .x {
                     -st-states: aaa,bbb;
@@ -122,12 +56,14 @@ describe('LS: css-pseudo-class', () => {
 
 
                 @st-scope .x {
-                    :^afterColon^
+                    &^nest^
+                    &:^nestColon^
                 }
 
                 @st-scope .x {
                     @media (max-width<500) {
-                        :^afterColonInMedia^
+                        &^nestInMedia^
+                        &:^nestColonInMedia^
                     }
                 }
             `);
@@ -135,42 +71,131 @@ describe('LS: css-pseudo-class', () => {
             const { replaceText } = textEditContext('/entry.st.css');
 
             assertCompletions({
-                message: 'after colon',
-                actualList: service.onCompletion('/entry.st.css', entryCarets.afterColon),
+                message: 'after &',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nest),
+                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+            });
+
+            assertCompletions({
+                message: 'after & in media',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nestInMedia),
+                expectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+            });
+
+            assertCompletions({
+                message: 'after &:',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nestColon),
                 expectedList: [
                     {
                         label: ':aaa',
-                        textEdit: replaceText(entryCarets.afterColon, ':aaa', { deltaStart: -1 }),
+                        textEdit: replaceText(entryCarets.nestColon, ':aaa', { deltaStart: -1 }),
                     },
                     {
                         label: ':bbb',
-                        textEdit: replaceText(entryCarets.afterColon, ':bbb', { deltaStart: -1 }),
+                        textEdit: replaceText(entryCarets.nestColon, ':bbb', { deltaStart: -1 }),
                     },
                 ],
             });
 
             assertCompletions({
-                message: 'after colon in media',
-                actualList: service.onCompletion('/entry.st.css', entryCarets.afterColonInMedia),
+                message: 'after &: in media',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nestColonInMedia),
                 expectedList: [
                     {
                         label: ':aaa',
-                        textEdit: replaceText(entryCarets.afterColonInMedia, ':aaa', {
+                        textEdit: replaceText(entryCarets.nestColonInMedia, ':aaa', {
                             deltaStart: -1,
                         }),
                     },
                     {
                         label: ':bbb',
-                        textEdit: replaceText(entryCarets.afterColonInMedia, ':bbb', {
+                        textEdit: replaceText(entryCarets.nestColonInMedia, ':bbb', {
                             deltaStart: -1,
                         }),
                     },
                 ],
             });
         });
-        describe('experimentalSelectorResolve', () => {
-            it('should suggest matching intersection states', () => {
-                const { service, carets, assertCompletions } = testLangService(`
+        it('should suggest root custom states an empty nested selector', () => {
+            const { service, carets, assertCompletions, textEditContext } = testLangService(`
+                .root {
+                    -st-states: root-state;
+                }
+                .x {
+                    -st-states: aaa,bbb;
+                }
+
+
+                @st-scope .x {
+                    ^empty^
+                    :^colon^
+                }
+
+                @st-scope .x {
+                    @media (max-width<500) {
+                        ^emptyInMedia^
+                        :^colonInMedia^
+                    }
+                }
+            `);
+            const entryCarets = carets['/entry.st.css'];
+            const { replaceText } = textEditContext('/entry.st.css');
+
+            assertCompletions({
+                message: 'empty',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.empty),
+                expectedList: [{ label: ':root-state' }],
+                unexpectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+            });
+
+            assertCompletions({
+                message: 'empty in media',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.emptyInMedia),
+                expectedList: [{ label: ':root-state' }],
+                unexpectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+            });
+
+            assertCompletions({
+                message: 'colon',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.colon),
+                expectedList: [
+                    {
+                        label: ':root-state',
+                        textEdit: replaceText(entryCarets.colon, ':root-state', {
+                            deltaStart: -1,
+                        }),
+                    },
+                ],
+                unexpectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+            });
+
+            assertCompletions({
+                message: 'colonInMedia',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.colonInMedia),
+                expectedList: [
+                    {
+                        label: ':root-state',
+                        textEdit: replaceText(entryCarets.colonInMedia, ':root-state', {
+                            deltaStart: -1,
+                        }),
+                    },
+                ],
+                unexpectedList: [{ label: ':aaa' }, { label: ':bbb' }],
+            });
+        });
+        it('should suggest matching intersection states', () => {
+            const { service, carets, assertCompletions, textEditContext } = testLangService({
+                'comp.st.css': `
+                    .root {
+                        -st-states: comp-state;
+                    }
+                `,
+                'entry.st.css': `
+                    @st-import Comp from './comp.st.css';
+                    .root {
+                        -st-extends: Comp;
+                        -st-states: root-state;
+                    }
                     .a {
                         -st-states: shared, onlyA;
                     }
@@ -180,17 +205,47 @@ describe('LS: css-pseudo-class', () => {
 
 
                     @st-scope .a, .b {
-                        :^^
+                        ^inScope^
+                        &^nest^
+                        &:^nestColon^
                     }
 
-                `);
-                const entryCarets = carets['/entry.st.css'];
+                `,
+            });
+            const entryCarets = carets['/entry.st.css'];
+            const { replaceText } = textEditContext('/entry.st.css');
 
-                assertCompletions({
-                    actualList: service.onCompletion('/entry.st.css', entryCarets[0]),
-                    expectedList: [{ label: ':shared' }],
-                    unexpectedList: [{ label: ':onlyA' }, { label: ':onlyB' }],
-                });
+            assertCompletions({
+                actualList: service.onCompletion('/entry.st.css', entryCarets.inScope),
+                expectedList: [{ label: ':root-state' }, { label: ':comp-state' }],
+                unexpectedList: [{ label: ':shared' }, { label: ':onlyA' }, { label: ':onlyB' }],
+            });
+
+            assertCompletions({
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nest),
+                expectedList: [{ label: ':shared' }],
+                unexpectedList: [
+                    { label: ':onlyA' },
+                    { label: ':onlyB' },
+                    { label: ':root-state' },
+                ],
+            });
+
+            assertCompletions({
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nestColon),
+                expectedList: [
+                    {
+                        label: ':shared',
+                        textEdit: replaceText(entryCarets.nestColon, ':shared', {
+                            deltaStart: -1,
+                        }),
+                    },
+                ],
+                unexpectedList: [
+                    { label: ':onlyA' },
+                    { label: ':onlyB' },
+                    { label: ':root-state' },
+                ],
             });
         });
     });


### PR DESCRIPTION
This PR adds the inference for multiple selector types behinds a new experimental flag that enables support for transformation, validation and completion of cases that combine multiple selectors like: `@st-scope`, `@custom-selector`, `:is()`, `:where()`, `:nth-x(, )`, and future support of nested CSS and multiple extends. 

In addition the new flag is changing the behavior of combinators and other selector nodes so that they will reset the selector inferred type back to the inferred context. 

The flag is meant for testing in v5 and is intended to be the default behavior in the upcoming v6

## Tasks
- [x] track multi-selector context while transforming
- [x] refactor to use new context
    - pseudo-class/element transformation
    - class/element transformation
    - mixin context
    - language service completions
    - remove old tracking code
- [x] add `experimentalSelectorInference` config flag to activate new behavior (supported from `stylable.config`)

### Changes in selector type inference with flag
- [x] combine multiple selectors in `:is()/:where()/:nth-x()` with optional preceding selector type (`:has()/:not()` don't narrow the inference)
    - add `nth-child/nth-last-child` to list of pseudo-classes that support nested selectors ([with An+B of S](https://w3c.github.io/csswg-drafts/selectors/#nth-child-pseudo))
- [x] narrow inferred selector after custom-pseudo-state with multiple mapped selectors
- [x] narrow inferred selector for nested selectors within `@st-scope` with multiple selectors
- [x] narrow inferred selector after inline `@custom-selector` (":--custom") with multiple selectors
- [x] reset selector inference after combinator, global and native element
- [x] use intersection completions in LSP (only custom-pseudo-classes atm)
- ~combine `@custom-selector` multiple selectors into `:is()`~ not possible because selectors need to be able to change the selector subject, `:is()` assumes the nested selectors subject is the preceding compound selector.

## Fix
- respect custom pseudo-element mapped selector with compound root (#186)