### PR TITLE
fix(esbuild): cache layer for the transform process

### DIFF
--- a/packages/esbuild/src/build-cache.ts
+++ b/packages/esbuild/src/build-cache.ts
@@ -1,0 +1,55 @@
+import { statSync } from 'fs';
+import type { OnLoadResult } from 'esbuild';
+
+// mtimes of known files shared between builds
+const fileInfo = new Map<string, number>();
+
+export function buildCache() {
+    const fileInfoDuringBuild = new Map<string, number>();
+    const cache = new Map<string, OnLoadResult>();
+    const checkCache = (path: string) => {
+        const cached = cache.get(path);
+        if (cached) {
+            const shouldRebuild = cached.watchFiles?.some((path) => {
+                const num = fileInfo.get(path);
+                if (num) {
+                    let stat = fileInfoDuringBuild.get(path);
+                    if (stat === undefined) {
+                        try {
+                            stat = statSync(path).mtimeMs;
+                            fileInfoDuringBuild.set(path, stat);
+                        } catch (e) {
+                            fileInfo.delete(path);
+                            return true;
+                        }
+                    }
+                    return stat !== num;
+                } else {
+                    return true;
+                }
+            });
+            if (!shouldRebuild) {
+                return cached;
+            }
+        }
+        return undefined;
+    };
+    const addToCache = (path: string, result: OnLoadResult) => {
+        cache.set(path, result);
+        for (const watchFile of result.watchFiles || []) {
+            if (fileInfo.has(watchFile)) {
+                continue;
+            }
+            fileInfo.set(watchFile, statSync(watchFile).mtimeMs);
+        }
+        return result;
+    };
+    const transferBuildInfo = () => {
+        for (const [key, value] of fileInfoDuringBuild) {
+            fileInfo.set(key, value);
+        }
+        fileInfoDuringBuild.clear();
+    };
+
+    return { checkCache, addToCache, transferBuildInfo };
+}

--- a/packages/esbuild/src/debug.ts
+++ b/packages/esbuild/src/debug.ts
@@ -1,0 +1,47 @@
+const timers: Record<string, number> = {};
+const counters: Record<string, number> = {};
+
+(globalThis as any).stylable_debug = () => {
+    console.log('Timers:');
+    for (const [name, time] of Object.entries(timers)) {
+        console.log(`  ${name}: ${time.toFixed(2)}ms`);
+    }
+    console.log('Counters:');
+    for (const [name, count] of Object.entries(counters)) {
+        console.log(`  ${name}: ${count}`);
+    }
+};
+
+(globalThis as any).stylable_debug_clear = () => {
+    for (const key of Object.keys(timers)) {
+        timers[key] = 0;
+    }
+    for (const key of Object.keys(counters)) {
+        counters[key] = 0;
+    }
+};
+
+export function wrapDebug<T extends any[], R>(name: string, fn: (...args: T) => R) {
+    return (...args: T) => {
+        inc(name);
+        const stop = start(name);
+        try {
+            return fn(...args);
+        } finally {
+            stop();
+        }
+    };
+}
+
+function inc(name: string) {
+    counters[name] ??= 0;
+    counters[name]++;
+}
+
+function start(name: string) {
+    timers[name] ??= 0;
+    const start = performance.now();
+    return () => {
+        timers[name] += performance.now() - start;
+    };
+}

--- a/packages/esbuild/src/debug.ts
+++ b/packages/esbuild/src/debug.ts
@@ -2,14 +2,17 @@ const timers: Record<string, number> = {};
 const counters: Record<string, number> = {};
 
 (globalThis as any).stylable_debug = () => {
-    console.log('Timers:');
-    for (const [name, time] of Object.entries(timers)) {
-        console.log(`  ${name}: ${time.toFixed(2)}ms`);
-    }
     console.log('Counters:');
-    for (const [name, count] of Object.entries(counters)) {
-        console.log(`  ${name}: ${count}`);
-    }
+    console.table(counters);
+    console.log('Timers:');
+    console.table(timers);
+    console.log(
+        'Total time:',
+        Object.values(timers)
+            .reduce((a, b) => a + b, 0)
+            .toFixed(2),
+        'ms'
+    );
 };
 
 (globalThis as any).stylable_debug_clear = () => {
@@ -22,6 +25,9 @@ const counters: Record<string, number> = {};
 };
 
 export function wrapDebug<T extends any[], R>(name: string, fn: (...args: T) => R) {
+    if (process.env.STYLABLE_DEBUG !== 'true') {
+        return fn;
+    }
     return (...args: T) => {
         inc(name);
         const stop = start(name);

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -300,6 +300,7 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
          */
         build.onEnd(
             wrapDebug(`onEnd generate cssInjection: ${cssInjection}`, ({ metafile }) => {
+                transferBuildInfo();
                 if (!onLoadCalled) {
                     lazyDebugPrint();
                     return;
@@ -357,7 +358,6 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
                         );
                     }
                 }
-                transferBuildInfo();
                 lazyClearCaches(stylable);
                 lazyDebugPrint();
             })

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -301,10 +301,7 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
         build.onEnd(
             wrapDebug(`onEnd generate cssInjection: ${cssInjection}`, ({ metafile }) => {
                 if (!onLoadCalled) {
-                    void Promise.resolve().then(() => {
-                        (globalThis as any).stylable_debug();
-                        (globalThis as any).stylable_debug_clear();
-                    });
+                    lazyDebugPrint();
                     return;
                 }
                 onLoadCalled = false;
@@ -362,15 +359,21 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
                 }
                 transferBuildInfo();
                 lazyClearCaches(stylable);
-
-                void Promise.resolve().then(() => {
-                    (globalThis as any).stylable_debug();
-                    (globalThis as any).stylable_debug_clear();
-                });
+                lazyDebugPrint();
             })
         );
     },
 });
