### PR TITLE
fix(webpack): false positive unused stylesheet collision

### DIFF
--- a/packages/webpack-plugin/src/plugin-utils.ts
+++ b/packages/webpack-plugin/src/plugin-utils.ts
@@ -470,7 +470,7 @@ function getModuleRequestPath(
 export interface OptimizationMapping {
     usageMapping: Record<string, boolean>;
     namespaceMapping: Record<string, string>;
-    namespaceToFileMapping: Map<string, Set<NormalModule>>;
+    potentialNamespaceCollision: Map<string, Set<NormalModule>>;
 }
 
 export function createOptimizationMapping(
@@ -485,17 +485,21 @@ export function createOptimizationMapping(
                 acc.usageMapping[namespace] = isUsed ?? true;
             }
             acc.namespaceMapping[namespace] = optimizer.getNamespace(namespace);
-            if (acc.namespaceToFileMapping.has(namespace)) {
-                acc.namespaceToFileMapping.get(namespace)!.add(module);
+            if (!isUsed) {
+                // skip collision map for unused stylesheets
+                return acc;
+            }
+            if (acc.potentialNamespaceCollision.has(namespace)) {
+                acc.potentialNamespaceCollision.get(namespace)!.add(module);
             } else {
-                acc.namespaceToFileMapping.set(namespace, new Set([module]));
+                acc.potentialNamespaceCollision.set(namespace, new Set([module]));
             }
             return acc;
         },
         {
             usageMapping: {},
             namespaceMapping: {},
-            namespaceToFileMapping: new Map<string, Set<NormalModule>>(),
+            potentialNamespaceCollision: new Map<string, Set<NormalModule>>(),
         }
     );
 }

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -589,11 +589,11 @@ export class StylableWebpackPlugin {
                 (m) => m.resource
             );
 
-            const { usageMapping, namespaceMapping, namespaceToFileMapping } =
+            const { usageMapping, namespaceMapping, potentialNamespaceCollision } =
                 createOptimizationMapping(sortedModules, optimizer);
 
             reportNamespaceCollision(
-                namespaceToFileMapping,
+                potentialNamespaceCollision,
                 compilation,
                 normalizeNamespaceCollisionOption(
                     this.options.unsafeMuteDiagnostics.DUPLICATE_MODULE_NAMESPACE


### PR DESCRIPTION
This PR fix a case of false positive `duplicate namespace` error.

There is no test for this case yet, as it is hard to reproduce with our infra, but these are the details:

- `nextjs` in app directory mode
- external stylable lib with 
  - components with stylable base 
  - component variants that import the base as interface
- user project import (Javascript):
  - component _(-> import base stylesheet)_
  - variant to style the component _(-> import base stylesheet)_

For some reason, although both imports (component & variant) are resolving the same base stylesheet, `webpack` is generating 2 modules, one with absolute path from the variant and one relative path from the component.

Our `duplicate namespace` check gets both modules, with the same namespace! and report the error.

The fix is to filter out the module that is being imported from the variant as it is only used as an interface and isn't important for this check. This is done by checking the `isUsed` flag we already provide for the module.