### PR TITLE
feat(node): experimental loader

### DIFF
--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -1,5 +1,5 @@
 export { processUrlDependencies } from './process-url-dependencies';
 export { hasImportedSideEffects, collectImportsWithSideEffects } from './has-imported-side-effects';
 export { sortModulesByDepth } from './sort-modules-by-depth';
-export { loadStylableConfig } from './load-stylable-config';
+export { loadStylableConfig, loadStylableConfigEsm } from './load-stylable-config';
 export { CalcDepthContext, calcDepth, getCSSViewModule } from './calc-depth';

--- a/packages/build-tools/src/load-stylable-config.ts
+++ b/packages/build-tools/src/load-stylable-config.ts
@@ -1,4 +1,5 @@
 import findConfig from 'find-config';
+import { pathToFileURL } from 'url';
 
 export function loadStylableConfig<T>(
     context: string,
@@ -11,6 +12,39 @@ export function loadStylableConfig<T>(
     if (path) {
         try {
             config = require(path);
+        } catch (e) {
+            throw new Error(
+                `Failed to load "stylable.config.js" from ${path}\n${(e as Error)?.stack}`
+            );
+        }
+        if (!config) {
+            throw new Error(
+                `Stylable configuration loaded from ${path} but no exported configuration found`
+            );
+        }
+        return {
+            path,
+            config: extract(config),
+        };
+    }
+    return undefined;
+}
+
+// use eval to preserve esm import from typescript compiling
+// it to require, because of our current build to cjs
+const esmImport: (url: URL) => any = eval(`(path) => import(path)`);
+
+export async function loadStylableConfigEsm<T>(
+    context: string,
+    extract: (config: any) => T
+): Promise<{ path: string; config: T } | undefined> {
+    const path =
+        findConfig('stylable.config.js', { cwd: context }) ??
+        findConfig('stylable.config.mjs', { cwd: context });
+    let config;
+    if (path) {
+        try {
+            config = await esmImport(pathToFileURL(path));
         } catch (e) {
             throw new Error(
                 `Failed to load "stylable.config.js" from ${path}\n${(e as Error)?.stack}`

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -28,3 +28,4 @@ export { testInlineExpects, testInlineExpectsErrors } from './inline-expectation
 export { testStylableCore } from './test-stylable-core';
 export { deindent } from './deindent';
 export { MinimalDocument, MinimalElement } from './minimal-dom';
+export { createTempDirectorySync, copyDirectory } from './native-temp-dir';

--- a/packages/core-test-kit/src/native-temp-dir.ts
+++ b/packages/core-test-kit/src/native-temp-dir.ts
@@ -1,0 +1,22 @@
+import { tmpdir } from 'os';
+import { mkdtempSync } from 'fs';
+import nodeFs from '@file-services/node';
+import type { IDirectoryContents, IFileSystem } from '@file-services/types';
+
+export function createTempDirectorySync(prefix = 'temp-') {
+    const path = nodeFs.realpathSync.native(mkdtempSync(nodeFs.join(tmpdir(), prefix)));
+    const remove = () => nodeFs.rmSync(path, { recursive: true, force: true });
+
+    return { path, remove, setContent: copyDirectory.bind(null, nodeFs, path) };
+}
+export function copyDirectory(fs: IFileSystem, targetPath: string, content: IDirectoryContents) {
+    fs.ensureDirectorySync(targetPath);
+    for (const [name, value] of Object.entries(content)) {
+        const itemPath = fs.join(targetPath, name);
+        if (typeof value === 'string') {
+            fs.writeFileSync(itemPath, value, { encoding: 'utf-8' });
+        } else {
+            copyDirectory(fs, itemPath, value);
+        }
+    }
+}

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -1,5 +1,6 @@
 import { createDefaultResolver } from '@stylable/core';
-import { testLangService, createTempDirectorySync } from '../../test-kit/test-lang-service';
+import { createTempDirectorySync } from '@stylable/core-test-kit';
+import { testLangService } from '../../test-kit/test-lang-service';
 import { Command } from 'vscode-languageserver';
 
 const triggerCompletion = Command.create('additional', 'editor.action.triggerSuggest');

--- a/packages/language-service/test/test-kit/test-lang-service.ts
+++ b/packages/language-service/test/test-kit/test-lang-service.ts
@@ -1,34 +1,14 @@
 import { createMemoryFs } from '@file-services/memory';
 import type { IDirectoryContents, IFileSystem } from '@file-services/types';
 import { Stylable, StylableConfig } from '@stylable/core';
-import { deindent } from '@stylable/core-test-kit';
+import { deindent, copyDirectory } from '@stylable/core-test-kit';
 import { StylableLanguageService } from '@stylable/language-service';
 import { range } from '@stylable/language-service/dist/lib/completion-types';
 import { CompletionItem, TextEdit } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-css-languageservice';
 import { URI } from 'vscode-uri';
 import { expect } from 'chai';
-import { tmpdir } from 'os';
-import { mkdtempSync } from 'fs';
 import nodeFs from '@file-services/node';
-
-export function createTempDirectorySync(prefix = 'temp-') {
-    const path = nodeFs.realpathSync.native(mkdtempSync(nodeFs.join(tmpdir(), prefix)));
-    const remove = () => nodeFs.rmSync(path, { recursive: true, force: true });
-
-    return { path, remove };
-}
-function copyDirectory(fs: IFileSystem, targetPath: string, content: IDirectoryContents) {
-    fs.ensureDirectorySync(targetPath);
-    for (const [name, value] of Object.entries(content)) {
-        const itemPath = fs.join(targetPath, name);
-        if (typeof value === 'string') {
-            fs.writeFileSync(itemPath, value, { encoding: 'utf-8' });
-        } else {
-            copyDirectory(fs, itemPath, value);
-        }
-    }
-}
 
 export interface TestOptions {
     testOnNativeFileSystem: string;

--- a/packages/node/loader.mjs
+++ b/packages/node/loader.mjs
@@ -1,0 +1,1 @@
+export * from './dist/loader.js';

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,6 +16,7 @@
     "!dist/test",
     "src",
     "register.js",
+    "loader.js",
     "!*/tsconfig.{json,tsbuildinfo}"
   ],
   "engines": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@stylable/core": "^5.8.0",
     "@stylable/module-utils": "^5.8.0",
+    "@stylable/build-tools": "^5.8.0",
     "find-config": "^1.0.0"
   },
   "files": [

--- a/packages/node/src/common.ts
+++ b/packages/node/src/common.ts
@@ -1,0 +1,1 @@
+export const defaultStylableMatcher = (filename: string) => !!filename.match(/\.st\.css$/);

--- a/packages/node/src/loader.ts
+++ b/packages/node/src/loader.ts
@@ -20,7 +20,7 @@ async function initiateModuleFactory() {
         {
             resolveNamespace,
             ...(defaultConfig?.config || {}),
-            projectRoot: 'root',
+            projectRoot: '/',
             fileSystem: nodeFs,
             resolverCache: new Map(),
         },

--- a/packages/node/src/loader.ts
+++ b/packages/node/src/loader.ts
@@ -1,0 +1,53 @@
+import { defaultStylableMatcher } from './common';
+import nodeFs from '@file-services/node';
+import { stylableModuleFactory } from '@stylable/module-utils';
+import { resolveNamespace } from './resolve-namespace';
+import { fileURLToPath } from 'url';
+
+const stylableToModule = stylableModuleFactory(
+    {
+        projectRoot: 'root',
+        fileSystem: nodeFs,
+        resolveNamespace,
+        resolverCache: new Map(),
+    },
+    {
+        moduleType: 'esm',
+        // point to cjs - the esm runtime isn't published with mjs
+        // and causes issues. currently it's problematic for direct esm
+        // usage and only works for bundlers.
+        runtimePath: '@stylable/runtime/dist/pure.js',
+    }
+);
+
+export interface LoaderContext {
+    conditions: string[];
+    format?: string | null;
+    importAssertions: Record<string, string>;
+}
+
+export interface LoaderResult {
+    format: string;
+    shortCircuit?: boolean;
+    source: string | ArrayBuffer | SharedArrayBuffer | Uint8Array;
+}
+
+export async function load(
+    url: string,
+    context: LoaderContext,
+    next: (specifier: string, context: LoaderContext) => Promise<LoaderResult>
+): Promise<LoaderResult> {
+    if (defaultStylableMatcher(url)) {
+        const filePath = fileURLToPath(url);
+        const sheetSource = nodeFs.readFileSync(filePath, { encoding: 'utf-8' });
+        const moduleSource = stylableToModule(sheetSource, filePath);
+        return {
+            shortCircuit: true,
+            format: 'module',
+            source: moduleSource,
+        };
+    }
+
+    // Defer to the next hook in the chain
+    return next(url, context);
+}

--- a/packages/node/src/require-hook.ts
+++ b/packages/node/src/require-hook.ts
@@ -2,6 +2,7 @@ import type { StylableConfig } from '@stylable/core';
 import { validateDefaultConfig } from '@stylable/core/dist/index-internal';
 import { stylableModuleFactory } from '@stylable/module-utils';
 import fs from 'fs';
+import { defaultStylableMatcher } from './common';
 import { resolveNamespace } from './resolve-namespace';
 
 export interface Options {
@@ -14,8 +15,6 @@ export interface Options {
 }
 
 const HOOK_EXTENSION = '.css';
-
-const defaultStylableMatcher = (filename: string) => !!filename.match(/\.st\.css$/);
 
 export function attachHook({
     matcher,

--- a/packages/node/src/tsconfig.json
+++ b/packages/node/src/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "../dist"
   },
-  "references": [{ "path": "../../core/src" }, { "path": "../../module-utils/src" }]
+  "references": [
+    { "path": "../../core/src" },
+    { "path": "../../module-utils/src" },
+    { "path": "../../build-tools/src" }
+  ]
 }

--- a/packages/node/test/loader.spec.ts
+++ b/packages/node/test/loader.spec.ts
@@ -58,4 +58,79 @@ const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
 
         expect(result.stdout).to.eql(`{ classes: [ 'root', 'part' ] }\n`);
     });
+    it('should use stylable.config (esm project)', () => {
+        tempDir.setContent({
+            'index.st.css': `
+                .root {}
+                .part {}
+            `,
+            'index.js': `
+                import { classes } from './index.st.css';
+                console.log(classes);
+            `,
+            'stylable.config.js': `
+                export function defaultConfig(fs) {
+                    return {
+                        resolveNamespace(namespace, path) {
+                            return 'x-' + namespace;
+                        }
+                    };
+                };
+            `,
+            'package.json': `
+                {
+                    "name": "test",
+                    "version": "0.0.1",
+                    "type": "module",
+                    "dependencies": {
+                        "@stylable/runtime": ${stylableRuntimeDepPath},
+                        "@stylable/node": ${stylableNodeDepPath}
+                    }
+                }
+            `,
+        });
+        const fixturePath = join(tempDir.path, 'index.js');
+
+        const result = runTest(fixturePath);
+
+        expect(result.stdout).to.eql(`{ root: 'x-index__root', part: 'x-index__part' }\n`);
+    });
+    it('should use stylable.config (cjs project)', () => {
+        tempDir.setContent({
+            'index.st.css': `
+                .root {}
+                .part {}
+            `,
+            'index.mjs': `
+                import { classes } from './index.st.css';
+                console.log(classes);
+            `,
+            'stylable.config.js': `
+                module.exports = {
+                    defaultConfig(fs) {
+                        return {
+                            resolveNamespace(namespace, path) {
+                                return 'x-' + namespace;
+                            }
+                        };
+                    }
+                };
+            `,
+            'package.json': `
+                {
+                    "name": "test",
+                    "version": "0.0.1",
+                    "dependencies": {
+                        "@stylable/runtime": ${stylableRuntimeDepPath},
+                        "@stylable/node": ${stylableNodeDepPath}
+                    }
+                }
+            `,
+        });
+        const fixturePath = join(tempDir.path, 'index.mjs');
+
+        const result = runTest(fixturePath);
+
+        expect(result.stdout).to.eql(`{ root: 'x-index__root', part: 'x-index__part' }\n`);
+    });
 });

--- a/packages/node/test/loader.spec.ts
+++ b/packages/node/test/loader.spec.ts
@@ -1,0 +1,52 @@
+import { spawnSync, execSync } from 'child_process';
+import { join, dirname } from 'path';
+import { createTempDirectorySync } from '@stylable/core-test-kit';
+import { expect } from 'chai';
+
+function runTest(fixturePath: string) {
+    execSync('npm install', { cwd: dirname(fixturePath) });
+    return spawnSync('node', ['--experimental-loader', '@stylable/node/loader.mjs', fixturePath], {
+        encoding: 'utf8',
+    });
+}
+const stylableRuntimePath = join(__dirname, '../../../runtime');
+const stylableRuntimeDepPath = '"file:' + JSON.stringify(stylableRuntimePath).substring(1);
+
+describe('node loader', () => {
+    let tempDir: ReturnType<typeof createTempDirectorySync>;
+    beforeEach('crate temp dir', () => {
+        tempDir = createTempDirectorySync('st-node-loader-');
+    });
+    afterEach('remove temp dir', () => {
+        tempDir.remove();
+    });
+    it('should load stylable modules', () => {
+        tempDir.setContent({
+            'index.st.css': `
+                .root {}
+                .part {}
+            `,
+            'index.js': `
+                import { classes } from './index.st.css';
+                console.log({
+                    classes: Object.keys(classes)
+                });            
+            `,
+            'package.json': `
+                {
+                    "name": "test",
+                    "version": "0.0.1",
+                    "type": "module",
+                    "dependencies": {
+                        "@stylable/runtime": ${stylableRuntimeDepPath}
+                    }
+                }
+            `,
+        });
+        const fixturePath = join(tempDir.path, 'index.js');
+
+        const result = runTest(fixturePath);
+
+        expect(result.stdout).to.eql(`{ classes: [ 'root', 'part' ] }\n`);
+    });
+});

--- a/packages/node/test/loader.spec.ts
+++ b/packages/node/test/loader.spec.ts
@@ -4,13 +4,18 @@ import { createTempDirectorySync } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 
 function runTest(fixturePath: string) {
-    execSync('npm install', { cwd: dirname(fixturePath) });
+    const fixtureDirPath = dirname(fixturePath);
+    execSync('npm install', { cwd: fixtureDirPath });
     return spawnSync('node', ['--experimental-loader', '@stylable/node/loader.mjs', fixturePath], {
         encoding: 'utf8',
+        cwd: fixtureDirPath,
     });
 }
-const stylableRuntimePath = join(__dirname, '../../../runtime');
-const stylableRuntimeDepPath = '"file:' + JSON.stringify(stylableRuntimePath).substring(1);
+
+const stylableRuntimeDepPath =
+    '"file:' + JSON.stringify(join(__dirname, '../../../runtime')).substring(1);
+const stylableNodeDepPath =
+    '"file:' + JSON.stringify(join(__dirname, '../../../node')).substring(1);
 
 // ToDo(major): remove conditional once node 14 support is dropped
 const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
@@ -41,7 +46,8 @@ const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
                     "version": "0.0.1",
                     "type": "module",
                     "dependencies": {
-                        "@stylable/runtime": ${stylableRuntimeDepPath}
+                        "@stylable/runtime": ${stylableRuntimeDepPath},
+                        "@stylable/node": ${stylableNodeDepPath}
                     }
                 }
             `,

--- a/packages/node/test/loader.spec.ts
+++ b/packages/node/test/loader.spec.ts
@@ -12,7 +12,9 @@ function runTest(fixturePath: string) {
 const stylableRuntimePath = join(__dirname, '../../../runtime');
 const stylableRuntimeDepPath = '"file:' + JSON.stringify(stylableRuntimePath).substring(1);
 
-describe('node loader', () => {
+// ToDo(major): remove conditional once node 14 support is dropped
+const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
+(nodeMajorVersion > 14 ? describe : describe.skip)('node loader', () => {
     let tempDir: ReturnType<typeof createTempDirectorySync>;
     beforeEach('crate temp dir', () => {
         tempDir = createTempDirectorySync('st-node-loader-');
@@ -20,6 +22,7 @@ describe('node loader', () => {
     afterEach('remove temp dir', () => {
         tempDir.remove();
     });
+
     it('should load stylable modules', () => {
         tempDir.setContent({
             'index.st.css': `

--- a/packages/node/test/tsconfig.json
+++ b/packages/node/test/tsconfig.json
@@ -4,5 +4,9 @@
     "outDir": "../dist/test",
     "types": ["node", "externals", "mocha"]
   },
-  "references": [{ "path": "../../core/src" }, { "path": "../src" }]
+  "references": [
+    { "path": "../../core/src" },
+    { "path": "../src" },
+    { "path": "../../core-test-kit/src" }
+  ]
 }


### PR DESCRIPTION
This PR adds a NodeJS loader to be used with [--experimental-loader](https://nodejs.org/api/esm.html#loaders).

The new loader doesn't support node 14 since the loader API changed (tests are skipped for v14).

## Tasks
- [x] implement default loading
- [x] use `stylable.config`

## Open issues (don't have to be solved in this PR)
- How do we differ between dev/production mode (2 loaders?, env flag?)
- How do we provide optimized namespaces mappings from a seperate process like webpack? (same issue with `attachHook`, but a bit more difficult since loaders don't get args ) 
- Currently the loader generates an esm module, but imports the cjs runtime (`@stylable/runtime/dist/pure.js`). This is done because our esm runtime is built into `.js` and the runtime package.json is not `type:module`, which means that the esm version cannot be imported by node and is currencly only used by bundlers that are more lenient. 