### PR TITLE
fix: first level pseudo-element def with extend in structure mode

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -827,10 +827,15 @@ export class InferredSelector {
         for (const resolvedContext of this.resolveSet.values()) {
             /**
              * search for elements in each resolved selector.
-             * start at 1 for extended symbols to prefer inherited elements over local
+             * start at 1 for legacy flat mode to prefer inherited elements over local
              */
             const startIndex =
-                resolvedContext.length === 1 || resolvedContext[0]?.symbol._kind === 'part' ? 0 : 1;
+                resolvedContext.length === 1 ||
+                (resolvedContext[0] &&
+                    (STStructure.isStructureMode(resolvedContext[0].meta) ||
+                        resolvedContext[0].symbol._kind === 'part'))
+                    ? 0
+                    : 1;
             resolved: for (let i = startIndex; i < resolvedContext.length; i++) {
                 const { symbol, meta } = resolvedContext[i];
                 const structureMode = STStructure.isStructureMode(meta);

--- a/packages/core/test/features/st-structure.spec.ts
+++ b/packages/core/test/features/st-structure.spec.ts
@@ -458,6 +458,26 @@ describe('@st structure', () => {
 
             shouldReportNoDiagnostics(meta);
         });
+        it('should resolve first level definition', () => {
+            const { sheets } = testStylableCore(`
+                @st .b {
+                    @st ::title => & > h2;
+                }
+                @st .a :is(.b) {
+                    @st ::title => & > h1;
+                }
+
+                /* @rule .entry__a > h1 */
+                .a::title {}
+
+                /* @rule .entry__b > h2 */
+                .b::title {}
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
         it('should resolve inherited parts', () => {
             const { sheets } = testStylableCore({
                 'base.st.css': `


### PR DESCRIPTION
This PR fixes a pseudo-element missed case with the new `@st` structure definition.

When defining a class with pseudo-element and extend, it is expected to resolve the name of the pseudo-element to it's top definition in the inheritance chain:

```css
@st .base {
    @st ::part => .part-base;
}
@st .top :is(.base) {
    @st ::part => .part-top;
}

/* expect to resolve ::part to ".part-top" */
.top::part {}
```

This doesn't work before this PR because the infer selector process preferred to skip the first resolved symbol (start at `.base` instead of `.top`). This is due to legacy flat mode implicitly defining any local class as a pseudo-element of the `.root` class. Skipping the first resolved symbol allowed targeting both extended parts through pseudo-element syntax or local directly using class syntax.

This is no longer necessary in structure mode, because there are no implicit parts.