### PR TITLE
fix: mixin with native CSS nesting

### DIFF
--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -63,6 +63,7 @@ export const diagnostics = {
     VALUE_CANNOT_BE_STRING: mixinHelperDiagnostics.VALUE_CANNOT_BE_STRING,
     INVALID_NAMED_PARAMS: mixinHelperDiagnostics.INVALID_NAMED_PARAMS,
     INVALID_MERGE_OF: utilDiagnostics.INVALID_MERGE_OF,
+    INVALID_RECURSIVE_MIXIN: utilDiagnostics.INVALID_RECURSIVE_MIXIN,
     PARTIAL_MIXIN_MISSING_ARGUMENTS: createDiagnosticReporter(
         '10001',
         'error',

--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -106,7 +106,6 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule | postcs
                 node.name === 'container'
             ) {
                 let scopeSelector = node.name === 'st-scope' ? node.params : '';
-                let isNestedInMixin = false;
                 if (scopeSelector) {
                     const ast = parseSelectorWithCache(scopeSelector, { clone: true });
                     const matchesSelectors = isRoot

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -537,6 +537,43 @@ describe(`features/st-mixin`, () => {
             `)
             );
         });
+        it('should mix nested at-rules with content', () => {
+            const { sheets } = testStylableCore(`
+                .mix {
+                    @media (x>y) {
+                        .inner {
+                            color: green;
+                        }
+                    }
+                }
+
+                .into {
+                    -st-mixin: mix;
+                }
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            expect(deindent(meta.targetAst!.toString())).to.eql(
+                deindent(`
+                .entry__mix {
+                    @media (x>y) {
+                        .entry__inner {
+                            color: green;
+                        }
+                    }
+                }
+
+                .entry__into {
+                    @media (x>y) {
+                        .entry__inner {
+                            color: green;
+                        }
+                    }
+                }
+            `)
+            );
+        });
     });
     describe(`st-import`, () => {
         it(`should mix imported class`, () => {

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -574,6 +574,87 @@ describe(`features/st-mixin`, () => {
             `)
             );
         });
+        it('should nest any declaration following nested mixed-in rules', () => {
+            const { sheets } = testStylableCore(`
+                .mix {
+                    .inner {
+                        color: green;
+                    }
+                }
+
+                .into {
+                    declA: 1;
+                    declB: 2;
+                    -st-mixin: mix;
+                    declC: 3;
+                    declD: 4;
+                }
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            expect(deindent(meta.targetAst!.toString())).to.eql(
+                deindent(`
+                .entry__mix {
+                    .entry__inner {
+                        color: green;
+                    }
+                }
+
+                .entry__into {
+                    declA: 1;
+                    declB: 2;
+                    .entry__inner {
+                        color: green;
+                    }
+                    & {
+                        declC: 3;
+                        declD: 4;
+                    }
+                }
+            `)
+            );
+        });
+        it('should nest mixin decls that follow another mixin with nested nodes', () => {
+            const { sheets } = testStylableCore(`
+                .mixNested {
+                    .inner {
+                        color: green;
+                    }
+                }
+                .mixDecl {
+                    color: blue;
+                }
+
+                .into {
+                    -st-mixin: mixNested, mixDecl;
+                }
+            `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            expect(deindent(meta.targetAst!.toString())).to.eql(
+                deindent(`
+                .entry__mixNested {
+                    .entry__inner {
+                        color: green;
+                    }
+                }
+                .entry__mixDecl {
+                    color: blue;
+                }
+
+                .entry__into {
+                    .entry__inner {
+                        color: green;
+                    }
+                    & {
+                        color: blue;
+                    }
+                }
+            `)
+            );
+        });
     });
     describe(`st-import`, () => {
         it(`should mix imported class`, () => {

--- a/packages/core/test/helpers/rule.spec.ts
+++ b/packages/core/test/helpers/rule.spec.ts
@@ -52,6 +52,9 @@ describe(`helpers/rule`, () => {
 
                 /*nesting*/
                 .i[out] { .i[in] {} }
+
+                /*nesting at-rule*/
+                .i[out] { @media (x) { [in] {} } }
             `),
                 '.i'
             );
@@ -80,6 +83,16 @@ describe(`helpers/rule`, () => {
                 {
                     selector: '[st-mixin-marker][out]',
                     nodes: [{ selector: '[st-mixin-marker][in]' }],
+                },
+                {
+                    selector: '[st-mixin-marker][out]',
+                    nodes: [
+                        {
+                            name: 'media',
+                            params: '(x)',
+                            nodes: [{ selector: '[in]' }],
+                        },
+                    ],
                 },
             ];
 


### PR DESCRIPTION
This PR fixes some cases of mixins with native CSS nesting:

- mixin with nesting rules
- mix into a nested rule
- preserve nesting selector inside mixed fragment
- error diagnostic in case of a mixin class that is found inside a nested fragment (temporary until we figure out how to handle this case better)
- mix nested at-rule with content
- preserve nesting rules and declaration validity when mixed in an invalid order (nest declarations following nested rules with `&` selector)