### PR TITLE
fix: edit parser unclosed at-rule bug

### DIFF
--- a/packages/language-service/src/lib-new/ast-from-position.ts
+++ b/packages/language-service/src/lib-new/ast-from-position.ts
@@ -74,7 +74,7 @@ export interface AstLocationResult {
 }
 function isClosed(node: postcss.AnyNode) {
     const isLast = node.parent && node.parent.nodes[node.parent.nodes.length - 1] === node;
-    if (node.type === 'decl') {
+    if (node.type === 'decl' || (node.type === 'atrule' && !node.nodes)) {
         return isLast ? node.parent?.raws.semicolon : true;
     }
     return true;
@@ -269,7 +269,7 @@ function checkDeclValue(node: postcss.AnyNode, checkContext: CheckContext) {
 function checkAtRuleParams(node: postcss.AnyNode, checkContext: CheckContext) {
     if (isAtRule(node)) {
         const valueStart =
-            checkContext.baseNodeOffset + 1 + node.name.length + node.raws.afterName!.length;
+            checkContext.baseNodeOffset + 1 + node.name.length + (node.raws.afterName!.length || 1);
         const valueEnd = valueStart + node.params.length;
         const isInParams = checkValue({
             type: 'atRuleParams',

--- a/packages/language-service/test/lib-new/ast-from-position.spec.ts
+++ b/packages/language-service/test/lib-new/ast-from-position.spec.ts
@@ -1080,5 +1080,42 @@ describe('ast-from-position', () => {
             expect(declValue, 'declValue').to.eql(undefined);
             expect(atRuleParams, 'atRuleParams').to.eql(undefined);
         });
+        it('should get unclosed at-rule cursor at name', () => {
+            const { position, parsed } = setupWithCursor(`@bookmark|`);
+
+            const { base, selector, declValue, atRuleParams } = getAstNodeAt(parsed, position);
+
+            // base level
+            expect(base.node.toString(), 'base target at-rule').to.eql('@bookmark');
+            expect(base.offsetInNode, 'base offset').to.eql(9);
+            expect(base.where, 'where').to.eql('atRuleName');
+            // unresolved levels
+            expect(selector, 'selector').to.eql(undefined);
+            expect(declValue, 'declValue').to.eql(undefined);
+            expect(atRuleParams, 'atRuleParams').to.eql(undefined);
+        });
+        it('should get unclosed at-rule cursor empty params', () => {
+            const { position, parsed } = setupWithCursor(`@bookmark |`);
+
+            const { base, selector, declValue, atRuleParams } = getAstNodeAt(parsed, position);
+
+            // base level
+            expect(base.node.toString(), 'base target at-rule').to.eql('@bookmark ');
+            expect(base.offsetInNode, 'base offset').to.eql(10);
+            expect(base.where, 'where').to.eql('atRuleParams');
+            // atrule-params level
+            expect(stringifyCSSValue(atRuleParams!.node as any), 'target params node').to.eql('');
+            expect(atRuleParams!.offsetInNode).to.eql(0);
+            assertNodes(atRuleParams!.parents, [
+                {
+                    desc: 'rule node',
+                    str: '@bookmark ',
+                },
+            ]);
+            expect(stringifyCSSValue(atRuleParams!.ast), 'params ast').to.eql('');
+            // unresolved levels
+            expect(selector, 'selector').to.eql(undefined);
+            expect(declValue, 'declValue').to.eql(undefined);
+        });
     });
 });

--- a/packages/language-service/test/lib-new/edit-time-parser.spec.ts
+++ b/packages/language-service/test/lib-new/edit-time-parser.spec.ts
@@ -292,7 +292,7 @@ describe('edit-time-parser', () => {
             ERRORS.ATRULE_MISSING_NAME,
         ]);
     });
-    it('should handle unclosed at-rule', () => {
+    it('should handle unclosed at-rule (open body without close)', () => {
         const { ast, errorNodes } = safeParse(`
             @xxx abc {
         `);
@@ -305,6 +305,17 @@ describe('edit-time-parser', () => {
             params: 'abc',
         });
         expect(errorNodes.get(unclosed), 'errors').to.eql([ERRORS.MISSING_CLOSE]);
+    });
+    it('should handle unclosed at-rule (no body or semicolon)', () => {
+        const { ast } = parseForEditing(`@xxx abc \t\t\t`);
+
+        expect(ast.toString(), 'stringify').to.equal('@xxx abc \t\t\t');
+        const unclosed = assertAtRule(ast.nodes[0]);
+        expect(unclosed, 'node').to.include({
+            name: 'xxx',
+            params: 'abc',
+        });
+        expect(ast.source!.end!.offset, 'close parent with extra space').to.eql(11);
     });
     it('should keep track of end of source for unclosed nested nodes', () => {
         const { ast } = safeParse(`


### PR DESCRIPTION
This PR fixes an internal bug with the `ast-from-position` for a case of unclosed at-rule at eof. Before this fix postcss would simply allow the unclosed at-rule without setting the `source.end` of the root node which caused the `ast-from-position` to ignore the unclosed at-rule.

This PR fixes:
- close all unclosed nodes at the end of safe parsing
- check for unclosed at-rule in `ast-from-position` 
- set minimum of one after the at-rule name as the params start value for the case where the space after the name is not entered yet: `@name|`

