### PR TITLE
feat: css nesting

### DIFF
--- a/packages/cli/test/watch-multiple-projects.spec.ts
+++ b/packages/cli/test/watch-multiple-projects.spec.ts
@@ -379,7 +379,7 @@ describe('Stylable Cli Watch - Multiple projects', function () {
                     action() {
                         return writeToExistingFile(
                             join(tempDir.path, 'packages', 'project-a', 'style.st.css'),
-                            '.root{ color:yellow; {} }'
+                            '.x.y{ -st-states: z; }'
                         );
                     },
                 },
@@ -390,7 +390,7 @@ describe('Stylable Cli Watch - Multiple projects', function () {
                     ),
                 },
                 {
-                    msg: '[error: 11011]: nesting of rules within rules is not supported',
+                    msg: '[error: 11003]: cannot define pseudo states inside complex selectors',
                     action() {
                         return writeToExistingFile(
                             join(tempDir.path, 'packages', 'project-a', 'style.st.css'),

--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -80,7 +80,7 @@ export class StylablePublicApi {
     }
 }
 
-function isStScopeStatement(node: any): node is postcss.AtRule {
+export function isStScopeStatement(node: any): node is postcss.AtRule {
     return node.type === 'atrule' && node.name === 'st-scope';
 }
 

--- a/packages/core/src/index-internal.ts
+++ b/packages/core/src/index-internal.ts
@@ -1,5 +1,5 @@
 export { safeParse } from './parser';
-export { processorDiagnostics, StylableProcessor } from './stylable-processor';
+export { StylableProcessor } from './stylable-processor';
 export {
     StylableTransformer,
     postProcessor,

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -1,5 +1,5 @@
 import type * as postcss from 'postcss';
-import { createDiagnosticReporter, Diagnostics } from './diagnostics';
+import { Diagnostics } from './diagnostics';
 import { knownPseudoClassesWithNestedSelectors } from './native-reserved-lists';
 import { StylableMeta } from './stylable-meta';
 import { CSSCustomProperty, STVar, STCustomSelector } from './features';
@@ -26,15 +26,6 @@ import {
 } from './helpers/selector';
 import { isChildOfAtRule } from './helpers/rule';
 
-export const processorDiagnostics = {
-    INVALID_NESTING: createDiagnosticReporter(
-        '11011',
-        'error',
-        (child: string, parent: string) =>
-            `nesting of rules within rules is not supported, found: "${child}" inside "${parent}"`
-    ),
-};
-
 export class StylableProcessor implements FeatureContext {
     public meta!: StylableMeta;
     constructor(
@@ -55,16 +46,6 @@ export class StylableProcessor implements FeatureContext {
                     isScoped: isChildOfAtRule(rule, `st-scope`),
                     reportUnscoped: true,
                 });
-            }
-            const parent = rule.parent;
-            if (parent?.type === 'rule') {
-                this.diagnostics.report(
-                    processorDiagnostics.INVALID_NESTING(
-                        rule.selector,
-                        (parent as postcss.Rule).selector
-                    ),
-                    { node: rule }
-                );
             }
         });
 

--- a/packages/core/test/diagnostic-codes.spec.ts
+++ b/packages/core/test/diagnostic-codes.spec.ts
@@ -22,7 +22,6 @@ import { parseImportMessages, ensureImportsMessages } from '@stylable/core/dist/
 import { mixinHelperDiagnostics } from '@stylable/core/dist/helpers/mixin';
 import { valueDiagnostics } from '@stylable/core/dist/helpers/value';
 import { functionDiagnostics } from '@stylable/core/dist/functions';
-import { processorDiagnostics } from '@stylable/core/dist/stylable-processor';
 import { transformerDiagnostics } from '@stylable/core/dist/stylable-transformer';
 import { utilDiagnostics, sourcePathDiagnostics } from '@stylable/core/dist/stylable-utils';
 
@@ -53,7 +52,6 @@ describe('diagnostics error codes', () => {
             ...valueDiagnostics,
             ...functionDiagnostics,
             ...STCustomState.diagnostics,
-            ...processorDiagnostics,
             ...transformerDiagnostics,
             ...utilDiagnostics,
             ...sourcePathDiagnostics,

--- a/packages/core/test/stylable-processor.spec.ts
+++ b/packages/core/test/stylable-processor.spec.ts
@@ -1,15 +1,10 @@
 import { resolve } from 'path';
 import chai, { expect } from 'chai';
-import { flatMatch, processSource, diagnosticBankReportToStrings } from '@stylable/core-test-kit';
+import { flatMatch, processSource } from '@stylable/core-test-kit';
 import { processNamespace } from '@stylable/core';
-import {
-    knownPseudoClassesWithNestedSelectors,
-    processorDiagnostics,
-} from '@stylable/core/dist/index-internal';
+import { knownPseudoClassesWithNestedSelectors } from '@stylable/core/dist/index-internal';
 
 chai.use(flatMatch);
-
-const processorStringDiagnostics = diagnosticBankReportToStrings(processorDiagnostics);
 
 describe('Stylable postcss process', () => {
     it('report if missing filename', () => {
@@ -18,23 +13,6 @@ describe('Stylable postcss process', () => {
         expect(diagnostics.reports[0]).to.include({
             severity: 'error',
             message: 'missing source filename',
-        });
-    });
-
-    it('error on invalid rule nesting', () => {
-        const { diagnostics } = processSource(
-            `
-            .x{
-                .y{}
-            }
-        
-        `,
-            { from: '/path/to/source.st.css' }
-        );
-
-        expect(diagnostics.reports[0]).to.include({
-            severity: 'error',
-            message: processorStringDiagnostics.INVALID_NESTING('.y', '.x'),
         });
     });
 

--- a/packages/core/test/stylable-transformer/nesting.spec.ts
+++ b/packages/core/test/stylable-transformer/nesting.spec.ts
@@ -1,0 +1,94 @@
+import {
+    diagnosticBankReportToStrings,
+    shouldReportNoDiagnostics,
+    testStylableCore,
+} from '@stylable/core-test-kit';
+import { CSSPseudoClass } from '@stylable/core/dist/features';
+
+const cssPseudoClassDiagnostics = diagnosticBankReportToStrings(CSSPseudoClass.diagnostics);
+
+describe('transformer/nesting', () => {
+    it('should bind & to nesting selector', () => {
+        const { sheets } = testStylableCore(`
+            .x {
+                -st-states: y;
+            }
+
+            /* @rule .entry__x */
+            .x {
+                /* @rule &.entry--y */
+                &:y {}
+            }
+        `);
+
+        const { meta } = sheets['/entry.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+    });
+    it('should reset selector inference to nearest ancestor style rule', () => {
+        const { sheets } = testStylableCore(`
+            .x {
+                -st-states: xxx;
+            }
+            .y {
+                -st-states: yyy;
+            }
+
+            .x {
+                /* @rule &.entry--xxx */
+                &:xxx {
+                    .y {
+                        /* @rule &.entry--yyy */
+                        &:yyy {}
+                    }
+                }
+            }
+        `);
+
+        const { meta } = sheets['/entry.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+    });
+    it('should reset selector inference to nearest ancestor style rule (in atrule)', () => {
+        const { sheets } = testStylableCore(`
+            .x {
+                -st-states: xxx;
+            }
+
+            .x {
+                @media {
+                    /* @rule &.entry--xxx */
+                    &:xxx {}
+                }
+            }
+        `);
+
+        const { meta } = sheets['/entry.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+    });
+    it('should bind to selector intersection', () => {
+        testStylableCore(
+            `
+                .x {
+                    -st-states: shared, onlyX;
+                }
+                .y {
+                    -st-states: shared;
+                }
+
+                .x, .y {
+                    /* @rule &.entry--shared */
+                    &:shared {}
+
+                    /* 
+                        @transform-error ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE('onlyX')} 
+                        @rule &:onlyX
+                    */
+                    &:onlyX {}
+                }
+            `,
+            { stylableConfig: { experimentalSelectorInference: true } }
+        );
+    });
+});

--- a/packages/core/test/stylable-transformer/nesting.spec.ts
+++ b/packages/core/test/stylable-transformer/nesting.spec.ts
@@ -57,8 +57,10 @@ describe('transformer/nesting', () => {
 
             .x {
                 @media {
-                    /* @rule &.entry--xxx */
-                    &:xxx {}
+                    @media {
+                        /* @rule &.entry--xxx */
+                        &:xxx {}
+                    }
                 }
             }
         `);
@@ -115,6 +117,12 @@ describe('transformer/nesting', () => {
                 */
                 .root :x {}
             }
+
+            /* 
+                legacy behavior without "experimentalSelectorInference"
+                @rule(after combinator) .entry__root .entry--x  
+            */
+            .root :x {}
         `);
     });
 });

--- a/packages/core/test/stylable-transformer/nesting.spec.ts
+++ b/packages/core/test/stylable-transformer/nesting.spec.ts
@@ -91,4 +91,30 @@ describe('transformer/nesting', () => {
             { stylableConfig: { experimentalSelectorInference: true } }
         );
     });
+    it('should infer to universal selector without nesting selector', () => {
+        testStylableCore(`
+            .root {
+                -st-states: x;
+            }
+            .part {
+                -st-states: x;
+            }
+
+            .part {
+                /* 
+                    @transform-error(first) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE('x')}
+                    @rule(first) :x 
+                */
+                :x {}
+
+                /* 
+                    @transform-error(after combinator) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE(
+                        'x'
+                    )}
+                    @rule(after combinator) .entry__root :x 
+                */
+                .root :x {}
+            }
+        `);
+    });
 });

--- a/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-css-pseudo-class.spec.ts
@@ -297,4 +297,53 @@ describe('LS: css-pseudo-class', () => {
             });
         });
     });
+    describe('nesting', () => {
+        it('should infer nest from parent nesting selector', () => {
+            const { service, carets, assertCompletions } = testLangService(`
+                .root {
+                    -st-states: root-state;
+                }
+                .part {
+                    -st-states: part-state;
+                }
+
+                .part {
+                    &^nest^
+                }
+
+                .part {
+                    & {
+                        &^doubleNest^
+                    }
+                }
+
+                /* currently nesting in non-& reset to root - this behavior might change */
+                .part {
+                    :hover {
+                        &^nestUnderNonAmp^
+                    }
+                }
+            `);
+            const entryCarets = carets['/entry.st.css'];
+
+            assertCompletions({
+                message: 'nest',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nest),
+                expectedList: [{ label: ':part-state' }],
+                unexpectedList: [{ label: ':root-state' }],
+            });
+            assertCompletions({
+                message: 'doubleNest',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.doubleNest),
+                expectedList: [{ label: ':part-state' }],
+                unexpectedList: [{ label: ':root-state' }],
+            });
+            assertCompletions({
+                message: 'nestUnderNonAmp',
+                actualList: service.onCompletion('/entry.st.css', entryCarets.nestUnderNonAmp),
+                expectedList: [{ label: ':root-state' }],
+                unexpectedList: [{ label: ':part-state' }],
+            });
+        });
+    });
 });


### PR DESCRIPTION
This PR adds support for [native CSS nesting](https://drafts.csswg.org/css-nesting/).

Most of the work to support nesting was already done in the refactor to support [selector intersection](#2827 ).

## Tasks

- [x] remove nesting rules error diagnostic
- [x] test nesting selector (`&`) transformation
- [x] test nesting selector completions in language service
- [x] handle unscoped nested selector - selector not starting with `&` should infer to a universal selector and not resolve to the stylesheet root.   