+
+function lazyDebugPrint() {
+    if (process.env.STYLABLE_DEBUG !== 'true') {
+        return;
+    }
+    void Promise.resolve().then(() => {
+        (globalThis as any).stylable_debug();
+        (globalThis as any).stylable_debug_clear();
+    });
+}
 
 function debounce<T extends (...args: any[]) => void>(fn: T, time: number) {
     let timeout: ReturnType<typeof setTimeout>;

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -418,7 +418,6 @@ function processAssetsAndApplyStubs(
 
 function importsCollector(res: StylableResults) {
     const imports: { from: string }[] = [];
-    const buildDeps: string[] = [];
     const collector = (contextMeta: StylableMeta, absPath: string, hasSideEffects: boolean) => {
         if (hasSideEffects) {
             if (!absPath.endsWith('.st.css')) {
@@ -427,12 +426,11 @@ function importsCollector(res: StylableResults) {
             } else {
                 imports.push({ from: absPath });
             }
-            buildDeps.push(absPath);
         } else if (contextMeta === res.meta) {
             imports.push({ from: namespaces.unused + `:` + absPath });
         }
     };
-    return { imports, buildDeps, collector };
+    return { imports, collector };
 }
 
 function enableEsbuildMetafile(build: PluginBuild, cssInjection: string) {

--- a/packages/node/src/find-package-json.ts
+++ b/packages/node/src/find-package-json.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import { dirname, join } from 'path';
+
+export function findPackageJson(
+    cwd: string,
+    cache = new Map<string, string>(),
+    visited: string[] = []
+) {
+    while (cwd) {
+        if (cache.has(cwd)) {
+            return {
+                packageJsonPath: cache.get(cwd),
+                visited,
+                cache,
+            };
+        }
+
+        const packageJsonPath = join(cwd, 'package.json');
+        visited.push(cwd);
+        if (fs.existsSync(packageJsonPath)) {
+            for (const dir of visited) {
+                cache.set(dir, packageJsonPath);
+            }
+            return {
+                packageJsonPath,
+                visited,
+                cache,
+            };
+        } else {
+            const parent = dirname(cwd);
+            if (parent === cwd) {
+                return null;
+            }
+            cwd = parent;
+        }
+    }
+    return null;
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -3,5 +3,6 @@ export {
     resolveNamespace,
     resolveNamespaceFactory,
     createNamespaceStrategyNode,
+    packageJsonLookupCache,
 } from './resolve-namespace';
 export { FileSystem, findFiles } from './find-files';

--- a/packages/node/src/resolve-namespace.ts
+++ b/packages/node/src/resolve-namespace.ts
@@ -4,7 +4,7 @@ import {
     defaultNoMatchHandler,
 } from '@stylable/core';
 import { dirname, relative } from 'path';
-import findConfig from 'find-config';
+import { findPackageJson } from './find-package-json';
 
 export function resolveNamespaceFactory(
     hashSalt = '',
@@ -14,13 +14,18 @@ export function resolveNamespaceFactory(
     return createNamespaceStrategyNode({ hashSalt, prefix, ...options });
 }
 
+export const packageJsonLookupCache = new Map<string, string>();
+
 export function createNamespaceStrategyNode(options: Partial<CreateNamespaceOptions> = {}) {
     return createNamespaceStrategy({
         normalizePath(packageRoot: string, stylesheetPath: string) {
             return relative(packageRoot, stylesheetPath).replace(/\\/g, '/');
         },
         getPackageInfo: (stylesheetPath) => {
-            const configPath = findConfig('package.json', { cwd: dirname(stylesheetPath) });
+            const configPath = findPackageJson(
+                dirname(stylesheetPath),
+                packageJsonLookupCache
+            )?.packageJsonPath;
             if (!configPath) {
                 throw new Error(`Could not find package.json for ${stylesheetPath}`);
             }


### PR DESCRIPTION
Since esbuild has no cache we need to manually implement it for the plugin.
 
This PR implement cache (naively check any deep dependency) for the transformation of stylable files.

more to caching should be done to other hooks.