### PR TITLE
refactor: move all global classes unwrap/collect to the end of transformation

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -4,7 +4,6 @@ import * as STSymbol from './st-symbol';
 import type { StylableSymbol } from './st-symbol';
 import type { ImportSymbol } from './st-import';
 import type { ElementSymbol } from './css-type';
-import * as STGlobal from './st-global';
 import * as STCustomState from './st-custom-state';
 import { getOriginDefinition } from '../helpers/resolve';
 import { namespace } from '../helpers/namespace';
@@ -16,6 +15,7 @@ import {
     stringifySelector,
     isSimpleSelector,
     parseSelectorWithCache,
+    walkSelector,
 } from '../helpers/selector';
 import { getAlias } from '../stylable-utils';
 import type { StylableMeta } from '../stylable-meta';
@@ -215,7 +215,7 @@ export const hooks = createFeature<{
             );
         }
         if (selectorContext.transform) {
-            namespaceClass(meta, symbol, node, originMeta);
+            namespaceClass(meta, symbol, node, selectorContext.globalClasses);
         }
     },
     transformJSExports({ exports, resolved }) {
@@ -245,7 +245,7 @@ export class StylablePublicApi {
             end: 0,
             dotComments: [],
         };
-        namespaceClass(resolved.meta, resolved.symbol, node, meta);
+        namespaceClass(resolved.meta, resolved.symbol, node);
         return stringifySelectorAst(node);
     }
 }
