### PR TITLE
feat: st-scope with no scoping selector

### DIFF
--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -20,38 +20,18 @@ export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutablePseudoClass }>
         if (!isStScopeStatement(atRule)) {
             return;
         }
-        const selectorAst = parseSelectorWithCache(atRule.params);
-        const isValidSelector =
-            selectorAst.length !== 0 &&
-            selectorAst.every((selector) => {
-                let foundSelector = false;
-                for (const { type } of selector.nodes) {
-                    switch (type) {
-                        case 'invalid':
-                            return false;
-                        case 'comment':
-                            break;
-                        default:
-                            foundSelector = true;
-                    }
-                }
-                return foundSelector;
-            });
-        if (isValidSelector) {
-            analyzeRule(
-                postcss.rule({
-                    selector: atRule.params,
-                    source: atRule.source,
-                }),
-                {
-                    isScoped: true,
-                    originalNode: atRule,
-                }
-            );
-        } else if (atRule.params.trim() !== '') {
-            // ToDo(tech debt): report invalid selector
-            // this is a breaking change as "/**/" currently works.
-        }
+        // notice: any value from params would be taken as a scoping
+        // selector to be prepended to nested selectors
+        analyzeRule(
+            postcss.rule({
+                selector: atRule.params,
+                source: atRule.source,
+            }),
+            {
+                isScoped: true,
+                originalNode: atRule,
+            }
+        );
         context.meta.scopes.push(atRule);
     },
     prepareAST({ node, toRemove }) {

--- a/packages/core/src/features/st-scope.ts
+++ b/packages/core/src/features/st-scope.ts
@@ -4,14 +4,13 @@ import type { Stylable } from '../stylable';
 import type { ImmutablePseudoClass } from '@tokey/css-selector-parser';
 import * as postcss from 'postcss';
 import type { SRule } from '../deprecated/postcss-ast-extension';
-import { createDiagnosticReporter } from '../diagnostics';
 
 export const diagnostics = {
-    MISSING_SCOPING_PARAM: createDiagnosticReporter(
-        '11009',
-        'error',
-        () => '"@st-scope" missing scoping selector parameter'
-    ),
+    // INVALID_SCOPING: createDiagnosticReporter(
+    //     '11009',
+    //     'error',
+    //     () => '"@st-scope" requires a valid selector or empty value'
+    // ),
 };
 
 // HOOKS
@@ -21,19 +20,38 @@ export const hooks = createFeature<{ IMMUTABLE_SELECTOR: ImmutablePseudoClass }>
         if (!isStScopeStatement(atRule)) {
             return;
         }
-        if (!atRule.params) {
-            context.diagnostics.report(diagnostics.MISSING_SCOPING_PARAM(), { node: atRule });
+        const selectorAst = parseSelectorWithCache(atRule.params);
+        const isValidSelector =
+            selectorAst.length !== 0 &&
+            selectorAst.every((selector) => {
+                let foundSelector = false;
+                for (const { type } of selector.nodes) {
+                    switch (type) {
+                        case 'invalid':
+                            return false;
+                        case 'comment':
+                            break;
+                        default:
+                            foundSelector = true;
+                    }
+                }
+                return foundSelector;
+            });
+        if (isValidSelector) {
+            analyzeRule(
+                postcss.rule({
+                    selector: atRule.params,
+                    source: atRule.source,
+                }),
+                {
+                    isScoped: true,
+                    originalNode: atRule,
+                }
+            );
+        } else if (atRule.params.trim() !== '') {
+            // ToDo(tech debt): report invalid selector
+            // this is a breaking change as "/**/" currently works.
         }
-        analyzeRule(
-            postcss.rule({
-                selector: atRule.params,
-                source: atRule.source,
-            }),
-            {
-                isScoped: true,
-                originalNode: atRule,
-            }
-        );
         context.meta.scopes.push(atRule);
     },
     prepareAST({ node, toRemove }) {

--- a/packages/core/test/scope-directive.spec.ts
+++ b/packages/core/test/scope-directive.spec.ts
@@ -9,9 +9,7 @@ import {
     shouldReportNoDiagnostics,
 } from '@stylable/core-test-kit';
 import { transformerDiagnostics } from '@stylable/core/dist/index-internal';
-import { STScope } from '@stylable/core/dist/features';
 
-const stScopeDiagnostics = diagnosticBankReportToStrings(STScope.diagnostics);
 const transformerStringDiagnostics = diagnosticBankReportToStrings(transformerDiagnostics);
 
 use(flatMatch);
@@ -515,30 +513,6 @@ describe('@st-scope', () => {
             expect((meta.targetAst!.first as Rule).selector).to.equal(
                 '.entry__root::unknownPart .entry__part::unknownPart'
             );
-        });
-        it('should warn about a missing scoping parameter', () => {
-            const config = {
-                entry: `/entry.st.css`,
-                files: {
-                    '/entry.st.css': {
-                        namespace: 'entry',
-                        content: `
-                        |@st-scope {
-                            .part {}
-                        }|
-                        `,
-                    },
-                },
-            };
-
-            const { meta } = expectTransformDiagnostics(config, [
-                {
-                    message: stScopeDiagnostics.MISSING_SCOPING_PARAM(),
-                    file: '/entry.st.css',
-                    severity: 'error',
-                },
-            ]);
-            expect((meta.targetAst!.first as Rule).selector).to.equal('.entry__part');
         });
     });
 });


### PR DESCRIPTION
This PR relaxes the restrictions on the usage of `@st-scope`, allowing it to be used solely for opting out of global side-effect restrictions. This means that there is no longer a need to prepend a scoping selector to any nested selectors.

The @st-scope directive offers two capabilities:

- It allows for opting out of `unscoped` selector diagnostics, which is useful for defining a theme or resetting with global side-effects.
- It reduces the repetition of selectors.

With native CSS nesting support, the second capability becomes redundant.

To address the opt-out feature more clearly, we can consider the following approaches:

1. Use eslint type instructions, such as `@st-ignore "unscoped"`.
2. Explicitly state the semantics of the stylesheet using statements like `@st-global, @st-theme, or @st-side-effects`.

For now, allowing no selector allows a similar type of behavior.

I didn't report a new error for invalid selectors or comments, as this would be a breaking change.