### PR TITLE
feat: added a `.mjs` pure runtime to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "clean": "rimraf -g ./packages/*/{dist,cjs,esm}",
-    "build": "tsc --build",
+    "build": "tsc --build && node scripts/build.js",
     "watch": "npm run build -- -w",
     "lint": "eslint .",
     "pretest": "npm run build",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,16 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+buildPureEsmRuntime();
+
+/**
+ * duplicate the pure.js file from the dist folder in to a .mjs file
+ */
+function buildPureEsmRuntime() {
+    const projectRoot = path.join(__dirname, '..', 'packages', 'runtime');
+
+    const pureJs = path.join(projectRoot, 'dist', 'pure.js');
+    const pureMjs = path.join(projectRoot, 'dist', 'pure.mjs');
+
+    fs.copyFileSync(pureJs, pureMjs);
+}


### PR DESCRIPTION
Our current runtime output is only compatible with bundlers. When running in Node.js esm modules, we need to use the `.mjs` version of our code, because our package is not currently set to `type: module`.