### PR TITLE
fix: warn diagnostics for `@st-scope` with no selector

### DIFF
--- a/packages/language-service/src/lib/css-service.ts
+++ b/packages/language-service/src/lib/css-service.ts
@@ -145,6 +145,7 @@ export class CssService {
             atRule.name = mq;
 
             const replacementDiff = `${stScope} ${atRule.params}`.length - `${mq} all`.length;
+            atRule.raws.afterName = ' ';
             atRule.params = 'all' + ' '.repeat(replacementDiff);
         });
 

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -176,6 +176,10 @@ describe('diagnostics', () => {
             const diagnostics = createDiagnostics(
                 {
                     [filePath]: deindent(`
+                    @st-scope{
+                        .root {}
+                    }
+
                     @st-scope {
                         .root {}
                     }

--- a/packages/language-service/test/lib/diagnostics.spec.ts
+++ b/packages/language-service/test/lib/diagnostics.spec.ts
@@ -176,6 +176,10 @@ describe('diagnostics', () => {
             const diagnostics = createDiagnostics(
                 {
                     [filePath]: deindent(`
+                    @st-scope {
+                        .root {}
+                    }
+                    
                     @st-scope [div=rtl] {
                          .root {}
                     }


### PR DESCRIPTION
This PR fixes a missed case in [st-scope with no scoping selector](#2883) to make sure that a `@st-scope {}` (no selector) avoids the native css language service ""unknown at-rule" warning