### PR TITLE
fix(lsp): named import completions from native css

### DIFF
--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -837,7 +837,7 @@ function maybeResolveImport(
     meta: StylableMeta
 ): StylableMeta | null {
     let resolvedImport: StylableMeta | null = null;
-    if (importName && importName.endsWith('.st.css')) {
+    if (importName && importName.endsWith('.css')) {
         try {
             const imported = meta.getImportStatements().find((i) => i.request === importName)!;
             resolvedImport = stylable.fileProcessor.process(
@@ -886,7 +886,7 @@ export const StImportNamedCompletionProvider: CompletionProvider & {
                     }
                 });
 
-                if (importName.endsWith('.st.css')) {
+                if (importName.endsWith('.css')) {
                     const resolvedImport: StylableMeta | null = this.resolveImport(
                         importName,
                         stylable,

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -13,6 +13,37 @@ describe('LS: st-import', () => {
     afterEach('remove temp dir', () => {
         tempDir.remove();
     });
+    it('should suggest symbols from native css', () => {
+        const { service, carets, assertCompletions } = testLangService({
+            'native.css': `
+                .classA {}
+                .classB {
+                    --propA: 1;
+                }
+                :vars {
+                    varA: green;
+                }
+                @property --propB;
+            `,
+            'entry.st.css': `
+                @st-import [^top^] from './native.css';
+            `,
+        });
+        const entryPath = '/entry.st.css';
+        const entryCarets = carets[entryPath];
+
+        assertCompletions({
+            message: 'top',
+            actualList: service.onCompletion(entryPath, entryCarets.top),
+            expectedList: [
+                { label: 'classA' },
+                { label: 'classB' },
+                { label: 'varA' },
+                { label: '--propA' },
+                { label: '--propB' },
+            ],
+        });
+    });
     describe('specifier completion', () => {
         it('should suggest relative paths', () => {
             const { service, carets, assertCompletions, fs } = testLangService(

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -14,22 +14,30 @@ describe('LS: st-import', () => {
         tempDir.remove();
     });
     it('should suggest symbols from native css', () => {
-        const { service, carets, assertCompletions } = testLangService({
-            'native.css': `
-                .classA {}
-                .classB {
-                    --propA: 1;
-                }
-                :vars {
-                    varA: green;
-                }
-                @property --propB;
-            `,
-            'entry.st.css': `
-                @st-import [^top^] from './native.css';
-            `,
-        });
-        const entryPath = '/entry.st.css';
+        const { service, carets, assertCompletions, fs } = testLangService(
+            {
+                'native.css': `
+                    .classA {}
+                    .classB {
+                        --propA: 1;
+                    }
+                    :vars {
+                        varA: green;
+                    }
+                    @property --propB;
+                `,
+                'entry.st.css': `
+                    @st-import [^top^] from './native.css';
+                `,
+            },
+            {
+                // ToDo: this part of the completion provider still relays on old code
+                // that cannot run in memory-fs on windows. once the code is refactor this test
+                // should remove the "testOnNativeFileSystem" flag
+                testOnNativeFileSystem: tempDir.path,
+            }
+        );
+        const entryPath = fs.join(tempDir.path, 'entry.st.css');
         const entryCarets = carets[entryPath];
 
         assertCompletions({


### PR DESCRIPTION
This PR changes the completion provider to handle native css named import completions.