### PR TITLE
feat: typed css property reference lookup on known types

### DIFF
--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -186,7 +186,10 @@ export function processDeclarationValue(
                 const formatter = resolvedSymbols.js[value];
                 const formatterArgs = getFormatterArgs(parsedNode);
                 try {
-                    parsedNode.resolvedValue = formatter.symbol.apply(null, formatterArgs);
+                    parsedNode.resolvedValue = formatter.symbol.apply(
+                        { meta, evaluator, parsedValue, node, initialNode },
+                        formatterArgs
+                    );
                     if (evaluator.valueHook && typeof parsedNode.resolvedValue === 'string') {
                         parsedNode.resolvedValue = evaluator.valueHook(
                             parsedNode.resolvedValue,

--- a/packages/core/test/functions.spec.ts
+++ b/packages/core/test/functions.spec.ts
@@ -44,6 +44,66 @@ describe('Stylable functions (native, formatter and variable)', () => {
             expect(rule.nodes[0].toString()).to.equal('background: green');
         });
 
+        it('js formatter *this* context ', () => {
+            const result = generateStylableRoot({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'ns',
+                        content: `
+                            :import {
+                                -st-from: "./formatter";
+                                -st-default: scopeKeys;
+                            }
+                            .container {
+                                --keys: scopeKeys();
+                            }
+                        `,
+                    },
+                    '/formatter.js': {
+                        content: `
+                            module.exports = function() {
+                                return Object.keys(this).join(', ');
+                            }
+                        `,
+                    },
+                },
+            });
+
+            const rule = result.nodes[0] as postcss.Rule;
+            expect(rule.nodes[0].toString()).to.equal('--ns-keys: meta, evaluator, parsedValue, node, initialNode');
+        });
+
+        it('js formatter *this* context ', () => {
+            const result = generateStylableRoot({
+                entry: `/style.st.css`,
+                files: {
+                    '/style.st.css': {
+                        namespace: 'ns',
+                        content: `
+                            :import {
+                                -st-from: "./formatter";
+                                -st-default: ns;
+                            }
+                            .container {
+                                --animation-name: ns(kf);
+                            }
+                        `,
+                    },
+                    '/formatter.js': {
+                        content: `
+                            module.exports = function(name) {
+                                return this.meta.namespace + '__' + name;
+                            }
+                        `,
+                    },
+                },
+            });
+
+            const rule = result.nodes[0] as postcss.Rule;
+            expect(rule.nodes[0].toString()).to.equal('--ns-animation-name: ns__kf');
+        });
+
         it('apply simple js formatter with quote wrapped args', () => {
             const result = generateStylableRoot({
                 entry: `/style.st.css`,


### PR DESCRIPTION
## Previous direction:

This feature adds to the js formatter function call this caller.
This will allow us to implement a "namespace" function within a formatter. 

```css
@keyframes a {}
.root {
   --name: a;
   animation-name: var(--name);
}
```
This will not apply the animation to the root because the `--name` var is not name spaced
After this change users would be able to implement a solution.

```js
function ns(name) {
    return this.meta.namespace + '__' + name;
}
```  

- [ ] port to v4?
- [ ] less more context?
- [ ] docs


## New direction: 
This will hinder optimizations in the future. because we don't know the location of the replacements. and does not open full experience for the type of the value.

Another approach could be to type a property with `<'animation-name'>` or similar tagging and then follow it and transfrom
```css
@property --name {
   syntax: "<'animation-name'>"
   ...
}  
@st-import [keyframes(a)] from ".";
.root {
  --name: a;
}
```

will lookup for a symbol that match the type. or valid custom property reference. 
