### PR TITLE
feat: support CSS nesting in CSS mixin

### DIFF
--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -29,3 +29,4 @@ export { testStylableCore } from './test-stylable-core';
 export { deindent } from './deindent';
 export { MinimalDocument, MinimalElement } from './minimal-dom';
 export { createTempDirectorySync, copyDirectory } from './native-temp-dir';
+export { assertAtRule, assertComment, assertDecl, assertRule } from './postcss-node-asserts';

--- a/packages/core-test-kit/src/postcss-node-asserts.ts
+++ b/packages/core-test-kit/src/postcss-node-asserts.ts
@@ -1,0 +1,26 @@
+import type * as postcss from 'postcss';
+
+export function assertRule(node: any, msg?: string): postcss.Rule {
+    if (node?.type !== 'rule') {
+        throw new Error('expected postcss rule' + (msg ? ` (${msg})` : ''));
+    }
+    return node;
+}
+export function assertAtRule(node: any, msg?: string): postcss.Rule {
+    if (node?.type !== 'atrule') {
+        throw new Error('expected postcss at-rule' + (msg ? ` (${msg})` : ''));
+    }
+    return node;
+}
+export function assertDecl(node: any, msg?: string): postcss.Declaration {
+    if (node?.type !== 'decl') {
+        throw new Error('expected postcss declaration' + (msg ? ` (${msg})` : ''));
+    }
+    return node;
+}
+export function assertComment(node: any, msg?: string): postcss.Comment {
+    if (node?.type !== 'comment') {
+        throw new Error('expected comment node' + (msg ? ` (${msg})` : ''));
+    }
+    return node;
+}

--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -422,7 +422,7 @@ function handleJSMixin(
         meta.source
     );
 
-    mergeRules(mixinRoot, config.rule, mixDef.data.originDecl, context.diagnostics);
+    mergeRules(mixinRoot, config.rule, mixDef.data.originDecl, context.diagnostics, true);
 }
 
 function handleCSSMixin(
@@ -498,11 +498,23 @@ function handleCSSMixin(
     }
 
     if (roots.length === 1) {
-        mergeRules(roots[0], config.rule, mixDef.data.originDecl, config.transformer.diagnostics);
+        mergeRules(
+            roots[0],
+            config.rule,
+            mixDef.data.originDecl,
+            config.transformer.diagnostics,
+            false
+        );
     } else if (roots.length > 1) {
         const mixinRoot = postcss.root();
         roots.forEach((root) => mixinRoot.prepend(...root.nodes));
-        mergeRules(mixinRoot, config.rule, mixDef.data.originDecl, config.transformer.diagnostics);
+        mergeRules(
+            mixinRoot,
+            config.rule,
+            mixDef.data.originDecl,
+            config.transformer.diagnostics,
+            false
+        );
     }
 }
 

--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -5,7 +5,7 @@ import * as STCustomSelector from './st-custom-selector';
 import * as STVar from './st-var';
 import type { ElementSymbol } from './css-type';
 import type { ClassSymbol } from './css-class';
-import { createSubsetAst } from '../helpers/rule';
+import { createSubsetAst, isStMixinMarker } from '../helpers/rule';
 import { scopeNestedSelector } from '../helpers/selector';
 import { mixinHelperDiagnostics, parseStMixin, parseStPartialMixin } from '../helpers/mixin';
 import { resolveArgumentsValue } from '../functions';
