### PR TITLE
feat(lsp): filter completions by context

### DIFF
--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -12,7 +12,7 @@ export const StImportPlugin: LangServicePlugin = {
     analyzeCaretLocation(context) {
         const node = context.location.base.node;
         if (node.type === 'atrule' && node.name === 'st-import') {
-            context.setFlag('runNativeCSSService', false);
+            context.flags.runNativeCSSService = false;
         }
     },
     onCompletion({ context }) {

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -6,8 +6,15 @@ import path from 'path';
 import { STSymbol } from '@stylable/core/dist/index-internal';
 import type { AstLocationResult } from '../ast-from-position';
 import type { CSSValueAST } from '@tokey/css-value-parser';
+import type { LangServicePlugin } from '../../lib/completion-providers';
 
-export function getCompletions(context: LangServiceContext): Completion[] {
+export const StImportPlugin: LangServicePlugin = {
+    onCompletion({ context }) {
+        return getCompletions(context);
+    },
+};
+
+function getCompletions(context: LangServiceContext): Completion[] {
     const completions: Completion[] = [];
     const { node } = context.location.base;
     if (node.type === 'atrule' && node.name === 'st-import') {

--- a/packages/language-service/src/lib-new/features/ls-st-import.ts
+++ b/packages/language-service/src/lib-new/features/ls-st-import.ts
@@ -9,6 +9,12 @@ import type { CSSValueAST } from '@tokey/css-value-parser';
 import type { LangServicePlugin } from '../../lib/completion-providers';
 
 export const StImportPlugin: LangServicePlugin = {
+    analyzeCaretLocation(context) {
+        const node = context.location.base.node;
+        if (node.type === 'atrule' && node.name === 'st-import') {
+            context.setFlag('runNativeCSSService', false);
+        }
+    },
     onCompletion({ context }) {
         return getCompletions(context);
     },

--- a/packages/language-service/src/lib-new/lang-service-context.ts
+++ b/packages/language-service/src/lib-new/lang-service-context.ts
@@ -33,7 +33,7 @@ export class LangServiceContext {
     public ambiguousNodes: Map<any, ParseReport[]>;
     public location: ReturnType<typeof getAstNodeAt>;
     public document: TextDocument;
-    private flags = {
+    public flags = {
         runNativeCSSService: true,
     };
     constructor(
@@ -58,12 +58,6 @@ export class LangServiceContext {
             this.fileData.stat.mtime.getTime(),
             this.fileData.content
         );
-    }
-    public setFlag(flag: keyof LangServiceContext['flags'], enabled: boolean) {
-        this.flags[flag] = enabled;
-    }
-    public getFlag(flag: keyof LangServiceContext['flags']) {
-        return this.flags[flag];
     }
     public getPosition(offset: number = this.offset) {
         return this.document.positionAt(offset);

--- a/packages/language-service/src/lib-new/lang-service-context.ts
+++ b/packages/language-service/src/lib-new/lang-service-context.ts
@@ -33,6 +33,9 @@ export class LangServiceContext {
     public ambiguousNodes: Map<any, ParseReport[]>;
     public location: ReturnType<typeof getAstNodeAt>;
     public document: TextDocument;
+    private flags = {
+        runNativeCSSService: true,
+    };
     constructor(
         public fs: IFileSystem,
         public stylable: Stylable,
@@ -55,6 +58,12 @@ export class LangServiceContext {
             this.fileData.stat.mtime.getTime(),
             this.fileData.content
         );
+    }
+    public setFlag(flag: keyof LangServiceContext['flags'], enabled: boolean) {
+        this.flags[flag] = enabled;
+    }
+    public getFlag(flag: keyof LangServiceContext['flags']) {
+        return this.flags[flag];
     }
     public getPosition(offset: number = this.offset) {
         return this.document.positionAt(offset);

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -53,7 +53,7 @@ import type { CursorPosition } from './utils/selector-analyzer';
 import type { LangServiceContext } from '../lib-new/lang-service-context';
 import * as cssPseudoClass from '../lib-new/features/ls-css-pseudo-class';
 
-export interface ProviderOptions {
+export interface PluginCompletionOptions {
     context: LangServiceContext;
     meta: StylableMeta;
     fs: IFileSystem;
@@ -77,7 +77,7 @@ export interface ProviderOptions {
 
 export interface LangServicePlugin {
     analyzeCaretLocation?(context: LangServiceContext): void;
-    onCompletion(options: ProviderOptions): Completion[];
+    onCompletion(options: PluginCompletionOptions): Completion[];
 }
 
 export class ProviderPosition {
@@ -193,14 +193,14 @@ const topLevelDeclarations: Array<keyof typeof topLevelDirectives> = [
 
 // Inside :import ruleset, which is not inside media query
 // If directive doesn't already exist
-export const ImportInternalDirectivesProvider: LangServicePlugin = {
+export const ImportInternalDirectivesPlugin: LangServicePlugin = {
     onCompletion({
         parentSelector,
         isMediaQuery,
         fullLineText,
         position,
         lineChunkAtCursor,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         if (parentSelector && parentSelector.selector === ':import' && !isMediaQuery) {
             const res: Completion[] = [];
             importDeclarations.forEach((name) => {
@@ -229,7 +229,7 @@ export const ImportInternalDirectivesProvider: LangServicePlugin = {
 // Inside ruleset, which is not :import or :vars
 // Only inside simple selector, except -st-mixin
 // If directive doesn't already exist
-export const RulesetInternalDirectivesProvider: LangServicePlugin & {
+export const RulesetInternalDirectivesPlugin: LangServicePlugin & {
     isSimpleSelector: (sel: string) => boolean;
 } = {
     onCompletion({
@@ -238,7 +238,7 @@ export const RulesetInternalDirectivesProvider: LangServicePlugin & {
         fullLineText,
         position,
         lineChunkAtCursor,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         const res: Completion[] = [];
         if (
             parentSelector &&
@@ -291,7 +291,7 @@ export const RulesetInternalDirectivesProvider: LangServicePlugin & {
 
 // Only top level
 // @st-namespace may not repeat
-export const TopLevelDirectiveProvider: LangServicePlugin = {
+export const TopLevelDirectivePlugin: LangServicePlugin = {
     onCompletion({
         parentSelector,
         isMediaQuery,
@@ -300,7 +300,7 @@ export const TopLevelDirectiveProvider: LangServicePlugin = {
         lineChunkAtCursor,
         meta,
         astAtCursor,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         if (!parentSelector) {
             if (
                 !isMediaQuery &&
@@ -341,10 +341,14 @@ export const TopLevelDirectiveProvider: LangServicePlugin = {
 // RHS of declaration
 // Declaration is not -st-directive (except -st-mixin)
 // Not inside another value()
-export const ValueDirectiveProvider: LangServicePlugin & {
+export const ValueDirectivePlugin: LangServicePlugin & {
     isInsideValueDirective: (wholeLine: string, pos: number) => boolean;
 } = {
-    onCompletion({ parentSelector, fullLineText, position }: ProviderOptions): Completion[] {
+    onCompletion({
+        parentSelector,
+        fullLineText,
+        position,
+    }: PluginCompletionOptions): Completion[] {
         if (
             parentSelector &&
             !isDirective(fullLineText) &&
@@ -401,14 +405,14 @@ export const ValueDirectiveProvider: LangServicePlugin & {
 };
 
 // Selector level
-export const GlobalCompletionProvider: LangServicePlugin = {
+export const GlobalCompletionPlugin: LangServicePlugin = {
     onCompletion({
         context,
         parentSelector,
         fullLineText,
         position,
         lineChunkAtCursor,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         const isSelectorContext =
             context.isInSelectorAllowedSpace() ||
             // natively allow in custom-selector; ToDO: make custom-selector plugin that enable selector at mapped location
@@ -447,7 +451,7 @@ export const GlobalCompletionProvider: LangServicePlugin = {
 
 // Selector level
 // Not after :, unless entire chunk is :
-export const SelectorCompletionProvider: LangServicePlugin = {
+export const SelectorCompletionPlugin: LangServicePlugin = {
     onCompletion({
         context,
         parentSelector,
@@ -457,7 +461,7 @@ export const SelectorCompletionProvider: LangServicePlugin = {
         meta,
         fakes,
         stylable,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         if (
             context.isInSelectorAllowedSpace() &&
             !parentSelector &&
@@ -527,8 +531,13 @@ export const SelectorCompletionProvider: LangServicePlugin = {
 
 // Inside ruleset of simple selector, not :import or :vars
 // RHS of -st-extends
-export const ExtendCompletionProvider: LangServicePlugin = {
-    onCompletion({ lineChunkAtCursor, position, meta, stylable }: ProviderOptions): Completion[] {
+export const ExtendCompletionPlugin: LangServicePlugin = {
+    onCompletion({
+        lineChunkAtCursor,
+        position,
+        meta,
+        stylable,
+    }: PluginCompletionOptions): Completion[] {
         if (lineChunkAtCursor.startsWith(`-st-extends`)) {
             const value = lineChunkAtCursor.slice(`-st-extends:`.length);
             const spaces = value.search(/\S|$/);
@@ -583,13 +592,13 @@ export const ExtendCompletionProvider: LangServicePlugin = {
 
 // Inside ruleset, which is not :import or :vars
 // RHS of -st-extends
-export const CssMixinCompletionProvider: LangServicePlugin = {
+export const CssMixinCompletionPlugin: LangServicePlugin = {
     onCompletion({
         lineChunkAtCursor,
         meta,
         position,
         fullLineText,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         if (lineChunkAtCursor.startsWith(`-st-mixin:`)) {
             const { names, lastName } = getExistingNames(fullLineText, position);
             const symbols = meta.getAllSymbols();
@@ -629,7 +638,7 @@ export const CssMixinCompletionProvider: LangServicePlugin = {
 // Only inside simple selector
 // RHS of -st-mixin
 // There is  a JS/TS import
-export const CodeMixinCompletionProvider: LangServicePlugin = {
+export const CodeMixinCompletionPlugin: LangServicePlugin = {
     onCompletion({
         parentSelector,
         meta,
@@ -639,7 +648,7 @@ export const CodeMixinCompletionProvider: LangServicePlugin = {
         fs,
         tsLangService,
         stylable,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         if (
             meta
                 .getImportStatements()
@@ -671,7 +680,7 @@ export const CodeMixinCompletionProvider: LangServicePlugin = {
 
 // Inside ruleset, which is not :import
 // RHS of any rule except -st-extends, -st-from
-export const FormatterCompletionProvider: LangServicePlugin = {
+export const FormatterCompletionPlugin: LangServicePlugin = {
     onCompletion({
         meta,
         fullLineText,
@@ -681,7 +690,7 @@ export const FormatterCompletionProvider: LangServicePlugin = {
         fs,
         tsLangService,
         stylable,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         if (
             meta
                 .getImportStatements()
@@ -717,7 +726,7 @@ export const FormatterCompletionProvider: LangServicePlugin = {
 // Inside :import
 // RHS of -st-named
 // import exists
-export const NamedCompletionProvider: LangServicePlugin & {
+export const NamedCompletionPlugin: LangServicePlugin & {
     resolveImport: (
         importName: string,
         stylable: Stylable,
@@ -732,7 +741,7 @@ export const NamedCompletionProvider: LangServicePlugin & {
         position,
         fullLineText,
         src,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         const { isNamedValueLine, namedValues } = getNamedValues(src, position.line);
         if (isNamedValueLine) {
             let importName = '';
@@ -895,7 +904,7 @@ function maybeResolveImport(
     return resolvedImport;
 }
 
-export const PseudoElementCompletionProvider: LangServicePlugin = {
+export const PseudoElementCompletionPlugin: LangServicePlugin = {
     onCompletion({
         parentSelector,
         resolved,
@@ -906,7 +915,7 @@ export const PseudoElementCompletionProvider: LangServicePlugin = {
         meta,
         position,
         fullLineText,
-    }: ProviderOptions): Completion[] {
+    }: PluginCompletionOptions): Completion[] {
         let comps: any[] = [];
         if (
             !parentSelector &&
@@ -1107,8 +1116,8 @@ function isPositionInDecl(position: ProviderPosition, decl: postcss.Declaration)
     return false;
 }
 
-export const StateTypeCompletionProvider: LangServicePlugin = {
-    onCompletion({ astAtCursor, fullLineText, position }: ProviderOptions): Completion[] {
+export const StateTypeCompletionPlugin: LangServicePlugin = {
+    onCompletion({ astAtCursor, fullLineText, position }: PluginCompletionOptions): Completion[] {
         const acc: Completion[] = [];
 
         if (isNodeRule(astAtCursor)) {
@@ -1191,14 +1200,19 @@ export const StateTypeCompletionProvider: LangServicePlugin = {
     },
 };
 
-export const StateSelectorCompletionProvider: LangServicePlugin = {
-    onCompletion({ context }: ProviderOptions) {
+export const StateSelectorCompletionPlugin: LangServicePlugin = {
+    onCompletion({ context }: PluginCompletionOptions) {
         return cssPseudoClass.getCompletions(context);
     },
 };
 
-export const ValueCompletionProvider: LangServicePlugin = {
-    onCompletion({ fullLineText, position, meta, stylable }: ProviderOptions): Completion[] {
+export const ValueCompletionPlugin: LangServicePlugin = {
+    onCompletion({
+        fullLineText,
+        position,
+        meta,
+        stylable,
+    }: PluginCompletionOptions): Completion[] {
         if (isInValue(fullLineText, position)) {
             const inner = fullLineText
                 .slice(0, fullLineText.indexOf(')', position.character) + 1)

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -76,6 +76,7 @@ export interface ProviderOptions {
 }
 
 export interface LangServicePlugin {
+    analyzeCaretLocation?(context: LangServiceContext): void;
     onCompletion(options: ProviderOptions): Completion[];
 }
 

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -29,26 +29,26 @@ import type {
 import { URI } from 'vscode-uri';
 
 import {
-    CodeMixinCompletionProvider,
+    CodeMixinCompletionPlugin,
     LangServicePlugin,
     createRange,
-    CssMixinCompletionProvider,
-    ExtendCompletionProvider,
-    FormatterCompletionProvider,
-    GlobalCompletionProvider,
-    ImportInternalDirectivesProvider,
-    NamedCompletionProvider,
-    ProviderOptions,
+    CssMixinCompletionPlugin,
+    ExtendCompletionPlugin,
+    FormatterCompletionPlugin,
+    GlobalCompletionPlugin,
+    ImportInternalDirectivesPlugin,
+    NamedCompletionPlugin,
+    PluginCompletionOptions,
     ProviderPosition,
     ProviderRange,
-    PseudoElementCompletionProvider,
-    RulesetInternalDirectivesProvider,
-    SelectorCompletionProvider,
-    StateSelectorCompletionProvider,
-    StateTypeCompletionProvider,
-    TopLevelDirectiveProvider,
-    ValueCompletionProvider,
-    ValueDirectiveProvider,
+    PseudoElementCompletionPlugin,
+    RulesetInternalDirectivesPlugin,
+    SelectorCompletionPlugin,
+    StateSelectorCompletionPlugin,
+    StateTypeCompletionPlugin,
+    TopLevelDirectivePlugin,
+    ValueCompletionPlugin,
+    ValueDirectivePlugin,
 } from './completion-providers';
 import { topLevelDirectives } from './completion-types';
 import type { Completion } from './completion-types';
@@ -87,27 +87,27 @@ function findLast<T>(
 export class Provider {
     private plugins: LangServicePlugin[] = [
         StImportPlugin,
-        RulesetInternalDirectivesProvider,
-        ImportInternalDirectivesProvider,
-        TopLevelDirectiveProvider,
-        ValueDirectiveProvider,
-        GlobalCompletionProvider,
-        SelectorCompletionProvider,
-        ExtendCompletionProvider,
-        CssMixinCompletionProvider,
-        CodeMixinCompletionProvider,
-        FormatterCompletionProvider,
-        NamedCompletionProvider,
-        StateTypeCompletionProvider,
-        StateSelectorCompletionProvider,
-        PseudoElementCompletionProvider,
-        ValueCompletionProvider,
+        RulesetInternalDirectivesPlugin,
+        ImportInternalDirectivesPlugin,
+        TopLevelDirectivePlugin,
+        ValueDirectivePlugin,
+        GlobalCompletionPlugin,
+        SelectorCompletionPlugin,
+        ExtendCompletionPlugin,
+        CssMixinCompletionPlugin,
+        CodeMixinCompletionPlugin,
+        FormatterCompletionPlugin,
+        NamedCompletionPlugin,
+        StateTypeCompletionPlugin,
+        StateSelectorCompletionPlugin,
+        PseudoElementCompletionPlugin,
+        ValueCompletionPlugin,
     ];
     constructor(private stylable: Stylable, private tsLangService: ExtendedTsLanguageService) {}
 
     public analyzeCaretContext(context: LangServiceContext) {
-        for (const provider of this.plugins) {
-            provider.analyzeCaretLocation?.(context);
+        for (const plugin of this.plugins) {
+            plugin.analyzeCaretLocation?.(context);
         }
     }
     public provideCompletionItemsFromSrc(
@@ -124,7 +124,7 @@ export class Provider {
             return [];
         }
 
-        const options = this.createProviderOptions(
+        const options = this.createPluginCompletionOptions(
             context,
             src,
             pos,
@@ -727,7 +727,7 @@ export class Provider {
         }
     }
 
-    private createProviderOptions(
+    private createPluginCompletionOptions(
         context: LangServiceContext,
         src: string,
         position: ProviderPosition,
@@ -736,7 +736,7 @@ export class Provider {
         fullLineText: string,
         cursorPosInLine: number,
         fs: IFileSystem
-    ): ProviderOptions {
+    ): PluginCompletionOptions {
         const path = pathFromPosition(meta.sourceAst, {
             line: position.line + 1,
             character: position.character,

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -30,7 +30,7 @@ import { URI } from 'vscode-uri';
 
 import {
     CodeMixinCompletionProvider,
-    CompletionProvider,
+    LangServicePlugin,
     createRange,
     CssMixinCompletionProvider,
     ExtendCompletionProvider,
@@ -49,7 +49,6 @@ import {
     TopLevelDirectiveProvider,
     ValueCompletionProvider,
     ValueDirectiveProvider,
-    newStImportCompletionProvider,
 } from './completion-providers';
 import { topLevelDirectives } from './completion-types';
 import type { Completion } from './completion-types';
@@ -68,6 +67,7 @@ import {
     SelectorQuery,
 } from './utils/selector-analyzer';
 import type { LangServiceContext } from '../lib-new/lang-service-context';
+import { StImportPlugin } from '../lib-new/features/ls-st-import';
 
 function findLast<T>(
     arr: T[],
@@ -85,8 +85,8 @@ function findLast<T>(
 }
 
 export class Provider {
-    private providers: CompletionProvider[] = [
-        newStImportCompletionProvider,
+    private plugins: LangServicePlugin[] = [
+        StImportPlugin,
         RulesetInternalDirectivesProvider,
         ImportInternalDirectivesProvider,
         TopLevelDirectiveProvider,
@@ -129,8 +129,8 @@ export class Provider {
             res.cursorLineIndex,
             fs
         );
-        for (const provider of this.providers) {
-            completions.push(...provider.provide(options));
+        for (const provider of this.plugins) {
+            completions.push(...provider.onCompletion(options));
         }
 
         return this.dedupeComps(completions);

--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -105,6 +105,11 @@ export class Provider {
     ];
     constructor(private stylable: Stylable, private tsLangService: ExtendedTsLanguageService) {}
 
+    public analyzeCaretContext(context: LangServiceContext) {
+        for (const provider of this.plugins) {
+            provider.analyzeCaretLocation?.(context);
+        }
+    }
     public provideCompletionItemsFromSrc(
         context: LangServiceContext,
         fs: IFileSystem

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -328,7 +328,7 @@ export class StylableLanguageService {
             }
         }
         // native CSS service
-        if (context.getFlag('runNativeCSSService')) {
+        if (context.flags.runNativeCSSService) {
             const cssCompletions = this.cssService.getCompletions(cleanDocument, position);
             for (const cssComp of cssCompletions) {
                 const label = cssComp.label;

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -327,17 +327,17 @@ export class StylableLanguageService {
                 );
             }
         }
-
-        const cssCompletions = this.cssService.getCompletions(cleanDocument, position);
-
-        for (const cssComp of cssCompletions) {
-            const label = cssComp.label;
-
-            if (!groupedCompletions.has(label)) {
-                // CSS declaration property names have built in sorting
-                // at-rules, rules and declaration values do not
-                cssComp.sortText = cssComp.sortText || 'z';
-                groupedCompletions.set(label, cssComp);
+        // native CSS service
+        if (context.getFlag('runNativeCSSService')) {
+            const cssCompletions = this.cssService.getCompletions(cleanDocument, position);
+            for (const cssComp of cssCompletions) {
+                const label = cssComp.label;
+                if (!groupedCompletions.has(label)) {
+                    // CSS declaration property names have built in sorting
+                    // at-rules, rules and declaration values do not
+                    cssComp.sortText = cssComp.sortText || 'z';
+                    groupedCompletions.set(label, cssComp);
+                }
             }
         }
 

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -67,6 +67,7 @@ export class StylableLanguageService {
 
         if (stylableFile && stylableFile.stat.isFile()) {
             const context = new LangServiceContext(this.fs, this.stylable, stylableFile, offset);
+            this.provider.analyzeCaretContext(context);
             return this.getCompletions(context);
         } else {
             return [];

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -87,6 +87,48 @@ describe('LS: st-import', () => {
             unexpectedList: [{ label: '@st-import' }],
         }));
     });
+    it('should not suggest native css or selectors', () => {
+        const { service, assertCompletions, fs } = testLangService(
+            {
+                'other.st.css': ``,
+                'entry.st.css': `
+                    @st-import ^default^ from '.^specifierEmpty^';
+                    @st-import [^named^, keyframes(^namedTyped^)] from '.^specifierWithDot^';
+                    
+                    .xxx {}
+                `,
+            },
+            { testOnNativeFileSystem: tempDir.path }
+        );
+
+        const entryPath = fs.join(tempDir.path, 'entry.st.css');
+
+        assertCompletions(entryPath, ({ filePath, carets }) => ({
+            message: 'specifierEmpty',
+            actualList: service.onCompletion(filePath, carets.specifierEmpty),
+            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+        }));
+        assertCompletions(entryPath, ({ filePath, carets }) => ({
+            message: 'specifierWithDot',
+            actualList: service.onCompletion(filePath, carets.specifierWithDot),
+            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+        }));
+        assertCompletions(entryPath, ({ filePath, carets }) => ({
+            message: 'default',
+            actualList: service.onCompletion(filePath, carets.default),
+            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+        }));
+        assertCompletions(entryPath, ({ filePath, carets }) => ({
+            message: 'named',
+            actualList: service.onCompletion(filePath, carets.named),
+            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+        }));
+        assertCompletions(entryPath, ({ filePath, carets }) => ({
+            message: 'namedTyped',
+            actualList: service.onCompletion(filePath, carets.namedTyped),
+            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+        }));
+    });
     describe('named imports', () => {
         it('should suggest named imports', () => {
             const { service, assertCompletions, fs } = testLangService(

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -103,30 +103,36 @@ describe('LS: st-import', () => {
 
         const entryPath = fs.join(tempDir.path, 'entry.st.css');
 
+        const unexpectedList = [
+            { label: '.xxx' },
+            { label: 'input' },
+            { label: '@media' },
+            { label: ':global()' },
+        ];
         assertCompletions(entryPath, ({ filePath, carets }) => ({
             message: 'specifierEmpty',
             actualList: service.onCompletion(filePath, carets.specifierEmpty),
-            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+            unexpectedList,
         }));
         assertCompletions(entryPath, ({ filePath, carets }) => ({
             message: 'specifierWithDot',
             actualList: service.onCompletion(filePath, carets.specifierWithDot),
-            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+            unexpectedList,
         }));
         assertCompletions(entryPath, ({ filePath, carets }) => ({
             message: 'default',
             actualList: service.onCompletion(filePath, carets.default),
-            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+            unexpectedList,
         }));
         assertCompletions(entryPath, ({ filePath, carets }) => ({
             message: 'named',
             actualList: service.onCompletion(filePath, carets.named),
-            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+            unexpectedList,
         }));
         assertCompletions(entryPath, ({ filePath, carets }) => ({
             message: 'namedTyped',
             actualList: service.onCompletion(filePath, carets.namedTyped),
-            unexpectedList: [{ label: '.xxx' }, { label: 'input' }, { label: '@media' }],
+            unexpectedList,
         }));
     });
     describe('named imports', () => {


### PR DESCRIPTION
This PR adds a way to allow stylable lsp plugins to check context before completion in order to take ownership of context and filter out other providers.

Currently implemented to filter out native-css service and selector completions from `@st-import` at-rule 

In addition a small refactor to change "provide" that would only be for completion into "lsp plugin" to group general lsp api around a feature/concept