### PR TITLE
fix: structure mode pseudo-element selector definition bug

### DIFF
--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -499,7 +499,7 @@ export class StylableResolver {
                         break;
                     }
                 } else {
-                    current = { _kind: 'css', symbol: parent, meta };
+                    current = { _kind: 'css', symbol: parent, meta: current.meta };
                 }
             } else {
                 break;


### PR DESCRIPTION
This PR fixes a missed case for pseudo-element resolve/transform.

The case happens when a class with internal pseudo-elements extend another class with internal parts.
Then when extending the top class in another stylesheet, the resolver doesn't progress the current meta, and instead resolved the origin stylesheet meta (see test).