### PR TITLE
fix(core): imported symbols runtime leak

### DIFF
--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -313,7 +313,7 @@ export class StylableTransformer {
                 value: decl.value,
                 meta,
                 node: decl,
-                cssVarsMapping,
+                cssVarsMapping: cssVarsMapping.localToGlobal,
             }).outputValue;
         };
 
@@ -353,7 +353,7 @@ export class StylableTransformer {
             context: transformContext,
             ast,
             transformer: this,
-            cssVarsMapping,
+            cssVarsMapping: cssVarsMapping.localToGlobal,
             path,
         };
         if (this.experimentalSelectorInference) {

--- a/packages/core/test/features/css-contains.spec.ts
+++ b/packages/core/test/features/css-contains.spec.ts
@@ -401,10 +401,29 @@ describe('features/css-contains', () => {
             });
 
             // JS exports
-            expect(exports.containers, `JS exports`).to.eql({
-                c1: `imported__c1`,
-                'local-container': `imported__c2`,
+            expect(exports.containers, `JS exports only locals`).to.eql({});
+        });
+        it(`should NOT expose imported symbols properties to runtime`, () => {
+            const { sheets } = testStylableCore({
+                '/containers.st.css': `
+                    .root {
+                        container-name: x y;
+                    }
+                `,
+                '/entry.st.css': `
+                    @st-import [container(x, y as localY)] from './containers.st.css';
+                    
+                    @container x (inline-size > 1px) {}
+                    @container localY (inline-size > 1px) {}
+                `,
             });
+
+            const { meta, exports } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            // JS exports
+            expect(exports.containers).to.eql({});
         });
         it('should report unknown container name', () => {
             testStylableCore({
@@ -458,9 +477,7 @@ describe('features/css-contains', () => {
             });
 
             // JS exports
-            expect(exports.containers, `JS exports`).to.eql({
-                x: `b__x`,
-            });
+            expect(exports.containers, `JS exports only locals`).to.eql({});
         });
         it('should resolve imported global container name', () => {
             const { sheets } = testStylableCore({
@@ -505,7 +522,7 @@ describe('features/css-contains', () => {
                 `,
             });
 
-            const { meta, exports } = sheets['/entry.st.css'];
+            const { meta } = sheets['/entry.st.css'];
 
             shouldReportNoDiagnostics(meta);
 
@@ -523,12 +540,6 @@ describe('features/css-contains', () => {
                 name: 'after',
                 global: false,
                 import: meta.getImportStatements()[0],
-            });
-
-            // JS exports
-            expect(exports.containers, `JS exports`).to.eql({
-                before: `imported__before`,
-                after: `imported__after`,
             });
         });
     });
@@ -603,9 +614,7 @@ describe('features/css-contains', () => {
             );
 
             // JS exports
-            expect(exports.containers, `JS export`).to.eql({
-                a: 'a',
-            });
+            expect(exports.containers, `JS export only locals`).to.eql({});
         });
     });
 });

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -493,7 +493,7 @@ describe(`features/css-custom-property`, () => {
                 `,
             });
 
-            const { meta, exports } = sheets['/entry.st.css'];
+            const { meta } = sheets['/entry.st.css'];
 
             shouldReportNoDiagnostics(meta);
 
@@ -510,10 +510,29 @@ describe(`features/css-custom-property`, () => {
                 global: false,
                 alias: STSymbol.get(meta, `--after`, `import`),
             });
+        });
+        it(`should NOT expose imported symbols properties to runtime`, () => {
+            const { sheets } = testStylableCore({
+                '/props.st.css': `
+                    @property --propA;
+                    .root {
+                        --propB: red;
+                    }
+                `,
+                '/entry.st.css': `
+                    @st-import [--propA, --propB as --local] from './props.st.css';
+                    .root {
+                        --propA: green;
+                    }
+                `,
+            });
+
+            const { meta, exports } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
 
             // JS exports
-            expect(exports.vars.before, `before JS export`).to.eql(`--props-before`);
-            expect(exports.vars.after, `after JS export`).to.eql(`--props-after`);
+            expect(exports.vars).to.eql({});
         });
         it(`should re-export imported symbols`, () => {
             const { sheets } = testStylableCore({
@@ -534,14 +553,9 @@ describe(`features/css-custom-property`, () => {
                 `,
             });
 
-            const { meta, exports } = sheets['/entry.st.css'];
+            const { meta } = sheets['/entry.st.css'];
 
             shouldReportNoDiagnostics(meta);
-
-            // JS exports
-            expect(exports.vars.propA, `propA export`).to.eql(`--props-propA`);
-            expect(exports.vars.local, `mapped export`).to.eql(`--props-propB`);
-            expect(exports.vars.deepProp, `deep export`).to.eql(`--base-deepProp`);
         });
         it(`should override imported with local definition`, () => {
             const { sheets } = testStylableCore({
@@ -621,7 +635,7 @@ describe(`features/css-custom-property`, () => {
                 `,
             });
 
-            const { meta, exports } = sheets['/entry.st.css'];
+            const { meta } = sheets['/entry.st.css'];
 
             shouldReportNoDiagnostics(meta);
 
@@ -632,9 +646,6 @@ describe(`features/css-custom-property`, () => {
                 global: false,
                 alias: STSymbol.get(meta, `--mapped`, `import`),
             });
-
-            // JS exports
-            expect(exports.vars.mapped, `mapped JS export`).to.eql(`--props-a`);
         });
         it(`should resolve global property`, () => {
             const { sheets } = testStylableCore({
@@ -951,7 +962,7 @@ describe(`features/css-custom-property`, () => {
             });
 
             const { meta: nativeMeta } = stylable.transform('/native.css');
-            const { meta, exports } = stylable.transform('/entry.st.css');
+            const { meta } = stylable.transform('/entry.st.css');
 
             shouldReportNoDiagnostics(nativeMeta);
             shouldReportNoDiagnostics(meta);
@@ -968,13 +979,6 @@ describe(`features/css-custom-property`, () => {
                     }
                 `)
             );
-
-            // JS exports
-            expect(exports.vars, `JS export`).to.eql({
-                a: '--a',
-                b: '--b',
-                c: '--c',
-            });
         });
         it('should ignore stylable specific transformations', () => {
             const { stylable } = testStylableCore({

--- a/packages/core/test/features/css-keyframes.spec.ts
+++ b/packages/core/test/features/css-keyframes.spec.ts
@@ -314,10 +314,7 @@ describe(`features/css-keyframes`, () => {
             });
 
             // JS exports
-            expect(exports.keyframes, `JS exports`).to.eql({
-                anim1: `imported__anim1`,
-                'local-anim': `imported__anim2`,
-            });
+            expect(exports.keyframes, `expose only locals to runtime`).to.eql({});
         });
         it(`should resolve imported global @keyframes`, () => {
             const { sheets } = testStylableCore({
@@ -359,10 +356,7 @@ describe(`features/css-keyframes`, () => {
             });
 
             // JS exports
-            expect(exports.keyframes, `JS exports`).to.eql({
-                anim1: `anim1`,
-                'local-anim': `anim2`,
-            });
+            expect(exports.keyframes, `expose only locals to runtime`).to.eql({});
         });
         it(`should override imported with local @keyframes`, () => {
             const { sheets } = testStylableCore({
@@ -654,9 +648,7 @@ describe(`features/css-keyframes`, () => {
             );
 
             // JS exports
-            expect(exports.keyframes, `JS export`).to.eql({
-                jump: 'jump',
-            });
+            expect(exports.keyframes, `expose only locals to runtime`).to.eql({});
         });
         it('should ignore stylable specific transformations', () => {
             const { stylable } = testStylableCore({

--- a/packages/core/test/features/css-layer.spec.ts
+++ b/packages/core/test/features/css-layer.spec.ts
@@ -283,10 +283,28 @@ describe('features/css-layer', () => {
             });
 
             // JS exports
-            expect(exports.layers, `JS exports`).to.eql({
-                layer1: `imported__layer1`,
-                'local-layer': `imported__layer2`,
+            expect(exports.layers, `JS exports only locals`).to.eql({});
+        });
+        it(`should NOT expose imported symbols properties to runtime`, () => {
+            const { sheets } = testStylableCore({
+                '/layers.st.css': `
+                    @layer x {}
+                    @layer y {}
+                `,
+                '/entry.st.css': `
+                    @st-import [layer(x, y as localY)] from './layers.st.css';
+                    
+                    @layer x {}
+                    @layer localY {}
+                `,
             });
+
+            const { meta, exports } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            // JS exports
+            expect(exports.layers).to.eql({});
         });
         it('should resolve imported global @layer', () => {
             const { sheets } = testStylableCore({
@@ -326,10 +344,7 @@ describe('features/css-layer', () => {
             });
 
             // JS exports
-            expect(exports.layers, `JS exports`).to.eql({
-                layer1: `layer1`,
-                'local-layer': `layer2`,
-            });
+            expect(exports.layers, `JS exports only locals`).to.eql({});
         });
         it('should report unknown @layer import', () => {
             const { sheets } = testStylableCore({
@@ -404,9 +419,7 @@ describe('features/css-layer', () => {
             });
 
             // JS exports
-            expect(exports.layers, `JS exports`).to.eql({
-                L1: `imported__L1`,
-            });
+            expect(exports.layers, `JS exports only locals`).to.eql({});
         });
     });
     describe('st-mixin', () => {
@@ -531,7 +544,6 @@ describe('features/css-layer', () => {
                 L2: 'entry__L2',
                 'L3\\.X': 'entry__L3\\.X',
                 'global-layer': 'global-layer',
-                imported: 'other__imported',
             });
         });
         it.skip('should not allow between @import rules', () => {
@@ -572,11 +584,7 @@ describe('features/css-layer', () => {
             );
 
             // JS exports
-            expect(exports.layers, 'JS export').to.eql({
-                a: 'a',
-                b: 'b',
-                c: 'c',
-            });
+            expect(exports.layers, 'JS export only locals').to.eql({});
         });
         it('should ignore stylable specific transformations', () => {
             const { stylable } = testStylableCore({

--- a/packages/core/test/features/st-import.spec.ts
+++ b/packages/core/test/features/st-import.spec.ts
@@ -98,6 +98,20 @@ describe(`features/st-import`, () => {
         });
         expect(meta.getSymbol(`c`), `mapped origin`).to.equal(undefined);
     });
+    it('should not add imported symbols to runtime exports', () => {
+        const { sheets } = testStylableCore({
+            'origin.st.css': `
+                .cls {}
+            `,
+            'entry.st.css': `
+                @st-import Root, [cls] from "./origin.st.css"; 
+            `,
+        });
+
+        const { exports } = sheets['/entry.st.css'];
+
+        expect(Object.keys(exports.classes)).to.not.contain('cls');
+    });
     it(`should only be defined at top level`, () => {
         const { sheets } = testStylableCore(`
             .x {

--- a/packages/core/test/features/st-var.spec.ts
+++ b/packages/core/test/features/st-var.spec.ts
@@ -826,7 +826,7 @@ describe(`features/st-var`, () => {
                 text: `value(before)`,
             });
 
-            // exports
+            // exports only local vars
             expect(exports.stVars, `JS export not contains imported`).to.eql({
                 localBefore: `before-val`,
                 localAfter: `after-val`,

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -217,7 +217,9 @@ describe('Stylable', () => {
                 'foo.st.css': '.foo {}',
                 'entry.st.css': `
                   @st-import [foo] from './foo.st.css';
-                  .root .foo { }
+                  .baz {
+                    -st-extends: foo;
+                  }
                 `,
             });
 
@@ -229,7 +231,9 @@ describe('Stylable', () => {
                 '/entry.st.css',
                 `
                 @st-import [bar] from './foo.st.css';
-                .root .bar { }
+                .baz {
+                    -st-extends: bar;
+                }
 
                 `
             );
@@ -240,7 +244,7 @@ describe('Stylable', () => {
             const res = stylable.transform(stylable.analyze('/entry.st.css'));
 
             expect(res.exports.classes).to.eql({
-                bar: 'foo__bar',
+                baz: 'entry__baz foo__bar',
                 root: 'entry__root',
             });
             expect(

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -221,10 +221,13 @@ describe('Generate DTS', function () {
             'origin.st.css': `
                 .cls {}
                 @property --customProp;
+                :vars {
+                    buildVar: red;
+                }
             `,
             'test.st.css': `
-                @st-import CompRoot, [cls, --customProp] from './origin.st.css';
-                .cls { color: green; }
+                @st-import CompRoot, [cls, --customProp, buildVar] from './origin.st.css';
+                .cls { color: value(buildVar); }
                 .CompRoot { 
                     color: green;
                     --customProp: green;
@@ -232,17 +235,20 @@ describe('Generate DTS', function () {
             `,
             'test.ts': `
                 import { eq } from "./test-kit";
-                import { classes, vars } from "./test.st.css";
+                import { classes, vars, stVars } from "./test.st.css";
                 
                 eq<string>(classes.cls);
                 eq<string>(classes.CompRoot);
                 eq<string>(vars.customProp);
+                eq<string>(vars.customProp);
+                eq<string>(stVars.buildVar);
             `,
         });
 
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('cls'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('CompRoot'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('customProp'));
+        expect(tk.typecheck('test.ts')).to.include(propNotOnType('buildVar'));
     });
 
     describe('st function', () => {

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -227,6 +227,7 @@ describe('Generate DTS', function () {
                     buildVar: red;
                 }
                 @keyframes anim {}
+                @layer layer1 {}
             `,
             'test.st.css': `
                 @st-import CompRoot, [
@@ -235,6 +236,7 @@ describe('Generate DTS', function () {
                     buildVar,
                     keyframes(anim),
                     container(cont),
+                    layer(layer1),
                 ] from './origin.st.css';
                 .cls { color: value(buildVar); }
                 .CompRoot { 
@@ -243,10 +245,11 @@ describe('Generate DTS', function () {
                     animation: anim;
                 }
                 @container cont (inline-size > 1px) {}
+                @layer layer1 {}
             `,
             'test.ts': `
                 import { eq } from "./test-kit";
-                import { classes, vars, stVars, keyframes, containers } from "./test.st.css";
+                import { classes, vars, stVars, keyframes, containers, layers } from "./test.st.css";
                 
                 eq<string>(classes.cls);
                 eq<string>(classes.CompRoot);
@@ -255,6 +258,7 @@ describe('Generate DTS', function () {
                 eq<string>(stVars.buildVar);
                 eq<string>(keyframes.anim);
                 eq<string>(containers.cont);
+                eq<string>(layers.layer1);
             `,
         });
 
@@ -264,6 +268,7 @@ describe('Generate DTS', function () {
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('buildVar'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('anim'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('cont'));
+        expect(tk.typecheck('test.ts')).to.include(propNotOnType('layer1'));
     });
 
     describe('st function', () => {

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -224,24 +224,32 @@ describe('Generate DTS', function () {
                 :vars {
                     buildVar: red;
                 }
+                @keyframes anim {}
             `,
             'test.st.css': `
-                @st-import CompRoot, [cls, --customProp, buildVar] from './origin.st.css';
+                @st-import CompRoot, [
+                    cls,
+                    --customProp,
+                    buildVar,
+                    keyframes(anim)
+                ] from './origin.st.css';
                 .cls { color: value(buildVar); }
                 .CompRoot { 
                     color: green;
                     --customProp: green;
+                    animation: anim;
                 }
             `,
             'test.ts': `
                 import { eq } from "./test-kit";
-                import { classes, vars, stVars } from "./test.st.css";
+                import { classes, vars, stVars, keyframes } from "./test.st.css";
                 
                 eq<string>(classes.cls);
                 eq<string>(classes.CompRoot);
                 eq<string>(vars.customProp);
                 eq<string>(vars.customProp);
                 eq<string>(stVars.buildVar);
+                eq<string>(keyframes.anim);
             `,
         });
 
@@ -249,6 +257,7 @@ describe('Generate DTS', function () {
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('CompRoot'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('customProp'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('buildVar'));
+        expect(tk.typecheck('test.ts')).to.include(propNotOnType('anim'));
     });
 
     describe('st function', () => {

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -218,23 +218,31 @@ describe('Generate DTS', function () {
 
     it('should not expose imported symbols', () => {
         tk.populate({
-            'origin.st.css': `.cls {}`,
+            'origin.st.css': `
+                .cls {}
+                @property --customProp;
+            `,
             'test.st.css': `
-                @st-import CompRoot, [cls] from './base.st.css';
+                @st-import CompRoot, [cls, --customProp] from './origin.st.css';
                 .cls { color: green; }
-                .CompRoot { color: green; }
+                .CompRoot { 
+                    color: green;
+                    --customProp: green;
+                }
             `,
             'test.ts': `
                 import { eq } from "./test-kit";
-                import { classes } from "./test.st.css";
+                import { classes, vars } from "./test.st.css";
                 
                 eq<string>(classes.cls);
                 eq<string>(classes.CompRoot);
+                eq<string>(vars.customProp);
             `,
         });
 
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('cls'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('CompRoot'));
+        expect(tk.typecheck('test.ts')).to.include(propNotOnType('customProp'));
     });
 
     describe('st function', () => {

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -219,7 +219,9 @@ describe('Generate DTS', function () {
     it('should not expose imported symbols', () => {
         tk.populate({
             'origin.st.css': `
-                .cls {}
+                .cls {
+                    container-name: cont;
+                }
                 @property --customProp;
                 :vars {
                     buildVar: red;
@@ -231,7 +233,8 @@ describe('Generate DTS', function () {
                     cls,
                     --customProp,
                     buildVar,
-                    keyframes(anim)
+                    keyframes(anim),
+                    container(cont),
                 ] from './origin.st.css';
                 .cls { color: value(buildVar); }
                 .CompRoot { 
@@ -239,10 +242,11 @@ describe('Generate DTS', function () {
                     --customProp: green;
                     animation: anim;
                 }
+                @container cont (inline-size > 1px) {}
             `,
             'test.ts': `
                 import { eq } from "./test-kit";
-                import { classes, vars, stVars, keyframes } from "./test.st.css";
+                import { classes, vars, stVars, keyframes, containers } from "./test.st.css";
                 
                 eq<string>(classes.cls);
                 eq<string>(classes.CompRoot);
@@ -250,6 +254,7 @@ describe('Generate DTS', function () {
                 eq<string>(vars.customProp);
                 eq<string>(stVars.buildVar);
                 eq<string>(keyframes.anim);
+                eq<string>(containers.cont);
             `,
         });
 
@@ -258,6 +263,7 @@ describe('Generate DTS', function () {
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('customProp'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('buildVar'));
         expect(tk.typecheck('test.ts')).to.include(propNotOnType('anim'));
+        expect(tk.typecheck('test.ts')).to.include(propNotOnType('cont'));
     });
 
     describe('st function', () => {

--- a/packages/module-utils/test/index.spec.ts
+++ b/packages/module-utils/test/index.spec.ts
@@ -67,7 +67,6 @@ describe('Module Factory', () => {
         expect(exports).to.deep.include({
             classes: {
                 root: 'entry__root',
-                part: 'imported__part',
             },
         });
     });

--- a/packages/module-utils/test/sourcemap.spec.ts
+++ b/packages/module-utils/test/sourcemap.spec.ts
@@ -199,14 +199,9 @@ describe('.d.ts source-maps', () => {
         const res = generateStylableResult({
             entry: `/entry.st.css`,
             files: {
-                '/another.st.css': {
-                    namespace: 'another',
-                    content: `.a { container: C1; }`,
-                },
                 '/entry.st.css': {
                     namespace: 'entry',
                     content: deindent(`
-                        @st-import [container(C1 as imported-container)] from "./another.st.css";
                         .a {
                             container: C2;
                         }
@@ -224,13 +219,7 @@ describe('.d.ts source-maps', () => {
             sourceMapConsumer.originalPositionFor(
                 getPosition(dtsText, 'C2":') // source mapping starts after the first double quote
             )
-        ).to.eql({ line: 3, column: 4, source: 'entry.st.css', name: null });
-        // imported container
-        expect(
-            sourceMapConsumer.originalPositionFor(
-                getPosition(dtsText, 'imported-container":') // source mapping starts after the first double quote
-            )
-        ).to.eql({ line: 1, column: 0, source: 'entry.st.css', name: null });
+        ).to.eql({ line: 2, column: 4, source: 'entry.st.css', name: null });
     });
 
     it('maps states in the ".d.ts" to their positions in the original ".st.css" file', async () => {

--- a/packages/module-utils/test/sourcemap.spec.ts
+++ b/packages/module-utils/test/sourcemap.spec.ts
@@ -163,14 +163,9 @@ describe('.d.ts source-maps', () => {
         const res = generateStylableResult({
             entry: `/entry.st.css`,
             files: {
-                '/another.st.css': {
-                    namespace: 'another',
-                    content: `@layer L0`,
-                },
                 '/entry.st.css': {
                     namespace: 'entry',
                     content: deindent(`
-                        @st-import [layer(L0 as imported-layer)] from "./another.st.css";
                         @layer L1 {}
                     `),
                 },
@@ -185,12 +180,6 @@ describe('.d.ts source-maps', () => {
         expect(
             sourceMapConsumer.originalPositionFor(
                 getPosition(dtsText, 'L1":') // source mapping starts after the first double quote
-            )
-        ).to.eql({ line: 2, column: 0, source: 'entry.st.css', name: null });
-        // imported layer
-        expect(
-            sourceMapConsumer.originalPositionFor(
-                getPosition(dtsText, 'imported-layer":') // source mapping starts after the first double quote
             )
         ).to.eql({ line: 1, column: 0, source: 'entry.st.css', name: null });
     });


### PR DESCRIPTION
This pull request addresses a longstanding regression related to the unintended runtime leakage of imported symbols.

During the process of refactoring the internal symbol resolution code to achieve consistent handling of various symbols, an oversight occurred. This oversight caused the generated JavaScript runtime and the  `.d.ts` files to inadvertently expose imported symbols of the stylesheet.

This situation is problematic because Stylable's assumption is that symbols of a stylesheet are only meant to be used if the stylesheet is imported into a JavaScript file. If it's not imported this way, it's assumed that the symbols' namespacing can't be connected to the DOM and can thus be removed as unnecessary code from the final output.

This fix is undoubtedly necessary. However, it's important to acknowledge that there's a possibility it could introduce disruptions in external code. To mitigate this potential impact, we're planning to conduct a thorough search across both public code repositories and internal code projects accessible to us. This search aims to identify instances where this fix might cause conflicts or complications. Based on our findings, we will make an informed decision about whether to integrate this fix into the upcoming v5 release or reserve it for inclusion in the subsequent major release, v6.