### PR TITLE
fix: report unexpected pseudo-state param error

### DIFF
--- a/packages/core/src/helpers/custom-state.ts
+++ b/packages/core/src/helpers/custom-state.ts
@@ -154,6 +154,12 @@ export const stateDiagnostics = {
         (state: string, finalSelector: string) =>
             `pseudo-state "${state}" result cannot start with a type or universal selector "${finalSelector}"`
     ),
+    NO_PARAM_REQUIRED: createDiagnosticReporter(
+        '08018',
+        'error',
+        (name: string, param: string) =>
+            `pseudo-state "${name}" accepts no parameter, but received "${param}"`
+    ),
 };
 
 // parse
@@ -859,6 +865,15 @@ export function transformPseudoClassToCustomState(
         convertToClass(stateNode).value = createBooleanStateClassName(name, namespace);
         delete stateNode.nodes;
     } else if (typeof stateDef === 'string') {
+        if (stateNode.nodes && selectorNode) {
+            diagnostics.report(
+                stateDiagnostics.NO_PARAM_REQUIRED(name, stringifySelector(stateNode.nodes)),
+                {
+                    node: selectorNode,
+                    word: stringifySelector(stateNode),
+                }
+            );
+        }
         // simply concat global mapped selector - ToDo: maybe change to 'selector'
         convertToInvalid(stateNode).value = stateDef;
         delete stateNode.nodes;

--- a/packages/core/src/helpers/custom-state.ts
+++ b/packages/core/src/helpers/custom-state.ts
@@ -861,10 +861,7 @@ export function transformPseudoClassToCustomState(
     diagnostics: Diagnostics,
     selectorNode?: postcss.Node
 ) {
-    if (stateDef === null) {
-        convertToClass(stateNode).value = createBooleanStateClassName(name, namespace);
-        delete stateNode.nodes;
-    } else if (typeof stateDef === 'string') {
+    if (stateDef === null || typeof stateDef === 'string') {
         if (stateNode.nodes && selectorNode) {
             diagnostics.report(
                 stateDiagnostics.NO_PARAM_REQUIRED(name, stringifySelector(stateNode.nodes)),
@@ -874,8 +871,14 @@ export function transformPseudoClassToCustomState(
                 }
             );
         }
-        // simply concat global mapped selector - ToDo: maybe change to 'selector'
-        convertToInvalid(stateNode).value = stateDef;
+        if (stateDef === null) {
+            // boolean
+            convertToClass(stateNode).value = createBooleanStateClassName(name, namespace);
+        } else {
+            // static template selector
+            // simply concat global mapped selector - ToDo: maybe change to 'selector'
+            convertToInvalid(stateNode).value = stateDef;
+        }
         delete stateNode.nodes;
     } else if (typeof stateDef === 'object') {
         if (isTemplateState(stateDef)) {

--- a/packages/core/test/features/css-pseudo-class.spec.ts
+++ b/packages/core/test/features/css-pseudo-class.spec.ts
@@ -34,24 +34,40 @@ describe('features/css-pseudo-class', () => {
     });
     describe('st-custom-state', () => {
         it('should transform boolean state', () => {
-            const { sheets } = testStylableCore(`
-                .root {
-                    /* @transform-remove(removed decl) */
-                    -st-states: bool,
-                                exBool(boolean);
-                }
+            const { sheets } = testStylableCore({
+                '/valid.st.css': `
+                    .root {
+                        /* @transform-remove(removed decl) */
+                        -st-states: bool,
+                                    exBool(boolean);
+                    }
 
-                /* @rule(boolean) .entry__root.entry--bool */
-                .root:bool {}
+                    /* @rule(boolean) .valid__root.valid--bool */
+                    .root:bool {}
 
-                /* @rule(explicit boolean) .entry__root.entry--exBool */
-                .root:exBool {}
+                    /* @rule(explicit boolean) .valid__root.valid--exBool */
+                    .root:exBool {}
 
-                /* @rule(nested) .entry__root:not(.entry--bool) */
-                .root:not(:bool) {}
-            `);
+                    /* @rule(nested) .valid__root:not(.valid--bool) */
+                    .root:not(:bool) {}
+                `,
+                '/invalid.st.css': `
+                    .root {
+                        -st-states: bool;
+                    }
+                    
+                    /* 
+                        @transform-error ${stCustomStateDiagnostics.NO_PARAM_REQUIRED(
+                            'bool',
+                            'unknown-param'
+                        )}
+                        @rule .invalid__root.invalid--bool
+                    */
+                    .root:bool(unknown-param) {}
+                `,
+            });
 
-            const { meta } = sheets['/entry.st.css'];
+            const { meta } = sheets['/valid.st.css'];
             shouldReportNoDiagnostics(meta);
         });
         describe('string parameter', () => {

--- a/packages/core/test/features/css-pseudo-class.spec.ts
+++ b/packages/core/test/features/css-pseudo-class.spec.ts
@@ -412,6 +412,38 @@ describe('features/css-pseudo-class', () => {
                 `);
             });
         });
+        describe('custom mapped static', () => {
+            it('should transform to global selector', () => {
+                const { sheets } = testStylableCore(`
+                    .root {
+                        -st-states: static(".x[y]"),
+                    }
+
+                    /* @rule .entry__root.x[y]*/
+                    .root:static {}
+                `);
+
+                const { meta } = sheets['/entry.st.css'];
+
+                shouldReportNoDiagnostics(meta);
+            });
+            it('should report error for unexpected param', () => {
+                testStylableCore(`
+                    .root {
+                        -st-states: static("[y]"),
+                    }
+
+                    /* 
+                        @transform-error ${stCustomStateDiagnostics.NO_PARAM_REQUIRED(
+                            'static',
+                            'unknown-param'
+                        )}
+                        @rule .entry__root[y]
+                    */
+                    .root:static(unknown-param) {}
+                `);
+            });
+        });
         describe('custom mapped parameter', () => {
             it('should transform mapped state (quoted)', () => {
                 const { sheets } = testStylableCore(`


### PR DESCRIPTION
This PR add a missing error diagnostic when passing an unexpected param to a pseudo-class that doesn't except parameters: template state and boolean state