### PR TITLE
chore: deprecate native namespace override

### DIFF
--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -66,6 +66,7 @@ export class StylableProcessor implements FeatureContext {
 
             this.collectUrls(decl);
         });
+        STNamespace.hooks.analyzeDone(this);
         STCustomSelector.hooks.analyzeDone(this);
         STStructure.hooks.analyzeDone(this);
 

--- a/packages/core/test/features/st-namespace.spec.ts
+++ b/packages/core/test/features/st-namespace.spec.ts
@@ -245,11 +245,16 @@ describe('features/st-namespace', () => {
             @namespace was previously used instead of @st-namespace.
             In order to preserve backwards compatibility, @namespace will
             continue to define the stylable namespace under specific conditions.
+
+            ToDo(major): remove special handling of native @namespace
         */
         it('should override default namespace with @namespace', () => {
             const { sheets } = testStylableCore({
                 '/other.st.css': `
-                    /* @transform-remove */
+                    /* 
+                        @transform-remove 
+                        @analyze-info ${diagnostics.NATIVE_OVERRIDE_DEPRECATION()}
+                    */
                     @namespace "button";
     
                     /* @rule .button__x */
@@ -258,8 +263,6 @@ describe('features/st-namespace', () => {
             });
 
             const { meta, exports } = sheets['/other.st.css'];
-
-            shouldReportNoDiagnostics(meta);
 
             expect(meta.namespace, 'meta.namespace').to.eql('button');
 

--- a/packages/esbuild/test/e2e/duplicate-namespace/a.st.css
+++ b/packages/esbuild/test/e2e/duplicate-namespace/a.st.css
@@ -1,3 +1,3 @@
-@namespace "X";
+@st-namespace "X";
 
 /* st-namespace-reference="x" */

--- a/packages/esbuild/test/e2e/duplicate-namespace/b.st.css
+++ b/packages/esbuild/test/e2e/duplicate-namespace/b.st.css
@@ -1,3 +1,3 @@
-@namespace "X";
+@st-namespace "X";
 
 /* st-namespace-reference="x" */

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components-deep/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components-deep/button.st.css
@@ -1,8 +1,9 @@
-@namespace "topBtn";
+@st-namespace "topBtn";
 
 .root {
     background: red;
 }
+
 .text {
     color: aliceblue;
 }

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components-deep/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components-deep/index.st.css
@@ -1,4 +1,4 @@
-@namespace "topIndex";
+@st-namespace "topIndex";
 
 :import {
     -st-from: "./button.st.css";

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components/index.st.css
@@ -1,4 +1,5 @@
-@namespace "compsIndex";
+@st-namespace "compsIndex";
+
 :import {
     -st-from: "test-components-deep/button.st.css";
     -st-default: Button;

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components/node_modules/test-components-deep/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components/node_modules/test-components-deep/button.st.css
@@ -1,8 +1,9 @@
-@namespace "deepBtn";
+@st-namespace "deepBtn";
 
 .root {
     background: green;
 }
+
 .text {
     color: blue;
 }

--- a/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components/node_modules/test-components-deep/index.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/4th-party-project/node_modules/test-components/node_modules/test-components-deep/index.st.css
@@ -1,4 +1,4 @@
-@namespace "deepIndex";
+@st-namespace "deepIndex";
 
 :import {
     -st-from: "./button.st.css";

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/cjs/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/cjs/button.st.css
@@ -1,4 +1,4 @@
-@namespace "cjs";
+@st-namespace "cjs";
 
 .root {
     background: red;

--- a/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/esm/button.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/browser-field/node_modules/test-components/esm/button.st.css
@@ -1,4 +1,4 @@
-@namespace "esm";
+@st-namespace "esm";
 
 .root {
     background: green;

--- a/packages/webpack-plugin/test/e2e/projects/simplest-project-target-node/node_modules/comp-lib/index.cjs.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/simplest-project-target-node/node_modules/comp-lib/index.cjs.st.css
@@ -1,4 +1,4 @@
-@namespace "Index";
+@st-namespace "Index";
 
 :vars {
     kind: cjs;

--- a/packages/webpack-plugin/test/e2e/projects/simplest-project-target-node/node_modules/comp-lib/index.es.st.css
+++ b/packages/webpack-plugin/test/e2e/projects/simplest-project-target-node/node_modules/comp-lib/index.es.st.css
@@ -1,4 +1,4 @@
-@namespace "Index";
+@st-namespace "Index";
 
 :vars {
     kind: esm;


### PR DESCRIPTION
This PR adds an info deprecation diagnostics to the native `@namespace` override stylable is doing.

The diagnostic will be reported for the rest of v5 from now on to guide users to change to `@st-namespace` instead and the functionality will be removed in v6.