### PR TITLE
refactor: make core compatible with esm bundling

### DIFF
--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -11,7 +11,7 @@ import { mixinHelperDiagnostics, parseStMixin, parseStPartialMixin } from '../he
 import { resolveArgumentsValue } from '../functions';
 import { cssObjectToAst } from '../parser';
 import * as postcss from 'postcss';
-import { FunctionNode, WordNode, stringify } from 'postcss-value-parser';
+import postcssValueParser, { FunctionNode, WordNode } from 'postcss-value-parser';
 import { fixRelativeUrls } from '../stylable-assets';
 import { isValidDeclaration, mergeRules, utilDiagnostics } from '../stylable-utils';
 import type { StylableMeta } from '../stylable-meta';
@@ -182,7 +182,9 @@ export class StylablePublicApi {
                     name,
                     kind: 'invalid',
                     args:
-                        data.valueNode?.type === 'function' ? stringify(data.valueNode.nodes) : '',
+                        data.valueNode?.type === 'function'
+                            ? postcssValueParser.stringify(data.valueNode.nodes)
+                            : '',
                 });
             }
         }

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1,6 +1,6 @@
 // importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
 // this allows @stylable/core to be bundled for browser usage without special custom configuration
-import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory';
+import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
 
 import type { ModuleResolver } from './types';
 import type { MinimalFS } from './cached-process-file';

--- a/typings/externals/index.d.ts
+++ b/typings/externals/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'enhanced-resolve/lib/ResolverFactory' {
+declare module 'enhanced-resolve/lib/ResolverFactory.js' {
     const ResolverFactory: typeof import('enhanced-resolve').ResolverFactory;
     export = ResolverFactory;
 }


### PR DESCRIPTION
this ensures core can be bundled using esbuild to cjs/esm