### PR TITLE
fix(esbuild): minify bug

### DIFF
--- a/packages/esbuild/test/e2e/esbuild-testkit.ts
+++ b/packages/esbuild/test/e2e/esbuild-testkit.ts
@@ -20,10 +20,12 @@ export class ESBuildTestKit {
         project,
         buildExport,
         tmp = true,
+        overrideOptions = {},
     }: {
         project: string;
         buildExport?: string;
         tmp?: boolean;
+        overrideOptions?: BuildOptions;
     }) {
         let openServerUrl: string | undefined;
         let buildFile = require.resolve(`@stylable/esbuild/test/e2e/${project}/build.js`);
@@ -62,6 +64,7 @@ export class ESBuildTestKit {
             format: 'esm',
             target: ['es2020'],
             bundle: true,
+            ...overrideOptions,
         }));
         this.disposables.push(() => buildContext.dispose());
 

--- a/packages/esbuild/test/e2e/simple-case/a.st.css
+++ b/packages/esbuild/test/e2e/simple-case/a.st.css
@@ -1,3 +1,4 @@
+@test-marker a.st.css|a;
 @st-import Imported from './imported-only-from-css.st.css';
 
 .root {

--- a/packages/esbuild/test/e2e/simple-case/b.st.css
+++ b/packages/esbuild/test/e2e/simple-case/b.st.css
@@ -1,3 +1,4 @@
+@test-marker b.st.css|b;
 @st-import Deep from "./deep.st.css";
 @st-import "./side-effects.st.css";
 @st-import themeColor from "./theme-color.js";

--- a/packages/esbuild/test/e2e/simple-case/internal-dir/internal-dir.st.css
+++ b/packages/esbuild/test/e2e/simple-case/internal-dir/internal-dir.st.css
@@ -1,3 +1,5 @@
+@test-marker internal-dir.st.css|internaldir;
+
 .root {
     background: url('./internal-dir.png');
 }

--- a/packages/esbuild/test/e2e/simple-case/reset.css
+++ b/packages/esbuild/test/e2e/simple-case/reset.css
@@ -1,3 +1,5 @@
+@test-marker reset.css|reset;
+
 body {
   --reset: true;
   margin: 0;

--- a/packages/esbuild/test/e2e/simple-case/side-effects.st.css
+++ b/packages/esbuild/test/e2e/simple-case/side-effects.st.css
@@ -1,3 +1,4 @@
+@test-marker side-effects.st.css|sideeffects;
 @property st-global(--side-effects);
 
 :global(body) {

--- a/packages/esbuild/test/e2e/simple-case/simple-case.spec.ts
+++ b/packages/esbuild/test/e2e/simple-case/simple-case.spec.ts
@@ -69,7 +69,7 @@ describe('Stylable ESBuild plugin', () => {
         expect(css).to.match(matchOrder);
     });
 
-    it.skip('should build a project with a bundle (minify)', async () => {
+    it('should build a project with a bundle (minify)', async () => {
         const { open, read } = await tk.build({
             project: 'simple-case',
             buildExport: 'cssBundleProd',

--- a/packages/esbuild/test/e2e/simple-case/simple-case.spec.ts
+++ b/packages/esbuild/test/e2e/simple-case/simple-case.spec.ts
@@ -9,19 +9,29 @@ import { sep } from 'node:path';
  */
 const stylesInOrder = [
     {
-        st_id: 'reset.css|reset',
+        path: 'reset.css',
+        fileName: 'reset.css',
+        namespace: 'reset',
     },
     {
-        st_id: 'side-effects.st.css|sideeffects',
+        path: 'side-effects.st.css',
+        fileName: 'side-effects.st.css',
+        namespace: 'sideeffects',
     },
     {
-        st_id: `internal-dir${sep}internal-dir.st.css|internaldir`,
+        path: `internal-dir${sep}internal-dir.st.css`,
+        fileName: 'internal-dir.st.css',
+        namespace: 'internaldir',
     },
     {
-        st_id: 'a.st.css|a',
+        path: 'a.st.css',
+        fileName: 'a.st.css',
+        namespace: 'a',
     },
     {
-        st_id: 'b.st.css|b',
+        path: 'b.st.css',
+        fileName: 'b.st.css',
+        namespace: 'b',
     },
 ];
 
@@ -38,7 +48,7 @@ describe('Stylable ESBuild plugin', () => {
         const { open } = await tk.build({ project: 'simple-case', buildExport: 'cssInJsDev' });
         await contract(
             await open({}, 'index.html', true),
-            stylesInOrder,
+            stylesInOrder.map(({ path, namespace }) => ({ st_id: `${path}|${namespace}` })),
             `"class extending component '.root => .b__root' in stylesheet 'b.st.css' was set on a node that does not extend '.root => .deep__root' from stylesheet 'deep.st.css'"`,
             'override-active'
         );
@@ -53,9 +63,27 @@ describe('Stylable ESBuild plugin', () => {
         const css = read('dist-bundle/index.css');
 
         const matchOrder = new RegExp(
-            stylesInOrder.map(({ st_id }) => escapeRegExp(st_id.split('|')[0])).join('[\\s\\S]*?')
+            stylesInOrder.map(({ fileName }) => escapeRegExp(fileName)).join('[\\s\\S]*?')
         );
 
+        expect(css).to.match(matchOrder);
+    });
+
+    it.skip('should build a project with a bundle (minify)', async () => {
+        const { open, read } = await tk.build({
+            project: 'simple-case',
+            buildExport: 'cssBundleProd',
+            overrideOptions: {
+                minify: true,
+            },
+        });
+        await contract(await open({}, 'index.bundle.html', true), [], 'none', 'override-removed');
+
+        const css = read('dist-bundle/index.css');
+
+        const matchOrder = new RegExp(
+            stylesInOrder.map(({ fileName }) => escapeRegExp(fileName)).join('[\\s\\S]*?')
+        );
         expect(css).to.match(matchOrder);
     });
 });


### PR DESCRIPTION
This PR addresses two critical issues that were causing esbuild to fail during the build process when the minify configuration was applied.

Both of these issues arose due to content removal by the minification process, which interfered with the expected behavior of the stylable stylesheet ordering:

1. **Comment-Dependent Sheet Paths**: The first issue stemmed from the reliance on comments injected by esbuild to determine stylesheet paths. These comments were being removed when `minify` was enabled, leading to a runtime-build error.
1. **Start/End Markers Removal**: The second issue pertained to the start and end markers inserted by the stylable plugin. These markers were sometimes eliminated as part of code optimization because they lacked uniqueness.

To resolve these issues, this PR eliminates the dependence on esbuild comments and introduces uniquely identifiable markers that will remain intact even when minification is applied.