@@ -110,6 +110,17 @@ export const diagnostics = {
 // HOOKS
 
 export const hooks = createFeature({
+    transformSelectorNode({ selectorContext, node }) {
+        const isMarker = isStMixinMarker(node);
+        if (isMarker) {
+            selectorContext.setNextSelectorScope(
+                selectorContext.inferredSelectorMixin,
+                node,
+                node.value
+            );
+        }
+        return isMarker;
+    },
     transformLastPass({ context, ast, transformer, cssVarsMapping, path }) {
         ast.walkRules((rule) => appendMixins(context, transformer, rule, cssVarsMapping, path));
     },

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -146,14 +146,13 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule | postcs
 
 export const stMixinMarker = 'st-mixin-marker';
 export const isStMixinMarker = (node: SelectorNode) =>
-    node.type === 'pseudo_class' && node.value === stMixinMarker;
+    node.type === 'attribute' && node.value === stMixinMarker;
 function replaceTargetWithMixinAnchor(selectorNode: Selector, prefixType: ImmutableSelectorNode) {
     walkSelector(selectorNode, (node) => {
         if (matchTypeAndValue(node, prefixType)) {
             convertToSelector(node).nodes = [
                 {
-                    type: `pseudo_class`,
-                    colonComments: [],
+                    type: `attribute`,
                     value: stMixinMarker,
                     start: node.start,
                     end: node.end,

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -48,7 +48,7 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule | postcs
     const prefixType = prefixSelectorList[0].nodes[0];
     const containsPrefix = containsMatchInFirstChunk.bind(null, prefixType);
     const mixinRoot = mixinTarget ? mixinTarget : postcss.root();
-    [...root.nodes].forEach((node) => {
+    root.nodes.forEach((node) => {
         if (node.type === 'decl') {
             mixinTarget?.append(node.clone());
         } else if (

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -12,6 +12,7 @@ import {
     ImmutableSelectorNode,
     groupCompoundSelectors,
     SelectorList,
+    SelectorNode,
 } from '@tokey/css-selector-parser';
 import * as postcss from 'postcss';
 import { transformInlineCustomSelectors } from './custom-selector';
@@ -70,7 +71,7 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule>(
                         if (!isRoot) {
                             selectorNode = fixChunkOrdering(selectorNode, prefixType);
                         }
-                        replaceTargetWithNesting(selectorNode, prefixType);
+                        replaceTargetWithMixinAnchor(selectorNode, prefixType);
                         return selectorNode;
                     })
                 );
@@ -99,7 +100,7 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule>(
                                 if (!isRoot) {
                                     selectorNode = fixChunkOrdering(selectorNode, prefixType);
                                 }
-                                replaceTargetWithNesting(selectorNode, prefixType);
+                                replaceTargetWithMixinAnchor(selectorNode, prefixType);
                                 return selectorNode;
                             })
                         );
@@ -130,13 +131,15 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule>(
     return mixinRoot as T;
 }
 
-function replaceTargetWithNesting(selectorNode: Selector, prefixType: ImmutableSelectorNode) {
+export const stMixinMarker = 'st-mixin-marker';
+function replaceTargetWithMixinAnchor(selectorNode: Selector, prefixType: ImmutableSelectorNode) {
     walkSelector(selectorNode, (node) => {
         if (matchTypeAndValue(node, prefixType)) {
             convertToSelector(node).nodes = [
                 {
-                    type: `nesting`,
-                    value: `&`,
+                    type: `pseudo_class`,
+                    colonComments: [],
+                    value: stMixinMarker,
                     start: node.start,
                     end: node.end,
                 },

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -132,6 +132,8 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule>(
 }
 
 export const stMixinMarker = 'st-mixin-marker';
+export const isStMixinMarker = (node: SelectorNode) =>
+    node.type === 'pseudo_class' && node.value === stMixinMarker;
 function replaceTargetWithMixinAnchor(selectorNode: Selector, prefixType: ImmutableSelectorNode) {
     walkSelector(selectorNode, (node) => {
         if (matchTypeAndValue(node, prefixType)) {

--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -175,7 +175,8 @@ export function isCompRoot(name: string) {
 export function scopeNestedSelector(
     scopeSelectorAst: ImmutableSelectorList,
     nestedSelectorAst: ImmutableSelectorList,
-    rootScopeLevel = false
+    rootScopeLevel = false,
+    isAnchor?: (node: SelectorNode) => boolean
 ): { selector: string; ast: SelectorList } {
     const resultSelectors: SelectorList = [];
     nestedSelectorAst.forEach((targetAst) => {
@@ -203,7 +204,7 @@ export function scopeNestedSelector(
                 : false;
             let nestedMixRoot = false;
             walkSelector(outputAst, (node, i, nodes) => {
-                if (node.type === 'nesting') {
+                if (isAnchor ? isAnchor(node) : node.type === 'nesting') {
                     nestedMixRoot = true;
                     nodes.splice(i, 1, {
                         type: `selector`,

--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -167,6 +167,7 @@ export function isCompRoot(name: string) {
     return name.charAt(0).match(/[A-Z]/);
 }
 
+const isNestedNode = (node: SelectorNode) => node.type === 'nesting';
 /**
  * combine 2 selector lists.
  * - add each scoping selector at the begging of each nested selector
@@ -176,7 +177,7 @@ export function scopeNestedSelector(
     scopeSelectorAst: ImmutableSelectorList,
     nestedSelectorAst: ImmutableSelectorList,
     rootScopeLevel = false,
-    isAnchor?: (node: SelectorNode) => boolean
+    isAnchor: (node: SelectorNode) => boolean = isNestedNode
 ): { selector: string; ast: SelectorList } {
     const resultSelectors: SelectorList = [];
     nestedSelectorAst.forEach((targetAst) => {
@@ -204,7 +205,7 @@ export function scopeNestedSelector(
                 : false;
             let nestedMixRoot = false;
             walkSelector(outputAst, (node, i, nodes) => {
-                if (isAnchor ? isAnchor(node) : node.type === 'nesting') {
+                if (isAnchor(node)) {
                     nestedMixRoot = true;
                     nodes.splice(i, 1, {
                         type: `selector`,

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -585,23 +585,26 @@ export class StylableTransformer {
                 }
             }
         } else if (node.type === 'pseudo_class') {
-            STMixin.hooks.transformSelectorNode({
+            const isCustomSelector = STCustomSelector.hooks.transformSelectorNode({
                 context: transformerContext,
                 selectorContext: context,
                 node,
-            }) ||
-                STCustomSelector.hooks.transformSelectorNode({
-                    context: transformerContext,
-                    selectorContext: context,
-                    node,
-                }) ||
+            });
+            if (!isCustomSelector) {
                 CSSPseudoClass.hooks.transformSelectorNode({
                     context: transformerContext,
                     selectorContext: context,
                     node,
                 });
+            }
         } else if (node.type === `nesting`) {
             context.setNextSelectorScope(context.inferredSelectorNest, node, node.value);
+        } else if (node.type === 'attribute') {
+            STMixin.hooks.transformSelectorNode({
+                context: transformerContext,
+                selectorContext: context,
+                node,
+            });
         }
     }
 }

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -193,7 +193,7 @@ export class StylableTransformer {
         stVarOverride: Record<string, string> = this.defaultStVarOverride,
         path: string[] = [],
         mixinTransform = false,
-        inferredNestSelector?: InferredSelector
+        inferredSelectorMixin?: InferredSelector
     ) {
         if (meta.type !== 'stylable') {
             return;
@@ -340,8 +340,8 @@ export class StylableTransformer {
                     meta,
                     node.selector,
                     node,
-                    (currentParent && this.containerInferredSelectorMap.get(currentParent)) ||
-                        inferredNestSelector
+                    currentParent && this.containerInferredSelectorMap.get(currentParent),
+                    inferredSelectorMixin
                 );
                 // save results
                 this.containerInferredSelectorMap.set(node, inferredSelector);
@@ -413,6 +413,7 @@ export class StylableTransformer {
         selector: string,
         selectorNode?: postcss.Rule | postcss.AtRule,
         inferredNestSelector?: InferredSelector,
+        inferredMixinSelector?: InferredSelector,
         unwrapGlobals = false
     ): {
         selector: string;
@@ -425,7 +426,8 @@ export class StylableTransformer {
             parseSelectorWithCache(selector, { clone: true }),
             selectorNode || postcss.rule({ selector }),
             selector,
-            inferredNestSelector
+            inferredNestSelector,
+            inferredMixinSelector
         );
         const targetSelectorAst = this.scopeSelectorAst(context);
         if (unwrapGlobals) {
@@ -443,7 +445,8 @@ export class StylableTransformer {
         selectorAst: SelectorList,
         selectorNode: postcss.Rule | postcss.AtRule,
         selectorStr?: string,
-        selectorNest?: InferredSelector
+        selectorNest?: InferredSelector,
+        selectorMixin?: InferredSelector
     ) {
         return new ScopeContext(
             meta,
@@ -453,6 +456,7 @@ export class StylableTransformer {
             this.scopeSelectorAst.bind(this),
             this,
             selectorNest,
+            selectorMixin,
             undefined,
             selectorStr
         );
@@ -581,18 +585,21 @@ export class StylableTransformer {
                 }
             }
         } else if (node.type === 'pseudo_class') {
-            const isCustomSelector = STCustomSelector.hooks.transformSelectorNode({
+            STMixin.hooks.transformSelectorNode({
                 context: transformerContext,
                 selectorContext: context,
                 node,
-            });
-            if (!isCustomSelector) {
+            }) ||
+                STCustomSelector.hooks.transformSelectorNode({
+                    context: transformerContext,
+                    selectorContext: context,
+                    node,
+                }) ||
                 CSSPseudoClass.hooks.transformSelectorNode({
                     context: transformerContext,
                     selectorContext: context,
                     node,
                 });
-            }
         } else if (node.type === `nesting`) {
             context.setNextSelectorScope(context.inferredSelectorNest, node, node.value);
         }
@@ -990,6 +997,7 @@ export class ScopeContext {
         public scopeSelectorAst: StylableTransformer['scopeSelectorAst'],
         private transformer: StylableTransformer,
         inferredSelectorNest?: InferredSelector,
+        public inferredSelectorMixin?: InferredSelector,
         inferredSelectorContext?: InferredSelector,
         selectorStr?: string
     ) {
@@ -1072,6 +1080,7 @@ export class ScopeContext {
             this.scopeSelectorAst,
             this.transformer,
             this.inferredSelectorNest,
+            this.inferredSelectorMixin,
             selectorContext || this.inferredSelectorContext
         );
         ctx.transform = this.transform;

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -62,9 +62,9 @@ export function mergeRules(
         // TODO: handle rules before and after decl on entry
         mixinAst.nodes.slice().forEach((node) => {
             if (node === mixinRoot) {
-                node.walkDecls((node) => {
-                    rule.insertBefore(mixinDecl, node);
-                });
+                for (const nested of [...node.nodes]) {
+                    rule.insertBefore(mixinDecl, nested);
+                }
             } else if (node.type === 'decl') {
                 rule.insertBefore(mixinDecl, node);
             } else if (node.type === 'rule' || node.type === 'atrule') {

--- a/packages/core/src/stylable-utils.ts
+++ b/packages/core/src/stylable-utils.ts
@@ -27,7 +27,7 @@ export function mergeRules(
 ) {
     let mixinRoot: postcss.Rule | null | 'NoRoot' = null;
     const nestedInKeyframes = isChildOfAtRule(rule, `keyframes`);
-    const anchorSelector = useNestingAsAnchor ? '&' : ':' + stMixinMarker;
+    const anchorSelector = useNestingAsAnchor ? '&' : '[' + stMixinMarker + ']';
     const anchorNodeCheck = useNestingAsAnchor ? undefined : isStMixinMarker;
     mixinAst.walkRules((mixinRule: postcss.Rule) => {
         if (isChildOfAtRule(mixinRule, 'keyframes')) {

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -185,7 +185,7 @@ export class Stylable {
     ): { selector: string; resolved: ResolvedElement[][] } {
         const meta = typeof pathOrMeta === `string` ? this.analyze(pathOrMeta) : pathOrMeta;
         const transformer = this.createTransformer(options);
-        const r = transformer.scopeSelector(meta, selector, undefined, undefined, true);
+        const r = transformer.scopeSelector(meta, selector, undefined, undefined, undefined, true);
         return {
             selector: r.selector,
             resolved: r.elements,

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -314,10 +314,10 @@ describe(`features/st-mixin`, () => {
         const { sheets } = testStylableCore(`
             .mix {
                 id: mix;
-                &:hover {
+                &:hover.mix {
                     id: hover;
                 }
-                @any-atrule {
+                @media {
                     id: atrule;
                 }
             }
@@ -335,9 +335,9 @@ describe(`features/st-mixin`, () => {
         const firstMixedDecl = assertDecl(mixedIntoRule.nodes[0], 'id: mix');
         expect(firstMixedDecl.prop).to.eql('id');
         expect(firstMixedDecl.value).to.eql('mix');
-        const nestHoverRule = assertRule(mixedIntoRule.nodes[1], '&:hover');
-        expect(nestHoverRule.selector).to.eql('&:hover');
-        const nestAtRule = assertAtRule(mixedIntoRule.nodes[2], '@any-atrule');
+        const nestHoverRule = assertRule(mixedIntoRule.nodes[1], '&:hover.mix');
+        expect(nestHoverRule.selector).to.eql('.entry__root&:hover');
+        const nestAtRule = assertAtRule(mixedIntoRule.nodes[2], '@media');
         const nestInAtRule = assertDecl(nestAtRule.nodes[0], 'id: atrule');
         expect(nestInAtRule.prop).to.eql('id');
         expect(nestInAtRule.value).to.eql('atrule');

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -307,6 +307,25 @@ describe(`features/st-mixin`, () => {
             }
         );
     });
+    it.skip('should support CSS nesting as part of a mixin', () => {
+        // ToDo: support mixin of CSS nesting (support in "mergeRules")
+        const { sheets } = testStylableCore(`
+            .mix {
+                id: mix;
+                &:hover {
+                    id: hover;
+                }
+            }
+
+            .root {
+                -st-mixin: mix;
+            }
+        `);
+
+        const { meta } = sheets['/entry.st.css'];
+
+        shouldReportNoDiagnostics(meta);
+    });
     describe(`st-import`, () => {
         it(`should mix imported class`, () => {
             const { sheets } = testStylableCore({

--- a/packages/core/test/helpers/rule.spec.ts
+++ b/packages/core/test/helpers/rule.spec.ts
@@ -57,29 +57,29 @@ describe(`helpers/rule`, () => {
             );
 
             const expected = [
-                { selector: ':st-mixin-marker .x' },
-                { selector: ':st-mixin-marker::x' },
-                { selector: ':st-mixin-marker[data]' },
-                { selector: ':st-mixin-marker:hover' },
-                { selector: ':st-mixin-marker' },
-                { selector: ':st-mixin-marker' },
-                { selector: ':st-mixin-marker.x' },
-                { selector: ':st-mixin-marker.x' },
-                { selector: ':st-mixin-marker.x.y::i.z:hover' },
-                { selector: ':st-mixin-marker:hover .y' },
-                { selector: ':st-mixin-marker .y' },
-                { selector: ':st-mixin-marker:not(.x)' },
-                { selector: ':st-mixin-marker :st-mixin-marker.x:hover' },
-                { selector: ':st-mixin-marker.y.x' },
-                { selector: ':st-mixin-marker:st-mixin-marker' }, // TODO: check if possible
-                { selector: ':not(:st-mixin-marker) :st-mixin-marker' },
-                { selector: ':nth-child(5n - 1 of :st-mixin-marker)' },
-                { selector: ':nth-child(5n - 2 of :st-mixin-marker, :st-mixin-marker)' },
-                { selector: ':nth-child(5n - 3 of :st-mixin-marker, .x, :st-mixin-marker)' }, // ToDo: check if to remove unrelated nested selectors
-                { selector: ':st-mixin-marker' },
+                { selector: '[st-mixin-marker] .x' },
+                { selector: '[st-mixin-marker]::x' },
+                { selector: '[st-mixin-marker][data]' },
+                { selector: '[st-mixin-marker]:hover' },
+                { selector: '[st-mixin-marker]' },
+                { selector: '[st-mixin-marker]' },
+                { selector: '[st-mixin-marker].x' },
+                { selector: '[st-mixin-marker].x' },
+                { selector: '[st-mixin-marker].x.y::i.z:hover' },
+                { selector: '[st-mixin-marker]:hover .y' },
+                { selector: '[st-mixin-marker] .y' },
+                { selector: '[st-mixin-marker]:not(.x)' },
+                { selector: '[st-mixin-marker] [st-mixin-marker].x:hover' },
+                { selector: '[st-mixin-marker].y.x' },
+                { selector: '[st-mixin-marker][st-mixin-marker]' }, // TODO: check if possible
+                { selector: ':not([st-mixin-marker]) [st-mixin-marker]' },
+                { selector: ':nth-child(5n - 1 of [st-mixin-marker])' },
+                { selector: ':nth-child(5n - 2 of [st-mixin-marker], [st-mixin-marker])' },
+                { selector: ':nth-child(5n - 3 of [st-mixin-marker], .x, [st-mixin-marker])' }, // ToDo: check if to remove unrelated nested selectors
+                { selector: '[st-mixin-marker]' },
                 {
-                    selector: ':st-mixin-marker[out]',
-                    nodes: [{ selector: ':st-mixin-marker[in]' }],
+                    selector: '[st-mixin-marker][out]',
+                    nodes: [{ selector: '[st-mixin-marker][in]' }],
                 },
             ];
 
@@ -99,7 +99,7 @@ describe(`helpers/rule`, () => {
 
             const expected = [
                 { selector: ':global(.x)' },
-                { selector: ':global(.x) :st-mixin-marker' },
+                { selector: ':global(.x) [st-mixin-marker]' },
             ];
 
             testMatcher(expected, res.nodes);
@@ -119,14 +119,14 @@ describe(`helpers/rule`, () => {
             );
 
             const expected = [
-                { selector: ':st-mixin-marker' },
-                { selector: ':st-mixin-marker:hover' },
+                { selector: '[st-mixin-marker]' },
+                { selector: '[st-mixin-marker]:hover' },
                 {
                     type: 'atrule',
                     params: '(max-width: 300px)',
                     nodes: [
-                        { selector: ':st-mixin-marker' },
-                        { selector: ':st-mixin-marker:hover' },
+                        { selector: '[st-mixin-marker]' },
+                        { selector: '[st-mixin-marker]:hover' },
                     ],
                 },
             ];
@@ -145,7 +145,7 @@ describe(`helpers/rule`, () => {
                 '.i'
             );
 
-            const expected = [{ selector: ':st-mixin-marker' }];
+            const expected = [{ selector: '[st-mixin-marker]' }];
 
             testMatcher(expected, res.nodes);
         });

--- a/packages/core/test/helpers/rule.spec.ts
+++ b/packages/core/test/helpers/rule.spec.ts
@@ -49,6 +49,9 @@ describe(`helpers/rule`, () => {
 
                 /*not extracted*/
                 .x .i{}
+
+                /*nesting*/
+                .i[out] { .i[in] {} }
             `),
                 '.i'
             );
@@ -74,6 +77,10 @@ describe(`helpers/rule`, () => {
                 { selector: ':nth-child(5n - 2 of :st-mixin-marker, :st-mixin-marker)' },
                 { selector: ':nth-child(5n - 3 of :st-mixin-marker, .x, :st-mixin-marker)' }, // ToDo: check if to remove unrelated nested selectors
                 { selector: ':st-mixin-marker' },
+                {
+                    selector: ':st-mixin-marker[out]',
+                    nodes: [{ selector: ':st-mixin-marker[in]' }],
+                },
             ];
 
             testMatcher(expected, res.nodes);

--- a/packages/core/test/helpers/rule.spec.ts
+++ b/packages/core/test/helpers/rule.spec.ts
@@ -54,26 +54,26 @@ describe(`helpers/rule`, () => {
             );
 
             const expected = [
-                { selector: '& .x' },
-                { selector: '&::x' },
-                { selector: '&[data]' },
-                { selector: '&:hover' },
-                { selector: '&' },
-                { selector: '&' },
-                { selector: '&.x' },
-                { selector: '&.x' },
-                { selector: '&.x.y::i.z:hover' },
-                { selector: '&:hover .y' },
-                { selector: '& .y' },
-                { selector: '&:not(.x)' },
-                { selector: '& &.x:hover' },
-                { selector: '&.y.x' },
-                { selector: '&&' }, // TODO: check if possible
-                { selector: ':not(&) &' },
-                { selector: ':nth-child(5n - 1 of &)' },
-                { selector: ':nth-child(5n - 2 of &, &)' },
-                { selector: ':nth-child(5n - 3 of &, .x, &)' }, // ToDo: check if to remove unrelated nested selectors
-                { selector: '&' },
+                { selector: ':st-mixin-marker .x' },
+                { selector: ':st-mixin-marker::x' },
+                { selector: ':st-mixin-marker[data]' },
+                { selector: ':st-mixin-marker:hover' },
+                { selector: ':st-mixin-marker' },
+                { selector: ':st-mixin-marker' },
+                { selector: ':st-mixin-marker.x' },
+                { selector: ':st-mixin-marker.x' },
+                { selector: ':st-mixin-marker.x.y::i.z:hover' },
+                { selector: ':st-mixin-marker:hover .y' },
+                { selector: ':st-mixin-marker .y' },
+                { selector: ':st-mixin-marker:not(.x)' },
+                { selector: ':st-mixin-marker :st-mixin-marker.x:hover' },
+                { selector: ':st-mixin-marker.y.x' },
+                { selector: ':st-mixin-marker:st-mixin-marker' }, // TODO: check if possible
+                { selector: ':not(:st-mixin-marker) :st-mixin-marker' },
+                { selector: ':nth-child(5n - 1 of :st-mixin-marker)' },
+                { selector: ':nth-child(5n - 2 of :st-mixin-marker, :st-mixin-marker)' },
+                { selector: ':nth-child(5n - 3 of :st-mixin-marker, .x, :st-mixin-marker)' }, // ToDo: check if to remove unrelated nested selectors
+                { selector: ':st-mixin-marker' },
             ];
 
             testMatcher(expected, res.nodes);
@@ -90,7 +90,10 @@ describe(`helpers/rule`, () => {
                 true
             );
 
-            const expected = [{ selector: ':global(.x)' }, { selector: ':global(.x) &' }];
+            const expected = [
+                { selector: ':global(.x)' },
+                { selector: ':global(.x) :st-mixin-marker' },
+            ];
 
             testMatcher(expected, res.nodes);
         });
@@ -109,12 +112,15 @@ describe(`helpers/rule`, () => {
             );
 
             const expected = [
-                { selector: '&' },
-                { selector: '&:hover' },
+                { selector: ':st-mixin-marker' },
+                { selector: ':st-mixin-marker:hover' },
                 {
                     type: 'atrule',
                     params: '(max-width: 300px)',
-                    nodes: [{ selector: '&' }, { selector: '&:hover' }],
+                    nodes: [
+                        { selector: ':st-mixin-marker' },
+                        { selector: ':st-mixin-marker:hover' },
+                    ],
                 },
             ];
 
@@ -132,7 +138,7 @@ describe(`helpers/rule`, () => {
                 '.i'
             );
 
-            const expected = [{ selector: '&' }];
+            const expected = [{ selector: ':st-mixin-marker' }];
 
             testMatcher(expected, res.nodes);
         });

--- a/packages/core/test/helpers/selector.spec.ts
+++ b/packages/core/test/helpers/selector.spec.ts
@@ -135,6 +135,137 @@ describe(`helpers/selector`, () => {
             });
         }
     });
+    describe(`scopeNestedSelector with custom anchor`, () => {
+        const tests: Array<{
+            label: string;
+            scope: string;
+            nested: string;
+            expected: string;
+            only?: boolean;
+        }> = [
+            {
+                label: '+ no anchor selector',
+                scope: '.a',
+                nested: '.x',
+                expected: '.a .x',
+            },
+            {
+                label: '+ complex selector with no anchor selector',
+                scope: '.a',
+                nested: '.x:hover',
+                expected: '.a .x:hover',
+            },
+            {
+                label: '+ anchor selector',
+                scope: '.a',
+                nested: ':xxx',
+                expected: '.a',
+            },
+            {
+                label: 'compound scope + anchor selector',
+                scope: '.a:hover',
+                nested: ':xxx',
+                expected: '.a:hover',
+            },
+            {
+                label: 'compound scope + anchor selector (2)',
+                scope: '.a.x',
+                nested: ':xxx',
+                expected: '.a.x',
+            },
+            {
+                label: 'complex scope + anchor selector',
+                scope: '.a.x .b:hover',
+                nested: ':xxx',
+                expected: '.a.x .b:hover',
+            },
+            {
+                label: '+ anchor selector with compound class',
+                scope: '.a',
+                nested: ':xxx.x',
+                expected: '.a.x',
+            },
+            {
+                label: '+ anchor selector with complex class',
+                scope: '.a',
+                nested: ':xxx.x .y',
+                expected: '.a.x .y',
+            },
+            {
+                label: 'complex scope + anchor selector with complex class',
+                scope: '.a .b',
+                nested: ':xxx.x .y',
+                expected: '.a .b.x .y',
+            },
+            {
+                label: '+ multiple anchor selector',
+                scope: '.a',
+                nested: ':xxx :xxx',
+                expected: '.a .a',
+            },
+            {
+                label: 'multi scopes + multiple anchor selectors',
+                scope: '.a, .b',
+                nested: ':xxx :xxx :xxx',
+                expected: '.a .a .a, .b .b .b',
+            },
+            {
+                label: 'multi compound scopes + multi anchor selector',
+                scope: '.a:hover, .b:focus',
+                nested: ':xxx :xxx :xxx',
+                expected: '.a:hover .a:hover .a:hover, .b:focus .b:focus .b:focus',
+            },
+            {
+                label: '+ global before',
+                scope: '.a',
+                nested: ':global(.x) :xxx',
+                expected: ':global(.x) .a',
+            },
+            {
+                label: '+ nested anchor selector',
+                scope: '.a',
+                nested: ':not(:xxx)',
+                expected: ':not(.a)',
+            },
+            {
+                label: 'multi scopes + nested anchor selector',
+                scope: '.a, .b',
+                nested: ':not(:xxx)',
+                expected: ':not(.a), :not(.b)',
+            },
+            {
+                label: '+ nested deep anchor selector',
+                scope: '.a',
+                nested: ':not(:xxx, :not(:xxx))',
+                expected: ':not(.a, :not(.a))',
+            },
+            {
+                label: '+ nested nth of anchor selector',
+                scope: '.a',
+                nested: ':nth-child(5n+2 of :xxx)',
+                expected: ':nth-child(5n+2 of .a)',
+            },
+            {
+                label: 'nesting scope persists',
+                scope: '&',
+                nested: '.no-parent-re-scoping',
+                expected: '& .no-parent-re-scoping',
+            },
+        ];
+
+        for (const { only, scope, expected, nested } of tests) {
+            const test = only ? it.only : it;
+            test(`apply "${scope}" on "${nested}" should output "${expected}"`, () => {
+                const { selector } = scopeNestedSelector(
+                    parseSelector(scope),
+                    parseSelector(nested),
+                    false,
+                    (node) => node.type === 'pseudo_class' && node.value === 'xxx'
+                );
+                expect(selector).to.equal(expected);
+            });
+        }
+    });
     describe(`isSimpleSelector`, () => {
         it(`should return simple for class selector`, () => {
             const result = isSimpleSelector(`.a`);

--- a/packages/language-service/test/test-kit/postcss-node-asserts.ts
+++ b/packages/language-service/test/test-kit/postcss-node-asserts.ts
@@ -1,33 +1,9 @@
 import type { Invalid } from '@stylable/language-service/dist/lib-new/invalid-node';
-import type * as postcss from 'postcss';
+export { assertAtRule, assertComment, assertDecl, assertRule } from '@stylable/core-test-kit';
 
-export function assertRule(node: any, msg?: string): postcss.Rule {
-    if (node?.type !== 'rule') {
-        throw new Error('expected postcss rule' + (msg ? ` (${msg})` : ''));
-    }
-    return node;
-}
-export function assertAtRule(node: any, msg?: string): postcss.Rule {
-    if (node?.type !== 'atrule') {
-        throw new Error('expected postcss at-rule' + (msg ? ` (${msg})` : ''));
-    }
-    return node;
-}
-export function assertDecl(node: any, msg?: string): postcss.Declaration {
-    if (node?.type !== 'decl') {
-        throw new Error('expected postcss declaration' + (msg ? ` (${msg})` : ''));
-    }
-    return node;
-}
 export function assertInvalid(node: any, msg?: string): Invalid {
     if (node?.type !== 'invalid') {
         throw new Error('expected invalid node' + (msg ? ` (${msg})` : ''));
-    }
-    return node;
-}
-export function assertComment(node: any, msg?: string): postcss.Comment {
-    if (node?.type !== 'comment') {
-        throw new Error('expected comment node' + (msg ? ` (${msg})` : ''));
     }
     return node;
 }


### PR DESCRIPTION
## Custom marker from mixin anchor

Up until now, when a mixin fragment was created, Stylable used a nesting selector (`&`) internally to mark the mixin anchor that would be fused in transformation to the mixin target. This is conflicting with native CSS nesting in case the mixin has a nesting selector in it's source.

This PR refactors the internal selector that is used to mark the mixin anchor from `&` to `[st-mixin-marker]`, solving an issue with mixins that contain CSS nesting.

## Collect and merge nested rules

- Merges the transformed mixin fragment for nested rules
- fix: merge nested at-rules instead of flattening deep declarations

## NO NESTING IN JS MIXINS

JS mixin uses `&` to reference the mix target anchor, which is a public API that cannot change. To support nesting in JS mixin, Stylable would have to offer a new mixin API that would provide some other way of referencing the mixin anchor.