### PR TITLE
fix: mixin of class from st-scope params

### DIFF
--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -1636,6 +1636,7 @@ describe(`features/st-mixin`, () => {
                     @st-scope .mix {
                         .part { color: green; }
                         .part2 { color: purple; }
+                        &:state { color: gold; }
                     }
                     @st-scope .mix.compoundAfter {
                         .part { color: blue; }
@@ -1643,16 +1644,23 @@ describe(`features/st-mixin`, () => {
                     @st-scope .compoundBefore.mix {
                         .part { color: pink; }
                     }
+                    @st-scope .mix, .notMix, .mix[extra] {
+                        .part { color: white; }
+                    }
+                    .mix {
+                        -st-states: state;
+                    }
                 `,
                 '/entry.st.css': `
                     @st-import [mix] from './mix.st.css';
 
                     /* 
-                        @rule[1] .entry__into .mix__part {color: green;} 
-                        @rule[2] .entry__into .mix__part2 {color: purple;} 
-                        @rule[3] .entry__into.mix__compoundAfter .mix__part {color: blue;} 
-                        @rule[4] .entry__into.mix__compoundBefore .mix__part {color: pink;} 
-                        
+                        @rule(descendant)[1] .entry__into .mix__part {color: green;} 
+                        @rule(descendant2)[2] .entry__into .mix__part2 {color: purple;} 
+                        @rule(state)[3] .entry__into.mix--state {color: gold;} 
+                        @rule(+after)[4] .entry__into.mix__compoundAfter .mix__part {color: blue;} 
+                        @rule(+before)[5] .entry__into.mix__compoundBefore .mix__part {color: pink;} 
+                        @rule(multi selector)[6] .entry__into .mix__part, .entry__into[extra] .mix__part {color: white;}
                     */
                     .into {
                         -st-mixin: mix;

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -1629,6 +1629,42 @@ describe(`features/st-mixin`, () => {
             shouldReportNoDiagnostics(meta);
         });
     });
+    describe('st-scope', () => {
+        it('should collect mixin from st-sope selector', () => {
+            const { sheets } = testStylableCore({
+                '/mix.st.css': `
+                    @st-scope .mix {
+                        .part { color: green; }
+                        .part2 { color: purple; }
+                    }
+                    @st-scope .mix.compoundAfter {
+                        .part { color: blue; }
+                    }
+                    @st-scope .compoundBefore.mix {
+                        .part { color: pink; }
+                    }
+                `,
+                '/entry.st.css': `
+                    @st-import [mix] from './mix.st.css';
+
+                    /* 
+                        @rule[1] .entry__into .mix__part {color: green;} 
+                        @rule[2] .entry__into .mix__part2 {color: purple;} 
+                        @rule[3] .entry__into.mix__compoundAfter .mix__part {color: blue;} 
+                        @rule[4] .entry__into.mix__compoundBefore .mix__part {color: pink;} 
+                        
+                    */
+                    .into {
+                        -st-mixin: mix;
+                    }
+                `,
+            });
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
+    });
     describe(`higher-level feature integrations`, () => {
         // ToDo: move to their higher level feature spec when created
         describe(`css-asset`, () => {


### PR DESCRIPTION
This PR fix a regression bug (worked in v4) that causes `mixin` that is defined as part of `@st-scope` params to be mixed incorrectly.
The issue causes the original mixin class to be added as part of the selector instead of being replaced by the context selector.

For example:
```css
@st-scope .mix {
    .x {}
}

.into {
    -st-mixin: mix;
}

/* should transforms into */
.into .x {}

/* but is incorrectly transformed into */
.into .mix .x {}
```