### PR TITLE
refactor: bailout transform for internal `-st-` decls

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -302,25 +302,19 @@ export class StylableTransformer {
                 });
             }
 
-            if (this.mode === 'production') {
-                if (decl.prop.startsWith('-st-')) {
+            if (decl.prop.startsWith('-st-')) {
+                if (this.mode === 'production') {
                     this.directiveNodes.push(decl);
                 }
+                return;
             }
 
-            switch (decl.prop) {
-                case `-st-partial-mixin`:
-                case `-st-mixin`:
-                case `-st-states`:
-                    break;
-                default:
-                    decl.value = this.evaluator.evaluateValue(transformContext, {
-                        value: decl.value,
-                        meta,
-                        node: decl,
-                        cssVarsMapping,
-                    }).outputValue;
-            }
+            decl.value = this.evaluator.evaluateValue(transformContext, {
+                value: decl.value,
+                meta,
+                node: decl,
+                cssVarsMapping,
+            }).outputValue;
         };
 
         ast.walk((node) => {


### PR DESCRIPTION
This PR bails-out fast out of transformation for build-time declaration - any declaration that start with `-st-`.