### PR TITLE
fix: `@st-scope` deep scoping

### DIFF
--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -18,11 +18,17 @@ import * as postcss from 'postcss';
 import { transformInlineCustomSelectors } from './custom-selector';
 
 export function isChildOfAtRule(rule: postcss.Container, atRuleName: string) {
-    return !!(
-        rule.parent &&
-        rule.parent.type === 'atrule' &&
-        (rule.parent as postcss.AtRule).name === atRuleName
-    );
+    let currentParent = rule.parent;
+    while (currentParent) {
+        if (
+            currentParent.type === 'atrule' &&
+            (currentParent as postcss.AtRule).name === atRuleName
+        ) {
+            return true;
+        }
+        currentParent = currentParent.parent;
+    }
+    return false;
 }
 
 export function isInConditionalGroup(node: postcss.Rule | postcss.AtRule, includeRoot = true) {

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -1002,6 +1002,27 @@ describe(`features/css-class`, () => {
             });
         });
     });
+    describe('st-scope', () => {
+        it('should mark everything inside as scoped', () => {
+            const { sheets } = testStylableCore({
+                '/external.st.css': ``,
+                '/valid.st.css': `
+                    @st-import [root as external] from './external.st.css';
+                    @st-scope .root {
+                        .external {}
+
+                        @media screen and (max-width: 555px) {
+                            .external {}
+                        }
+                    }
+                `,
+            });
+
+            const { meta } = sheets['/valid.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
+    });
     describe(`css-pseudo-element`, () => {
         // ToDo: move to css-pseudo-element spec once feature is created
         describe(`st-mixin`, () => {

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -1003,7 +1003,7 @@ describe(`features/css-class`, () => {
         });
     });
     describe('st-scope', () => {
-        it('should mark everything inside as scoped', () => {
+        it('should allow nested global/external selectors anywhere', () => {
             const { sheets } = testStylableCore({
                 '/external.st.css': ``,
                 '/valid.st.css': `

--- a/packages/core/test/features/css-keyframes.spec.ts
+++ b/packages/core/test/features/css-keyframes.spec.ts
@@ -149,10 +149,13 @@ describe(`features/css-keyframes`, () => {
         // ToDo: make sure this is actually testing anything: "from" and "to" wouldn't be namespaces anyhow
         const { sheets } = testStylableCore(`
             @keyframes name {
-                /* @check from */
+                /* @rule from */
                 from {}
-                /* @check to */
-                to {}
+                /* @rule to */
+                to {
+                    /* @rule deep */
+                    deep {}
+                }
             }
         `);
 


### PR DESCRIPTION
This PR fix an unintended restriction on deep nested scope check within `@st-scope`. The intended use of `@st-scope` is to mark anything within it as scoped, including rules nested in media queries. 