### PR TITLE
fix(lang-service): ensure .d.ts contains no internals

### DIFF
--- a/packages/language-service/src/lib-new/edit-time-parser.ts
+++ b/packages/language-service/src/lib-new/edit-time-parser.ts
@@ -7,18 +7,22 @@ import * as postcss from 'postcss';
 // ToDo: model single char tokens
 type PostcssToken = [string, string, number, number];
 
-type AnyNode =
+export type AnyNode =
     | Invalid
     | postcss.AnyNode
     | postcss.Container
     | postcss.Document
     | postcss.Declaration;
+
 export interface ParseForEditingResult {
-    ast: EditTimeParser['root'];
-    errorNodes: EditTimeParser['errorNodes'];
-    ambiguousNodes: EditTimeParser['ambiguousNodes'];
+    ast: postcss.Root;
+    errorNodes: Map<AnyNode, string[]>;
+    ambiguousNodes: Map<AnyNode, string[]>;
 }
-export function parseForEditing(source: string, { from = '' }: { from?: string } = {}) {
+export function parseForEditing(
+    source: string,
+    { from = '' }: { from?: string } = {}
+): ParseForEditingResult {
     const input = new postcss.Input(source, { from }); // ToDo: check why stringifier option doesn't work
     const parser = new EditTimeParser(input);
     parser.parse();


### PR DESCRIPTION
`EditTimeParser` extends `Parser`, which is defined in `typings/externals/index.d.ts` instead, use the exact types and ensure return type matches.

also exported `AnyNode`, as it's used in the return type.