@@ -295,15 +295,22 @@ export function namespaceClass(
     meta: StylableMeta,
     symbol: StylableSymbol,
     node: SelectorNode, // ToDo: check this is the correct type, should this be inline selector?
-    originMeta: StylableMeta
+    globalClasses?: Set<string>
 ) {
     if (`-st-global` in symbol && symbol[`-st-global`]) {
         // change node to `-st-global` value
         const flatNode = convertToSelector(node);
         const globalMappedNodes = symbol[`-st-global`]!;
         flatNode.nodes = globalMappedNodes;
-        // ToDo: check if this is causes an issue with globals from an imported alias
-        STGlobal.addGlobals(originMeta, globalMappedNodes);
+        if (globalClasses) {
+            for (const ast of globalMappedNodes) {
+                walkSelector(ast, (inner) => {
+                    if (inner.type === 'class') {
+                        globalClasses.add(inner.value);
+                    }
+                });
+            }
+        }
     } else {
         node = convertToClass(node);
         node.value = namespaceEscape(symbol.name, meta.namespace);
@@ -450,7 +457,7 @@ function handleDirectives(context: FeatureContext, decl: postcss.Declaration) {
     const isSimplePerSelector = isSimpleSelector(rule.selector);
     const type = isSimplePerSelector.reduce((accType, { type }) => {
         return !accType ? type : accType !== type ? `complex` : type;
-    }, `` as (typeof isSimplePerSelector)[number]['type']);
+    }, `` as typeof isSimplePerSelector[number]['type']);
     const isSimple = type !== `complex`;
     if (decl.prop === `-st-states`) {
         if (isSimple && type !== 'type') {

--- a/packages/core/src/features/css-pseudo-class.ts
+++ b/packages/core/src/features/css-pseudo-class.ts
@@ -39,7 +39,9 @@ export const hooks = createFeature({
                 STCustomSelector.getCustomSelectorExpended(meta, node.value.slice(2));
             if (customSelector) {
                 const mappedSelectorAst = parseSelectorWithCache(customSelector, { clone: true });
-                const mappedContext = selectorContext.createNestedContext(mappedSelectorAst);
+                const mappedContext = selectorContext.createNestedContext(mappedSelectorAst, {
+                    shareGlobalClasses: true,
+                });
                 // ToDo: wrap in :is() to get intersection of selectors
                 scopeSelectorAst(mappedContext);
                 if (mappedContext.currentAnchor) {
@@ -77,7 +79,9 @@ export const hooks = createFeature({
                 const innerSelectors = (
                     node.nodes[0] && node.nodes[0].type === `nth` ? node.nodes.slice(1) : node.nodes
                 ) as Selector[];
-                const nestedContext = selectorContext.createNestedContext(innerSelectors);
+                const nestedContext = selectorContext.createNestedContext(innerSelectors, {
+                    shareGlobalClasses: true,
+                });
                 scopeSelectorAst(nestedContext);
                 /**
                  * ToDo: remove once elements is deprecated!

--- a/packages/core/src/features/css-pseudo-class.ts
+++ b/packages/core/src/features/css-pseudo-class.ts
@@ -39,9 +39,7 @@ export const hooks = createFeature({
                 STCustomSelector.getCustomSelectorExpended(meta, node.value.slice(2));
             if (customSelector) {
                 const mappedSelectorAst = parseSelectorWithCache(customSelector, { clone: true });
-                const mappedContext = selectorContext.createNestedContext(mappedSelectorAst, {
-                    shareGlobalClasses: true,
-                });
+                const mappedContext = selectorContext.createNestedContext(mappedSelectorAst);
                 // ToDo: wrap in :is() to get intersection of selectors
                 scopeSelectorAst(mappedContext);
                 if (mappedContext.currentAnchor) {
@@ -79,9 +77,7 @@ export const hooks = createFeature({
                 const innerSelectors = (
                     node.nodes[0] && node.nodes[0].type === `nth` ? node.nodes.slice(1) : node.nodes
                 ) as Selector[];
-                const nestedContext = selectorContext.createNestedContext(innerSelectors, {
-                    shareGlobalClasses: true,
-                });
+                const nestedContext = selectorContext.createNestedContext(innerSelectors);
                 scopeSelectorAst(nestedContext);
                 /**
                  * ToDo: remove once elements is deprecated!

--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -76,7 +76,7 @@ export const hooks = createFeature<{
         if (selectorContext.transform && resolved && resolved.length > 1) {
             const { symbol, meta } = getOriginDefinition(resolved);
             if (symbol._kind === 'class') {
-                CSSClass.namespaceClass(meta, symbol, node, selectorContext.globalClasses);
+                CSSClass.namespaceClass(meta, symbol, node);
             } else {
                 node.value = symbol.name;
             }

--- a/packages/core/src/features/css-type.ts
+++ b/packages/core/src/features/css-type.ts
@@ -76,7 +76,7 @@ export const hooks = createFeature<{
         if (selectorContext.transform && resolved && resolved.length > 1) {
             const { symbol, meta } = getOriginDefinition(resolved);
             if (symbol._kind === 'class') {
-                CSSClass.namespaceClass(meta, symbol, node, selectorContext.originMeta);
+                CSSClass.namespaceClass(meta, symbol, node, selectorContext.globalClasses);
             } else {
                 node.value = symbol.name;
             }

--- a/packages/core/src/features/st-global.ts
+++ b/packages/core/src/features/st-global.ts
@@ -8,7 +8,7 @@ import {
     isCompRoot,
 } from '../helpers/selector';
 import type { StylableMeta } from '../stylable-meta';
-import type { ImmutableSelectorNode, SelectorList, PseudoClass } from '@tokey/css-selector-parser';
+import type { ImmutableSelectorNode, SelectorList } from '@tokey/css-selector-parser';
 import { createDiagnosticReporter } from '../diagnostics';
 import type * as postcss from 'postcss';
 
@@ -103,14 +103,11 @@ export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutableSelectorNode }
                 return;
             }
             const selectorAst = parseSelectorWithCache(r.selector, { clone: true });
-            const globals = unwrapPseudoGlobals(selectorAst);
-            for (const ast of globals) {
-                walkSelector(ast, (inner) => {
-                    if (inner.type === 'class') {
-                        meta.globals[inner.value] = true;
-                    }
-                });
-            }
+            walkSelector(unwrapPseudoGlobals(selectorAst), (inner) => {
+                if (inner.type === 'class') {
+                    meta.globals[inner.value] = true;
+                }
+            });
             r.selector = stringifySelector(selectorAst);
         });
     },
@@ -130,12 +127,11 @@ export function getGlobalRules(meta: StylableMeta) {
 }
 
 export function unwrapPseudoGlobals(selectorAst: SelectorList) {
-    const collectedGlobals: PseudoClass[] = [];
+    const collectedGlobals: SelectorList = [];
     walkSelector(selectorAst, (node) => {
         if (node.type === 'pseudo_class' && node.value === 'global') {
-            collectedGlobals.push(node);
             if (node.nodes?.length === 1) {
-                flattenFunctionalSelector(node);
+                collectedGlobals.push(flattenFunctionalSelector(node));
             }
             return walkSelector.skipNested;
         }

--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -3,6 +3,7 @@ import {
     stringifySelectorAst,
     walk,
     SelectorNode,
+    PseudoClass,
     Selector,
     SelectorList,
     FunctionalSelector,
@@ -108,6 +109,22 @@ export function convertToSelector(node: SelectorNode): Selector {
     castedNode.before ||= ``;
     castedNode.after ||= ``;
     // ToDo: should this fix castedNode.end?
+    return castedNode;
+}
+export function convertToPseudoClass(
+    node: SelectorNode,
+    name: string,
+    nestedSelectors?: SelectorList
+): PseudoClass {
+    const castedNode = node as PseudoClass;
+    castedNode.type = 'pseudo_class';
+    castedNode.value = name;
+    castedNode.colonComments = [];
+    if (nestedSelectors) {
+        castedNode.nodes = nestedSelectors;
+    } else {
+        delete castedNode.nodes;
+    }
     return castedNode;
 }
 

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -379,10 +379,8 @@ export class StylableTransformer {
             topNestClassName
         );
         const targetSelectorAst = this.scopeSelectorAst(context);
-        // collect global classes
-        for (const globalClass of context.globalClasses) {
-            originMeta.globals[globalClass] = true;
-        }
+        // ToDo(major): remove functionality, globals are stripped in transformLastPass
+        // and this api is not used by anyone.
         if (unwrapGlobals) {
             STGlobal.unwrapPseudoGlobals(targetSelectorAst);
         }
@@ -534,12 +532,7 @@ export class StylableTransformer {
                         // insert nested combinator before internal custom element
                         context.insertDescendantCombinatorBeforePseudoElement();
                     }
-                    CSSClass.namespaceClass(
-                        resolvedPart.meta,
-                        resolvedPart.symbol,
-                        node,
-                        context.globalClasses
-                    );
+                    CSSClass.namespaceClass(resolvedPart.meta, resolvedPart.symbol, node);
                 }
                 break;
             }
@@ -759,7 +752,6 @@ export class ScopeContext {
     public node?: CompoundSelector['nodes'][number];
     public currentAnchor?: ScopeAnchor;
     public nestingSelectorAnchor?: ScopeAnchor;
-    public globalClasses = new Set<string>();
     constructor(
         public originMeta: StylableMeta,
         public resolver: StylableResolver,
@@ -802,10 +794,7 @@ export class ScopeContext {
             }
         }
     }
-    public createNestedContext(
-        selectorAst: SelectorList,
-        share: { shareGlobalClasses?: boolean } = {}
-    ) {
+    public createNestedContext(selectorAst: SelectorList) {
         const ctx = new ScopeContext(
             this.originMeta,
             this.resolver,
@@ -820,9 +809,6 @@ export class ScopeContext {
         ctx.selectorIndex = -1;
         ctx.elements = [];
         ctx.additionalSelectors = [];
-        if (!share.shareGlobalClasses) {
-            ctx.globalClasses = new Set<string>();
-        }
 
         return ctx;
     }

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -379,6 +379,10 @@ export class StylableTransformer {
             topNestClassName
         );
         const targetSelectorAst = this.scopeSelectorAst(context);
+        // collect global classes
+        for (const globalClass of context.globalClasses) {
+            originMeta.globals[globalClass] = true;
+        }
         if (unwrapGlobals) {
             STGlobal.unwrapPseudoGlobals(targetSelectorAst);
         }
@@ -534,7 +538,7 @@ export class StylableTransformer {
                         resolvedPart.meta,
                         resolvedPart.symbol,
                         node,
-                        originMeta
+                        context.globalClasses
                     );
                 }
                 break;
@@ -755,6 +759,7 @@ export class ScopeContext {
     public node?: CompoundSelector['nodes'][number];
     public currentAnchor?: ScopeAnchor;
     public nestingSelectorAnchor?: ScopeAnchor;
+    public globalClasses = new Set<string>();
     constructor(
         public originMeta: StylableMeta,
         public resolver: StylableResolver,
@@ -797,7 +802,10 @@ export class ScopeContext {
             }
         }
     }
-    public createNestedContext(selectorAst: SelectorList) {
+    public createNestedContext(
+        selectorAst: SelectorList,
+        share: { shareGlobalClasses?: boolean } = {}
+    ) {
         const ctx = new ScopeContext(
             this.originMeta,
             this.resolver,
@@ -812,6 +820,9 @@ export class ScopeContext {
         ctx.selectorIndex = -1;
         ctx.elements = [];
         ctx.additionalSelectors = [];
+        if (!share.shareGlobalClasses) {
+            ctx.globalClasses = new Set<string>();
+        }
 
         return ctx;
     }

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -379,8 +379,6 @@ export class StylableTransformer {
             topNestClassName
         );
         const targetSelectorAst = this.scopeSelectorAst(context);
-        // ToDo(major): remove functionality, globals are stripped in transformLastPass
-        // and this api is not used by anyone.
         if (unwrapGlobals) {
             STGlobal.unwrapPseudoGlobals(targetSelectorAst);
         }


### PR DESCRIPTION
Small change to allow running `scopeSelectorAst` without modifying the meta. This changes the transformation of classes with `-st-global` definition to transform into `:global(selector)` and to be collected like other global selectors at the end of the transformation process instead of registering the global classes within the process in a special way.

This is required in order to run selector transformation/inference without mutating the context meta.