### PR TITLE
feat: default to universal inferred context selector

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -1002,11 +1002,12 @@ export class ScopeContext {
             following a combinator.
             
             Currently set to stylesheet root for top level selectors and selectors
-            directly nested under @st-scope. But will change in the future to a universal selector. 
+            directly nested under @st-scope. But will change in the future to a universal selector
+            once experimentalSelectorInference will be the default behavior
         */
         const inferredContext =
             inferredSelectorContext ||
-            (this.isNested
+            (this.isNested || transformer.experimentalSelectorInference
                 ? new InferredSelector(transformer, [
                       {
                           _kind: 'css',

--- a/packages/core/test/features/st-global.spec.ts
+++ b/packages/core/test/features/st-global.spec.ts
@@ -122,10 +122,10 @@ describe(`features/st-global`, () => {
                         /* @rule(unknown comp pseudo-element) .comp__root.g::part */
                         Comp:global(.g)::part {}
             
-                        /* @rule(unknown standalone pseudo-element) .comp__root.g::class */
+                        /* @rule(unknown pseudo-element) .comp__root.g::class */
                         Comp:global(.g)::class {}
 
-                        /* @rule(standalone pseudo-element) .comp__root.g  .entry__class */
+                        /* @rule(universal pseudo-element) .comp__root.g ::class */
                         Comp:global(.g) ::class {}
                     `,
                 },

--- a/packages/core/test/features/st-scope.spec.ts
+++ b/packages/core/test/features/st-scope.spec.ts
@@ -66,9 +66,6 @@ describe(`features/st-scope`, () => {
                     @st-scope .a, .b {
                         /* @rule(nest) .entry__a.entry--shared, .entry__b.entry--shared */
                         &:shared {}
-
-                        /* @rule(context) .entry__a .entry__b, .entry__b .entry__b */
-                        ::b {}
                     }
                 `,
                 { stylableConfig: { experimentalSelectorInference: true } }
@@ -77,6 +74,23 @@ describe(`features/st-scope`, () => {
             const { meta } = sheets['/entry.st.css'];
 
             shouldReportNoDiagnostics(meta);
+        });
+        it('should infer default context as universal selector', () => {
+            testStylableCore(
+                `
+                    .a {
+                        -st-states: shared;
+                    }
+                    .b {
+                        -st-states: shared;
+                    }
+                    @st-scope .a, .b {
+                        /* @rule(universal context) .entry__a ::b, .entry__b ::b */
+                        ::b {}
+                    }
+                `,
+                { stylableConfig: { experimentalSelectorInference: true } }
+            );
         });
     });
     describe('stylable API', () => {

--- a/packages/core/test/stylable-transformer/general.spec.ts
+++ b/packages/core/test/stylable-transformer/general.spec.ts
@@ -77,8 +77,22 @@ describe('Stylable postcss transform (General)', () => {
     });
 
     describe('experimentalSelectorInference', () => {
+        it('should set default inferred selector context to universal selector', () => {
+            testStylableCore(
+                `
+                    .root { -st-states: state; }
+                    .class { -st-states: state; }
+                
+                    /* @rule(unknown state) :state */
+                    :state {}
+        
+                    /* @rule(unknown pseudo-element) ::class */
+                    ::class {}
+                `,
+                { stylableConfig: { experimentalSelectorInference: true } }
+            );
+        });
         it('should reset inferred selector after combinator', () => {
-            // ToDo: fix extra space before ".entry__class"
             testStylableCore(
                 {
                     'comp.st.css': ` .part {} `,
@@ -92,7 +106,7 @@ describe('Stylable postcss transform (General)', () => {
                         /* @rule(unknown pseudo-element) .comp__root ::part */
                         Comp ::part {}
             
-                        /* @rule(standalone pseudo-element) .comp__root  .entry__class */
+                        /* @rule(standalone pseudo-element) .comp__root ::class */
                         Comp ::class {}
                     `,
                 },

--- a/packages/core/test/stylable-transformer/general.spec.ts
+++ b/packages/core/test/stylable-transformer/general.spec.ts
@@ -1,6 +1,15 @@
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
-import { generateStylableRoot, testStylableCore } from '@stylable/core-test-kit';
+import {
+    diagnosticBankReportToStrings,
+    generateStylableRoot,
+    testStylableCore,
+} from '@stylable/core-test-kit';
+import { CSSPseudoClass } from '@stylable/core/dist/features';
+import { transformerDiagnostics } from '@stylable/core/dist/index-internal';
+
+const cssPseudoClassDiagnostics = diagnosticBankReportToStrings(CSSPseudoClass.diagnostics);
+const transformerStringDiagnostics = diagnosticBankReportToStrings(transformerDiagnostics);
 
 describe('Stylable postcss transform (General)', () => {
     it('should output empty on empty input', () => {
@@ -83,10 +92,20 @@ describe('Stylable postcss transform (General)', () => {
                     .root { -st-states: state; }
                     .class { -st-states: state; }
                 
-                    /* @rule(unknown state) :state */
+                    /* 
+                        @transform-error(unknown state) ${cssPseudoClassDiagnostics.UNKNOWN_STATE_USAGE(
+                            'state'
+                        )}
+                        @rule(unknown state) :state 
+                    */
                     :state {}
         
-                    /* @rule(unknown pseudo-element) ::class */
+                    /* 
+                        @transform-error(unknown pseudo-element) ${transformerStringDiagnostics.UNKNOWN_PSEUDO_ELEMENT(
+                            `class`
+                        )}
+                        @rule(unknown pseudo-element) ::class 
+                    */
                     ::class {}
                 `,
                 { stylableConfig: { experimentalSelectorInference: true } }


### PR DESCRIPTION
This PR changes the inferred selector context under the new `experimentalSelectorInference` flag.

The default inferred selector context is used in 2 cases
- the starting point for any selector 
- reset after a combinator (with `experimentalSelectorInference`)

Before this change the inferred selector used was the stylesheet root, and this PR changes it to be a universal selector (behind the flag), which means that custom-pseudo-element/class cannot be floating:

```css
.root {
    -st-states: state;
}
.part {}

/* all of these cases will now report unknown pseudo diagnostics and will not transform */
:state {}
::part {}
.x :state {}
.x ::part {}
```