### PR TITLE
refactor(core): module -> {} in browser builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },
   "browser": {
-    "module": "./dist/module-with-extensions.js"
+    "module": false
   },
   "dependencies": {
     "@tokey/css-selector-parser": "^0.6.2",

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1,15 +1,19 @@
+// in browser build this gets remapped to an empty object via our package.json->"browser"
+import nodeModule from 'module';
 // importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
 // this allows @stylable/core to be bundled for browser usage without special custom configuration
 import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
-
 import type { ModuleResolver } from './types';
 import type { MinimalFS } from './cached-process-file';
 
 function bundleSafeRequireExtensions(): string[] {
     let extensions: string[];
     try {
-        // we use eval here to avoid bundling warnings about require.extensions we always has fallback for browsers
-        extensions = Object.keys(require('module')._extensions);
+        // we use nodeModule here to avoid bundling warnings about require.extensions we always has fallback for browsers
+        extensions = Object.keys(
+            (nodeModule as typeof nodeModule & { _extensions?: Record<string, unknown> })
+                ._extensions ?? {}
+        );
     } catch (e) {
         extensions = [];
     }

--- a/packages/core/src/module-with-extensions.ts
+++ b/packages/core/src/module-with-extensions.ts
@@ -1,3 +1,0 @@
-export = {
-    _extensions: {},
-};

--- a/packages/create-stylable-app/src/cli-main.ts
+++ b/packages/create-stylable-app/src/cli-main.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import yargs from 'yargs';
 import { createProjectFromTemplate } from './create-project';
 
-const argv = yargs
+const argv = yargs()
     .usage('npm init stylable-app <project-name>')
     .demand(1, 'missing project-name')
     .option('template', {


### PR DESCRIPTION
rather than defining our own partial polyfill, map it to an empty object and handle `_extensions` not being defined (also safer for future node versions).

also made yargs usage compatible with `"moduleResolution": "bundler"/"node16"`.