### PR TITLE
fix(lsp): unhandled errors

### DIFF
--- a/packages/language-service/src/lib/provider.ts
+++ b/packages/language-service/src/lib/provider.ts
@@ -400,7 +400,7 @@ export class Provider {
 
         let mixin = '';
         const rev = parsed.nodes[parsed.nodes.length - 1];
-        if (rev.type === 'function' && !!rev.unclosed) {
+        if (rev?.type === 'function' && !!rev.unclosed) {
             mixin = rev.value;
         } else {
             return null;

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -421,16 +421,16 @@ export class StylableLanguageService {
 
 wrapAndCatchErrors(
     {
-        onDefinition: [],
-        onCompletion: [],
-        onSignatureHelp: null,
-        onReferences: [],
-        onHover: null,
-        onColorPresentation: [],
-        onDocumentColor: undefined,
-        onDocumentFormatting: undefined,
-        onDocumentRangeFormatting: undefined,
-        onRenameRequest: undefined,
+        onDefinition: () => [],
+        onCompletion: () => [],
+        onSignatureHelp: () => null,
+        onReferences: () => [],
+        onHover: () => null,
+        onColorPresentation: () => [],
+        onDocumentColor: () => [],
+        onDocumentFormatting: () => [],
+        onDocumentRangeFormatting: () => [],
+        onRenameRequest: () => ({ changes: {} }),
     },
     StylableLanguageService
 );

--- a/packages/language-service/src/lib/service.ts
+++ b/packages/language-service/src/lib/service.ts
@@ -32,6 +32,7 @@ import { getRefs, getRenameRefs } from './provider';
 import { typescriptSupport } from './typescript-support';
 import type { ExtendedTsLanguageService } from './types';
 import { LangServiceContext } from '../lib-new/lang-service-context';
+import { wrapAndCatchErrors } from './utils/wrap-and-log';
 
 export interface StylableLanguageServiceOptions {
     fs: IFileSystem;
@@ -417,6 +418,22 @@ export class StylableLanguageService {
         return null;
     }
 }
+
+wrapAndCatchErrors(
+    {
+        onDefinition: [],
+        onCompletion: [],
+        onSignatureHelp: null,
+        onReferences: [],
+        onHover: null,
+        onColorPresentation: [],
+        onDocumentColor: undefined,
+        onDocumentFormatting: undefined,
+        onDocumentRangeFormatting: undefined,
+        onRenameRequest: undefined,
+    },
+    StylableLanguageService
+);
 
 export interface StylableFile {
     path: string;

--- a/packages/language-service/src/lib/utils/wrap-and-log.ts
+++ b/packages/language-service/src/lib/utils/wrap-and-log.ts
@@ -1,6 +1,6 @@
 type FunctionConfig<T> = Pick<
     {
-        [K in keyof T]: T[K] extends (...args: any[]) => infer R ? R : never;
+        [K in keyof T]: T[K] extends (...args: any[]) => infer R ? () => R : never;
     },
     {
         [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
@@ -22,7 +22,7 @@ export function wrapAndCatchErrors<T extends Record<string, any>>(
         }
         proto[name as keyof T] = function (this: T, ...args: any[]) {
             try {
-                return func.apply(this, args) || defaultReturn;
+                return func.apply(this, args) || (defaultReturn as () => any)();
             } catch (e) {
                 const errorContent = e instanceof Error ? e.stack : e;
                 console.error(`\nUnexpected error in ${name}\n`);

--- a/packages/language-service/src/lib/utils/wrap-and-log.ts
+++ b/packages/language-service/src/lib/utils/wrap-and-log.ts
@@ -20,9 +20,9 @@ export function wrapAndCatchErrors<T extends Record<string, any>>(
             );
             continue;
         }
-        proto[name as keyof T] = function (this: T, ...args: any[]) {
+        proto[name as keyof T] = function (this: T, ...args: unknown[]) {
             try {
-                return func.apply(this, args) || (defaultReturn as () => any)();
+                return func.apply(this, args) || (defaultReturn as () => unknown)();
             } catch (e) {
                 const errorContent = e instanceof Error ? e.stack : e;
                 console.error(`\nUnexpected error in ${name}\n`);

--- a/packages/language-service/src/lib/utils/wrap-and-log.ts
+++ b/packages/language-service/src/lib/utils/wrap-and-log.ts
@@ -1,0 +1,34 @@
+type FunctionConfig<T> = Pick<
+    {
+        [K in keyof T]: T[K] extends (...args: any[]) => infer R ? R : never;
+    },
+    {
+        [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
+    }[keyof T]
+>;
+
+export function wrapAndCatchErrors<T extends Record<string, any>>(
+    config: Partial<FunctionConfig<T>>,
+    context: new (...args: any[]) => T
+) {
+    const proto = context.prototype;
+    for (const [name, defaultReturn] of Object.entries(config)) {
+        const func = proto[name];
+        if (typeof func !== 'function') {
+            console.error(
+                `expected to find a function named ${name} on context, but found ${typeof func}`
+            );
+            continue;
+        }
+        proto[name as keyof T] = function (this: T, ...args: any[]) {
+            try {
+                return func.apply(this, args) || defaultReturn;
+            } catch (e) {
+                const errorContent = e instanceof Error ? e.stack : e;
+                console.error(`\nUnexpected error in ${name}\n`);
+                console.log(`${errorContent}\n\n`);
+                return;
+            }
+        } as T[typeof name];
+    }
+}


### PR DESCRIPTION
This PR wraps the main language service APIs, catch and log any unexpected errors, and return a fallback default value.

It should minimize the errors a user sees, and still allow us to research issues.

-----

In addition there is a small fix for `onSignatureHelp` that explodes:

```
.x {
    -st-mixin: mix(
        arg value(var)^caret:press(ctrl+shift+space)^
    )
}
``` 