### PR TITLE
fix(lsp): ast-from-position fixes

### DIFF
--- a/packages/language-service/src/lib-new/ast-from-position.ts
+++ b/packages/language-service/src/lib-new/ast-from-position.ts
@@ -275,7 +275,12 @@ function checkAtRuleParams(node: postcss.AnyNode, checkContext: CheckContext) {
     if (isAtRule(node)) {
         const AtPrefixLength = 1;
         const { afterName = '', between = '' } = node.raws;
-        const prelude = afterName + node.params + between;
+        const parentNode = node.parent;
+        const unclosedExtraSpace =
+            parentNode?.nodes[parentNode.nodes.length - 1] === node && !parentNode.raws.semicolon
+                ? node.parent?.raws.after
+                : '';
+        const prelude = afterName + node.params + between + unclosedExtraSpace;
         const valueStart = checkContext.baseNodeOffset + AtPrefixLength + node.name.length;
         const valueEnd = valueStart + prelude.length;
 

--- a/packages/language-service/test/lib-new/ast-from-position.spec.ts
+++ b/packages/language-service/test/lib-new/ast-from-position.spec.ts
@@ -596,7 +596,7 @@ describe('ast-from-position', () => {
         it(`should find value start`, () => {
             const { position, parsed } = setupWithCursor(`
                 .selector {
-                    decl1: |bookmark after;
+                    decl1: |bookmark after ;
                     decl2: other;
                 }
             `);
@@ -606,16 +606,16 @@ describe('ast-from-position', () => {
             expectAstLocation(base, {
                 node: (parsed.ast as any).nodes[0].nodes[0],
                 where: 'declValue',
-                stringify: `decl1: |bookmark after`,
+                stringify: `decl1: |bookmark after `,
             });
             // decl-value level
-            expect(stringifyCSSValue(declValue!.ast), 'value ast').to.eql(' bookmark after');
+            expect(stringifyCSSValue(declValue!.ast), 'value ast').to.eql(' bookmark after ');
             expectAstLocation(declValue!, {
                 stringify: ' |',
                 parents: [
                     {
                         desc: 'value node',
-                        str: 'decl1: bookmark after',
+                        str: 'decl1: bookmark after ',
                     },
                 ],
             });
@@ -691,7 +691,7 @@ describe('ast-from-position', () => {
         it(`should find value end`, () => {
             const { position, parsed } = setupWithCursor(`
                 .selector {
-                    decl1: before bookmark|;
+                    decl1: before bookmark| ;
                     decl2: other;
                 }
             `);
@@ -701,16 +701,16 @@ describe('ast-from-position', () => {
             expectAstLocation(base, {
                 node: (parsed.ast as any).nodes[0].nodes[0],
                 where: 'declValue',
-                stringify: `decl1: before bookmark|`,
+                stringify: `decl1: before bookmark| `,
             });
             // decl-value level
-            expect(stringifyCSSValue(declValue!.ast), 'value ast').to.eql(' before bookmark');
+            expect(stringifyCSSValue(declValue!.ast), 'value ast').to.eql(' before bookmark ');
             expectAstLocation(declValue!, {
                 stringify: 'bookmark|',
                 parents: [
                     {
                         desc: 'decl node',
-                        str: 'decl1: before bookmark',
+                        str: 'decl1: before bookmark ',
                     },
                 ],
             });
@@ -733,14 +733,15 @@ describe('ast-from-position', () => {
                 stringify: `decl1: before   |`,
             });
             // decl-value level
-            // ToDo: should be `before   |   \t`
-            expect(stringifyCSSValue(declValue!.ast), 'value ast').to.eql(' before');
-            expect(declValue!.afterValue, 'after value').to.eql(true);
+            expect(stringifyCSSValue(declValue!.ast), 'value ast').to.eql(' before      \t\n');
             expectAstLocation(declValue!, {
-                stringify: ' before  |',
+                stringify: '   |   \t\n',
+                deindent: false,
                 parents: [
                     {
                         desc: 'decl node',
+                        // postcss stringify doesn't show unclosed after spaces on decl
+                        // they belong in parent rule raws after
                         str: 'decl1: before',
                     },
                 ],
@@ -965,7 +966,6 @@ describe('ast-from-position', () => {
                 where: 'atRuleParams',
             });
             // atrule-params level
-            expect(atRuleParams!.afterValue, 'space is part of params').to.eql(false);
             expectAstLocation(atRuleParams!, {
                 stringify: '   |   ',
                 parents: [
@@ -996,7 +996,6 @@ describe('ast-from-position', () => {
                 where: 'atRuleParams',
             });
             // atrule-params level
-            expect(atRuleParams!.afterValue, 'after params value').to.eql(false);
             expectAstLocation(atRuleParams!, {
                 stringify: '   |   ',
                 parents: [

--- a/packages/language-service/test/lib-new/ast-from-position.spec.ts
+++ b/packages/language-service/test/lib-new/ast-from-position.spec.ts
@@ -1009,6 +1009,35 @@ describe('ast-from-position', () => {
             expect(selector, 'selector').to.eql(undefined);
             expect(declValue, 'declValue').to.eql(undefined);
         });
+        it(`should find between params and unclosed end`, () => {
+            const { position, parsed } = setupWithCursor(`@name params   |   \n\t`, {
+                deindent: false,
+            });
+
+            const { base, selector, declValue, atRuleParams } = getAstNodeAt(parsed, position);
+
+            // base level
+            expectAstLocation(base, {
+                stringify: '@name params   |',
+                deindent: false,
+                where: 'atRuleParams',
+            });
+            // atrule-params level
+            expect(stringifyCSSValue(atRuleParams!.ast), 'params ast').to.eql(' params      \n\t');
+            expectAstLocation(atRuleParams!, {
+                stringify: '   |   \n\t',
+                deindent: false,
+                parents: [
+                    {
+                        desc: 'rule node',
+                        str: '@name params',
+                    },
+                ],
+            });
+            // unresolved levels
+            expect(selector, 'selector').to.eql(undefined);
+            expect(declValue, 'declValue').to.eql(undefined);
+        });
         it(`should find before declaration`, () => {
             const { position, parsed } = setupWithCursor(`
                 .before {}


### PR DESCRIPTION
This PR fix a couple of errors in `ast-from-position` that is used to identified source context for the language-service:

- fix: `@name |params` should resolve `where` to `atRuleParams` and not `atRuleBody`
- fix: resolve at-rule params the entire prelude including `afterName`, `params`, `between` (params and `;` or `{`), and potential space for last unclosed at-rule
- fix: resolve declaration value from including anything from colon, actual value, and potential space for last unclosed declaration
- chore : improve `deindent` config in test-kit
