### PR TITLE
fix: peer dep + cache clear

### DIFF
--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -7,7 +7,7 @@
     "test": "mocha \"dist/test/**/*.spec.js\""
   },
   "peerDependencies": {
-    "esbuild": "^0.17.18"
+    "esbuild": ">=0.17.18"
   },
   "dependencies": {
     "@stylable/build-tools": "^5.12.0",

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -14,7 +14,7 @@ import {
     hasImportedSideEffects,
     collectImportsWithSideEffects,
 } from '@stylable/build-tools';
-import { resolveNamespace as resolveNamespaceNode } from '@stylable/node';
+import { packageJsonLookupCache, resolveNamespace as resolveNamespaceNode } from '@stylable/node';
 import { StylableOptimizer } from '@stylable/optimizer';
 import decache from 'decache';
 import {
@@ -110,6 +110,7 @@ export function stylableRollupPlugin({
             if (stylable) {
                 clearRequireCache();
                 stylable.initCache();
+                packageJsonLookupCache.clear();
             } else {
                 const stConfig = stylableConfig({
                     fileSystem: fs,


### PR DESCRIPTION
## esbuild: no upper limit on peer-dependency 

change esbuild peer dependency to `>=0.17.18` to allow any future version above `@stylable/esbuild` original check against version.

Since esbuild itself is in version 0 and breaking changes are allowed in minor, then it's fine have no upper limit.

When esbuild@1 is out we can release a version with an upper limit.

## rollup: clear cache

Try clearing the cache for relative `package.json`  to file on rebuild.

This is a trade off between speed and the need to re-execute the flow when packages are added/removed.

There are other integrations that don't clear this cache and we might want to think of a unified behavior
- maybe expose the cache control out of each integration and allow to fine tune the experience
- collect the possible resolved paths, listen for changes, and automatically fine-tune the invalidation 
