### PR TITLE
feat!: move to file-services/resolve as default resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6949,7 +6949,6 @@
         "balanced-match": "^2.0.0",
         "css-selector-tokenizer": "^0.8.0",
         "cssesc": "^3.0.0",
-        "enhanced-resolve": "^5.15.0",
         "is-vendor-prefixed": "^4.0.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.clonedeepwith": "^4.5.0",
@@ -7042,6 +7041,7 @@
       "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
+        "@file-services/node": "^8.2.0",
         "@stylable/build-tools": "^5.16.0",
         "@stylable/cli": "^5.16.0",
         "@stylable/core": "^5.16.0",
@@ -7061,6 +7061,7 @@
       "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
+        "@file-services/node": "^8.2.0",
         "@stylable/core": "^5.16.0",
         "@typescript-eslint/utils": "^5.61.0"
       }
@@ -7072,6 +7073,7 @@
       "dependencies": {
         "@stylable/core": "^5.16.0",
         "@stylable/runtime": "^5.16.0",
+        "@stylable/webpack-plugin": "^5.16.0",
         "css-loader": "^6.8.1",
         "decache": "^4.6.2",
         "loader-utils": "^3.2.1"
@@ -7089,6 +7091,7 @@
       "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
+        "@file-services/node": "^8.2.0",
         "@stylable/core": "^5.16.0",
         "@stylable/module-utils": "^5.16.0",
         "@stylable/node": "^5.16.0",
@@ -7143,6 +7146,7 @@
       "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
+        "@file-services/node": "^8.2.0",
         "@stylable/build-tools": "^5.16.0",
         "@stylable/core": "^5.16.0",
         "@stylable/module-utils": "^5.16.0",
@@ -7171,6 +7175,7 @@
       "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
+        "@file-services/node": "^8.2.0",
         "@stylable/build-tools": "^5.16.0",
         "@stylable/cli": "^5.16.0",
         "@stylable/core": "^5.16.0",
@@ -7257,6 +7262,7 @@
         "@stylable/optimizer": "^5.16.0",
         "@stylable/runtime": "^5.16.0",
         "decache": "^4.6.2",
+        "enhanced-resolve": "^5.15.0",
         "lodash.clonedeep": "^4.5.0",
         "postcss": "^8.4.29"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -524,6 +524,25 @@
         "@file-services/types": "^8.2.0"
       }
     },
+    "node_modules/@file-services/resolve": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@file-services/resolve/-/resolve-8.2.0.tgz",
+      "integrity": "sha512-uwl6bRS8t4t31JxyGZ7aSdIuixojYoYLHambTOM16xqQkXBjXBqfGyQMyyJirxpMTpvWx4rIuAdhIP2dPeBYHg==",
+      "dependencies": {
+        "type-fest": "^4.3.1"
+      }
+    },
+    "node_modules/@file-services/resolve/node_modules/type-fest": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
+      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@file-services/types": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@file-services/types/-/types-8.2.0.tgz",
@@ -6923,6 +6942,7 @@
       "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
+        "@file-services/resolve": "^8.2.0",
         "@tokey/css-selector-parser": "^0.6.2",
         "@tokey/css-value-parser": "^0.1.4",
         "@tokey/imports-parser": "^1.0.0",

--- a/packages/cli/src/cli-codemod.ts
+++ b/packages/cli/src/cli-codemod.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
+import fs from '@file-services/node';
 import { resolve } from 'path';
 import yargs from 'yargs';
 import { codeMods } from './code-mods/code-mods';

--- a/packages/cli/src/code-format.ts
+++ b/packages/cli/src/code-format.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 import yargs from 'yargs';
-import { nodeFs } from '@file-services/node';
+import fs from '@file-services/node';
 import { getDocumentFormatting, formatCSS } from '@stylable/code-formatter';
 import { createLogger } from './logger';
-import { writeFileSync } from 'fs';
 
-const { join } = nodeFs;
+const { join, writeFileSync } = fs;
 
 const argv = yargs
     .usage('$0 [options]')
@@ -134,7 +133,7 @@ for (const request of requires) {
 }
 
 function readDirectoryDeep(dirPath: string, fileSuffixFilter = '.st.css', res = new Set<string>()) {
-    const items = nodeFs.readdirSync(dirPath, { withFileTypes: true });
+    const items = fs.readdirSync(dirPath, { withFileTypes: true });
 
     for (const item of items) {
         const path = join(dirPath, item.name);
@@ -150,7 +149,7 @@ function readDirectoryDeep(dirPath: string, fileSuffixFilter = '.st.css', res = 
 }
 
 function formatStylesheet(filePath: string) {
-    const fileContent = nodeFs.readFileSync(filePath, 'utf-8');
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
 
     const newText = experimental
         ? formatCSS(fileContent, {
@@ -188,7 +187,7 @@ if (debug) {
     log('Starting code formatting');
 }
 
-const formatPathStats = nodeFs.statSync(target);
+const formatPathStats = fs.statSync(target);
 
 if (formatPathStats.isFile()) {
     if (target.endsWith('.st.css')) {

--- a/packages/cli/src/config/projects-config.ts
+++ b/packages/cli/src/config/projects-config.ts
@@ -15,6 +15,7 @@ import { createDefaultOptions, mergeBuildOptions, validateOptions } from './reso
 import { resolveNpmRequests } from './resolve-requests';
 import type { ModuleResolver } from '@stylable/core/dist/index-internal';
 import type { MinimalFS, processNamespace } from '@stylable/core';
+import type { IFileSystem } from '@file-services/types';
 
 interface StylableRuntimeConfigs {
     stcConfig?: Configuration<string> | undefined;
@@ -64,21 +65,21 @@ export async function projectsConfig(
 }
 
 // todo: make fs not optional next major version
-export function resolveConfig(context: string, request?: string, fs?: MinimalFS) {
+export function resolveConfig(context: string, request?: string, fs?: IFileSystem | MinimalFS) {
     return request ? requireConfigFile(request, context, fs) : resolveConfigFile(context, fs);
 }
 
-function requireConfigFile(request: string, context: string, fs?: MinimalFS) {
+function requireConfigFile(request: string, context: string, fs?: IFileSystem | MinimalFS) {
     const path = require.resolve(request, { paths: [context] });
     const config = resolveConfigValue(require(path), fs);
     return config ? { config, path } : undefined;
 }
 
-function resolveConfigFile(context: string, fs?: MinimalFS) {
+function resolveConfigFile(context: string, fs?: IFileSystem | MinimalFS) {
     return loadStylableConfig(context, (config) => resolveConfigValue(config, fs));
 }
 
-function resolveConfigValue(config: any, fs?: MinimalFS) {
+function resolveConfigValue(config: any, fs?: IFileSystem | MinimalFS) {
     return tryRun(
         (): StylableRuntimeConfigs => ({
             stcConfig: isSTCConfig(config)

--- a/packages/cli/src/config/projects-config.ts
+++ b/packages/cli/src/config/projects-config.ts
@@ -14,7 +14,7 @@ import { processProjects } from './process-projects';
 import { createDefaultOptions, mergeBuildOptions, validateOptions } from './resolve-options';
 import { resolveNpmRequests } from './resolve-requests';
 import type { ModuleResolver } from '@stylable/core/dist/index-internal';
-import type { MinimalFS, processNamespace } from '@stylable/core';
+import type { processNamespace } from '@stylable/core';
 import type { IFileSystem } from '@file-services/types';
 
 interface StylableRuntimeConfigs {
@@ -65,21 +65,21 @@ export async function projectsConfig(
 }
 
 // todo: make fs not optional next major version
-export function resolveConfig(context: string, request?: string, fs?: IFileSystem | MinimalFS) {
+export function resolveConfig(context: string, request?: string, fs?: IFileSystem) {
     return request ? requireConfigFile(request, context, fs) : resolveConfigFile(context, fs);
 }
 
-function requireConfigFile(request: string, context: string, fs?: IFileSystem | MinimalFS) {
+function requireConfigFile(request: string, context: string, fs?: IFileSystem) {
     const path = require.resolve(request, { paths: [context] });
     const config = resolveConfigValue(require(path), fs);
     return config ? { config, path } : undefined;
 }
 
-function resolveConfigFile(context: string, fs?: IFileSystem | MinimalFS) {
+function resolveConfigFile(context: string, fs?: IFileSystem) {
     return loadStylableConfig(context, (config) => resolveConfigValue(config, fs));
 }
 
-function resolveConfigValue(config: any, fs?: IFileSystem | MinimalFS) {
+function resolveConfigValue(config: any, fs?: IFileSystem) {
     return tryRun(
         (): StylableRuntimeConfigs => ({
             stcConfig: isSTCConfig(config)

--- a/packages/cli/test/assets.spec.ts
+++ b/packages/cli/test/assets.spec.ts
@@ -18,7 +18,7 @@ describe('assets', function () {
             '/src/other.st.css': '.other {}',
             '/node_modules/styles/3rd-party.css': '.third-party {}',
         });
-        const resolve = createDefaultResolver(fs, {});
+        const resolve = createDefaultResolver({ fs });
         const stylable = new Stylable({
             projectRoot: '/',
             fileSystem: fs,

--- a/packages/cli/test/build.spec.ts
+++ b/packages/cli/test/build.spec.ts
@@ -682,7 +682,7 @@ describe('build stand alone', () => {
         expect(dtsSourceMapContent).to.contain(`"main.st.css"`);
     });
 
-    describe('resolver', () => {
+    describe('resolver (build)', () => {
         it('should be able to build with enhanced-resolver alias configured', async () => {
             const identifier = 'build-identifier';
             const fs = createMemoryFs({
@@ -701,7 +701,7 @@ describe('build stand alone', () => {
                 requireModule: () => ({}),
                 resolveOptions: {
                     alias: {
-                        '@colors': '/colors',
+                        '@colors/*': '/colors/*',
                     },
                 },
             });

--- a/packages/cli/test/build.spec.ts
+++ b/packages/cli/test/build.spec.ts
@@ -681,60 +681,6 @@ describe('build stand alone', () => {
         expect(dtsSourceMapContent).to.contain(`"sources": [`);
         expect(dtsSourceMapContent).to.contain(`"main.st.css"`);
     });
-
-    describe('resolver (build)', () => {
-        it('should be able to build with enhanced-resolver alias configured', async () => {
-            const identifier = 'build-identifier';
-            const fs = createMemoryFs({
-                '/entry.st.css': `
-                    @st-import [green] from '@colors/green.st.css';
-                    
-                    .root { -st-mixin: green;}`,
-                '/colors/green.st.css': `
-                    .green { color: green; }`,
-            });
-
-            const diagnosticsManager = new DiagnosticsManager();
-            const stylable = new Stylable({
-                projectRoot: '/',
-                fileSystem: fs,
-                requireModule: () => ({}),
-                resolveOptions: {
-                    alias: {
-                        '@colors/*': '/colors/*',
-                    },
-                },
-            });
-
-            await build(
-                {
-                    outDir: '.',
-                    srcDir: '.',
-                    outputCSS: true,
-                    diagnostics: true,
-                },
-                {
-                    fs,
-                    stylable,
-                    rootDir: '/',
-                    projectRoot: '/',
-                    log,
-                    diagnosticsManager,
-                    identifier,
-                }
-            );
-
-            ['/entry.st.css', '/entry.css'].forEach((p) => {
-                expect(fs.existsSync(p), p).to.equal(true);
-            });
-
-            const messages = diagnosticsManager.get(identifier, '/entry.st.css')?.diagnostics;
-            expect(messages).to.eql(undefined);
-
-            const entryCSSContent = fs.readFileSync('/entry.css', 'utf8');
-            expect(entryCSSContent).to.contain(`color: green;`);
-        });
-    });
 });
 
 describe('build - bundle', () => {

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -564,12 +564,12 @@ describe('Stylable Cli', function () {
                 'package.json': `{"name": "test", "version": "0.0.0"}`,
                 'stylable.config.js': `
                     const { resolve } = require('node:path');
-                    const { createLegacyResolver } = require('@stylable/webpack-plugin');
+                    const { createWebpackResolver } = require('@stylable/webpack-plugin');
 
                     module.exports = {
                         defaultConfig(fs) {
                             return {
-                                resolveModule: createLegacyResolver(fs, {
+                                resolveModule: createWebpackResolver(fs, {
                                     alias: {
                                         '@colors': resolve(__dirname, './colors')
                                     }
@@ -618,12 +618,12 @@ describe('Stylable Cli', function () {
                 'stylable.config.js': `
                     const { join } = require('path');
                     const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-                    const { createLegacyResolver } = require('@stylable/webpack-plugin');
+                    const { createWebpackResolver } = require('@stylable/webpack-plugin');
 
                     module.exports = {
                         defaultConfig(fs) {
                             return {
-                                resolveModule: createLegacyResolver(fs, {
+                                resolveModule: createWebpackResolver(fs, {
                                     plugins: [new TsconfigPathsPlugin({ configFile: join(${JSON.stringify(
                                         tempDir.path
                                     )},'tsconfig.json') })],

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -564,7 +564,7 @@ describe('Stylable Cli', function () {
                 'package.json': `{"name": "test", "version": "0.0.0"}`,
                 'stylable.config.js': `
                     const { resolve } = require('node:path');
-                    const { createLegacyResolver } = require('@stylable/webpack-plugin');
+                    const { @stylable/webpack-plugin } = require('@stylable/webpack-plugin');
 
                     module.exports = {
                         defaultConfig(fs) {

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -564,7 +564,7 @@ describe('Stylable Cli', function () {
                 'package.json': `{"name": "test", "version": "0.0.0"}`,
                 'stylable.config.js': `
                     const { resolve } = require('node:path');
-                    const { @stylable/webpack-plugin } = require('@stylable/webpack-plugin');
+                    const { createLegacyResolver } = require('@stylable/webpack-plugin');
 
                     module.exports = {
                         defaultConfig(fs) {

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -564,7 +564,7 @@ describe('Stylable Cli', function () {
                 'package.json': `{"name": "test", "version": "0.0.0"}`,
                 'stylable.config.js': `
                     const { resolve } = require('node:path');
-                    const { createLegacyResolver } = require('@stylable/core');
+                    const { createLegacyResolver } = require('@stylable/webpack-plugin');
 
                     module.exports = {
                         defaultConfig(fs) {
@@ -618,7 +618,7 @@ describe('Stylable Cli', function () {
                 'stylable.config.js': `
                     const { join } = require('path');
                     const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-                    const { createLegacyResolver } = require('@stylable/core');
+                    const { createLegacyResolver } = require('@stylable/webpack-plugin');
 
                     module.exports = {
                         defaultConfig(fs) {

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -558,18 +558,18 @@ describe('Stylable Cli', function () {
         });
     });
 
-    describe('resolver', () => {
+    describe('resolver (cli)', () => {
         it('should be able to build with enhanced-resolver alias configured', () => {
             populateDirectorySync(tempDir.path, {
                 'package.json': `{"name": "test", "version": "0.0.0"}`,
                 'stylable.config.js': `
                     const { resolve } = require('node:path');
-                    const { createDefaultResolver } = require('@stylable/core');
+                    const { createLegacyResolver } = require('@stylable/core');
 
                     module.exports = {
                         defaultConfig(fs) {
                             return {
-                                resolveModule: createDefaultResolver(fs, {
+                                resolveModule: createLegacyResolver(fs, {
                                     alias: {
                                         '@colors': resolve(__dirname, './colors')
                                     }
@@ -618,12 +618,12 @@ describe('Stylable Cli', function () {
                 'stylable.config.js': `
                     const { join } = require('path');
                     const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
-                    const { createDefaultResolver } = require('@stylable/core');
+                    const { createLegacyResolver } = require('@stylable/core');
 
                     module.exports = {
                         defaultConfig(fs) {
                             return {
-                                resolveModule: createDefaultResolver(fs, {
+                                resolveModule: createLegacyResolver(fs, {
                                     plugins: [new TsconfigPathsPlugin({ configFile: join(${JSON.stringify(
                                         tempDir.path
                                     )},'tsconfig.json') })],

--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -19,6 +19,7 @@ import {
 import { isAbsolute } from 'path';
 import * as postcss from 'postcss';
 import { createMemoryFs } from '@file-services/memory';
+import type { IFileSystem } from '@file-services/types';
 import type { IDirectoryContents } from '@file-services/types';
 
 export interface File {
@@ -118,6 +119,24 @@ export function createProcess(
     return (path: string) => fileProcessor.process(path);
 }
 
+export function createResolveExtendsResults(
+    fileSystem: IFileSystem,
+    fileToProcess: string,
+    classNameToLookup: string,
+    isElement = false
+) {
+    const stylable = new Stylable({
+        fileSystem,
+        projectRoot: '/',
+    });
+
+    return stylable.resolver.resolveExtends(
+        stylable.analyze(fileToProcess),
+        classNameToLookup,
+        isElement
+    );
+}
+
 export function generateStylableResult(
     config: Config,
     diagnostics: Diagnostics = new Diagnostics()
@@ -140,7 +159,7 @@ export function generateStylableExports(config: Config) {
 
 export function generateStylableEnvironment(
     content: IDirectoryContents,
-    stylableConfig: Partial<StylableConfig> = {}
+    stylableConfig: Partial<Omit<StylableConfig, 'fileSystem'>> = {}
 ) {
     const fs = createMemoryFs(content);
 

--- a/packages/core-test-kit/src/generate-test-util.ts
+++ b/packages/core-test-kit/src/generate-test-util.ts
@@ -62,7 +62,7 @@ export function generateInfra(config: InfraConfig, diagnostics: Diagnostics = ne
         createDiagnostics: () => diagnostics,
     });
 
-    const resolveModule = createDefaultResolver(fs, {});
+    const resolveModule = createDefaultResolver({ fs });
     const resolvePath = (context: string | undefined = '/', moduleId: string) =>
         resolveModule(context, moduleId);
 

--- a/packages/core-test-kit/src/index.ts
+++ b/packages/core-test-kit/src/index.ts
@@ -19,6 +19,7 @@ export {
     generateStylableRoot,
     processSource,
     generateStylableEnvironment,
+    createResolveExtendsResults,
 } from './generate-test-util';
 export { flatMatch } from './matchers/flat-match';
 export { matchCSSMatchers } from './matchers/match-css';

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -1021,7 +1021,7 @@ describe('inline-expectations', () => {
             );
         });
         it(`should throw on possible location mismatch`, () => {
-            const resolveErrorMessage = 'Stylable could not resolve "./unknown.st.css" from "/"';
+            const resolveErrorMessage = "Stylable could not resolve \"./unknown.st.css\" from \"/\"\nVisited paths:\n/unknown.st.css\n/unknown.st.css.js\n/unknown.st.css.mjs\n/unknown.st.css.cjs\n/unknown.st.css.ts\n/unknown.st.css.mts\n/unknown.st.css.cts\n/unknown.st.css.json"
             const result = generateStylableResult({
                 entry: `/style.st.css`,
                 files: {

--- a/packages/core-test-kit/test/inline-expectations.spec.ts
+++ b/packages/core-test-kit/test/inline-expectations.spec.ts
@@ -1021,7 +1021,7 @@ describe('inline-expectations', () => {
             );
         });
         it(`should throw on possible location mismatch`, () => {
-            const resolveErrorMessage = `resolve './unknown.st.css' in '/'\n  No description file found in / or above\n  No description file found in / or above\n  no extension\n    /unknown.st.css doesn't exist\n  .js\n    /unknown.st.css.js doesn't exist\n  .json\n    /unknown.st.css.json doesn't exist\n  .node\n    /unknown.st.css.node doesn't exist\n  as directory\n    /unknown.st.css doesn't exist`;
+            const resolveErrorMessage = 'Stylable could not resolve "./unknown.st.css" from "/"';
             const result = generateStylableResult({
                 entry: `/style.st.css`,
                 files: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,6 @@
     "balanced-match": "^2.0.0",
     "css-selector-tokenizer": "^0.8.0",
     "cssesc": "^3.0.0",
-    "enhanced-resolve": "^5.15.0",
     "is-vendor-prefixed": "^4.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.clonedeepwith": "^4.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },
-  "browser": {
-    "module": false
-  },
   "dependencies": {
     "@file-services/resolve": "^8.2.0",
     "@tokey/css-selector-parser": "^0.6.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "module": false
   },
   "dependencies": {
+    "@file-services/resolve": "^8.2.0",
     "@tokey/css-selector-parser": "^0.6.2",
     "@tokey/css-value-parser": "^0.1.4",
     "@tokey/imports-parser": "^1.0.0",

--- a/packages/core/src/cached-process-file.ts
+++ b/packages/core/src/cached-process-file.ts
@@ -6,9 +6,7 @@ export interface CacheItem<T> {
 }
 
 export interface MinimalFS {
-    statSync: (filePath: string) => { mtime: Date };
     readFileSync: (filePath: string, encoding: 'utf8') => string;
-    readlinkSync: (filePath: string) => string;
 }
 
 export interface FileProcessor<T> {

--- a/packages/core/src/enhanced-resolve-alias.ts
+++ b/packages/core/src/enhanced-resolve-alias.ts
@@ -1,9 +1,0 @@
-// we don't want to bundle the entire enhanced-resolve package for the browser
-// it will throw if Stylable is used in the browser without a custom resolver
-export default {
-    createResolver: () => {
-        throw new Error(
-            'Stylable requires a custom resolver in lib bundles. please provide `resolveModule` options to the Stylable constructor.'
-        );
-    },
-};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,6 @@ export {
 } from './helpers/namespace';
 export { processNamespace } from './stylable-processor';
 export { CustomValueStrategy, createCustomValue } from './custom-values';
-export { createLegacyResolver } from './legacy-module-resolver';
 export { createDefaultResolver } from './module-resolver';
 
 // low-level api

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from './helpers/namespace';
 export { processNamespace } from './stylable-processor';
 export { CustomValueStrategy, createCustomValue } from './custom-values';
+export { createLegacyResolver } from './legacy-module-resolver';
 export { createDefaultResolver } from './module-resolver';
 
 // low-level api

--- a/packages/core/src/legacy-module-resolver.ts
+++ b/packages/core/src/legacy-module-resolver.ts
@@ -1,0 +1,47 @@
+// in browser build this gets remapped to an empty object via our package.json->"browser"
+import nodeModule from 'module';
+// importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
+// this allows @stylable/core to be bundled for browser usage without special custom configuration
+import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
+import type { ModuleResolver } from './types';
+import type { MinimalFS } from './cached-process-file';
+
+function bundleSafeRequireExtensions(): string[] {
+    let extensions: string[];
+    try {
+        // we use nodeModule here to avoid bundling warnings about require.extensions we always has fallback for browsers
+        extensions = Object.keys(
+            (nodeModule as typeof nodeModule & { _extensions?: Record<string, unknown> })
+                ._extensions ?? {}
+        );
+    } catch (e) {
+        extensions = [];
+    }
+    return extensions.length ? extensions : ['.js', '.json'];
+}
+
+const resolverContext = {};
+
+export function createLegacyResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
+    const extensions =
+        resolveOptions.extensions && resolveOptions.extensions.length
+            ? resolveOptions.extensions
+            : bundleSafeRequireExtensions();
+    const eResolver = ResolverFactory.createResolver({
+        ...resolveOptions,
+        extensions,
+        useSyncFileSystemCalls: true,
+        cache: false,
+        fileSystem,
+    });
+
+    return (directoryPath, request): string => {
+        const res = eResolver.resolveSync(resolverContext, directoryPath, request);
+        if (res === false) {
+            throw new Error(
+                `Stylable does not support browser field 'false' values. ${request} resolved to 'false' from ${directoryPath}`
+            );
+        }
+        return res;
+    };
+}

--- a/packages/core/src/module-resolver.ts
+++ b/packages/core/src/module-resolver.ts
@@ -1,47 +1,24 @@
 // in browser build this gets remapped to an empty object via our package.json->"browser"
-import nodeModule from 'module';
-// importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
-// this allows @stylable/core to be bundled for browser usage without special custom configuration
-import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
+
+import { IRequestResolverOptions, createRequestResolver } from '@file-services/resolve';
 import type { ModuleResolver } from './types';
-import type { MinimalFS } from './cached-process-file';
 
-function bundleSafeRequireExtensions(): string[] {
-    let extensions: string[];
-    try {
-        // we use nodeModule here to avoid bundling warnings about require.extensions we always has fallback for browsers
-        extensions = Object.keys(
-            (nodeModule as typeof nodeModule & { _extensions?: Record<string, unknown> })
-                ._extensions ?? {}
-        );
-    } catch (e) {
-        extensions = [];
-    }
-    return extensions.length ? extensions : ['.js', '.json'];
-}
-
-const resolverContext = {};
-
-export function createDefaultResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
-    const extensions =
-        resolveOptions.extensions && resolveOptions.extensions.length
-            ? resolveOptions.extensions
-            : bundleSafeRequireExtensions();
-    const eResolver = ResolverFactory.createResolver({
-        ...resolveOptions,
-        extensions,
-        useSyncFileSystemCalls: true,
-        cache: false,
-        fileSystem,
+export function createDefaultResolver(options: IRequestResolverOptions): ModuleResolver {
+    const resolver = createRequestResolver({
+        extensions: ['.js', '.json', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
+        ...options,
     });
 
     return (directoryPath, request): string => {
-        const res = eResolver.resolveSync(resolverContext, directoryPath, request);
-        if (res === false) {
+        const res = resolver(directoryPath, request);
+        if (res.resolvedFile === false) {
             throw new Error(
                 `Stylable does not support browser field 'false' values. ${request} resolved to 'false' from ${directoryPath}`
             );
         }
-        return res;
+        if (typeof res.resolvedFile !== 'string') {
+            throw new Error(`Stylable could not resolve ${JSON.stringify(request)} from ${JSON.stringify(directoryPath)}`);
+        }
+        return res.resolvedFile;
     };
 }

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -13,32 +13,40 @@ import {
     TransformHooks,
 } from './stylable-transformer';
 import type { IStylableOptimizer, ModuleResolver } from './types';
-import { createDefaultResolver } from './module-resolver';
+import {
+    createDefaultResolver,
+    IRequestResolverOptions,
+    IResolutionFileSystem,
+} from './module-resolver';
 import { STImport, STScope, STVar, STMixin, CSSClass, CSSCustomProperty } from './features';
 import { Dependency, visitMetaCSSDependencies } from './visit-meta-css-dependencies';
 import * as postcss from 'postcss';
 
-export interface StylableConfig {
+export interface StylableConfigBase {
     projectRoot: string;
-    fileSystem: MinimalFS;
     requireModule?: (path: string) => any;
     onProcess?: (meta: StylableMeta, path: string) => StylableMeta;
     hooks?: TransformHooks;
-    /** @deprecated provide a `resolveModule` instead */
-    resolveOptions?: {
-        alias?: any;
-        symlinks?: boolean;
-        [key: string]: any;
-    };
     optimizer?: IStylableOptimizer;
     mode?: 'production' | 'development';
     resolveNamespace?: typeof processNamespace;
-    resolveModule?: ModuleResolver;
     cssParser?: CssParser;
     resolverCache?: StylableResolverCache;
     fileProcessorCache?: Record<string, CacheItem<StylableMeta>>;
     experimentalSelectorInference?: boolean;
 }
+
+export type StylableConfig = StylableConfigBase &
+    (
+        | {
+              fileSystem: MinimalFS;
+              resolveModule: ModuleResolver;
+          }
+        | {
+              fileSystem: IResolutionFileSystem;
+              resolveModule?: ModuleResolver | Omit<IRequestResolverOptions, 'fs'>;
+          }
+    );
 
 // This defines and validates known configs for the defaultConfig in 'stylable.config.js
 const globalDefaultSupportedConfigs = new Set([
@@ -75,12 +83,11 @@ export class Stylable {
     public cssClass = new CSSClass.StylablePublicApi(this);
     //
     public projectRoot: string;
-    protected fileSystem: MinimalFS;
+    protected fileSystem: IResolutionFileSystem | MinimalFS;
     protected requireModule: (path: string) => any;
     protected onProcess?: (meta: StylableMeta, path: string) => StylableMeta;
     protected diagnostics = new Diagnostics();
     protected hooks: TransformHooks;
-    protected resolveOptions: any;
     public optimizer?: IStylableOptimizer;
     protected mode: 'production' | 'development';
     public resolveNamespace?: typeof processNamespace;
@@ -97,17 +104,16 @@ export class Stylable {
         this.requireModule =
             config.requireModule ||
             (() => {
-                throw new Error('Javascript files are not supported without requireModule options');
+                throw new Error(
+                    'Javascript files are not supported without Stylable `requireModule` option'
+                );
             });
         this.onProcess = config.onProcess;
         this.hooks = config.hooks || {};
-        this.resolveOptions = config.resolveOptions || {};
         this.optimizer = config.optimizer;
         this.mode = config.mode || `production`;
         this.resolveNamespace = config.resolveNamespace;
-        this.moduleResolver =
-            config.resolveModule ||
-            createDefaultResolver({ fs: this.fileSystem, ...this.resolveOptions });
+        this.moduleResolver = this.initModuleResolver(config);
         this.cssParser = config.cssParser || cssParse;
         this.resolverCache = config.resolverCache; // ToDo: v5 default to `new Map()`
         this.fileProcessorCache = config.fileProcessorCache;
@@ -121,6 +127,16 @@ export class Stylable {
 
         this.resolver = this.createResolver();
     }
+    private initModuleResolver(config: StylableConfig): ModuleResolver {
+        return typeof config.resolveModule === 'function'
+            ? config.resolveModule
+            : createDefaultResolver({
+                  fs: this
+                      .fileSystem as IResolutionFileSystem /* we force to provide resolveModule when using MinimalFS */,
+                  ...config.resolveModule,
+              });
+    }
+
     public getDependencies(meta: StylableMeta) {
         const dependencies: Dependency[] = [];
 

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -24,6 +24,7 @@ export interface StylableConfig {
     requireModule?: (path: string) => any;
     onProcess?: (meta: StylableMeta, path: string) => StylableMeta;
     hooks?: TransformHooks;
+    /** @deprecated provide a `resolveModule` instead */
     resolveOptions?: {
         alias?: any;
         symlinks?: boolean;
@@ -105,7 +106,8 @@ export class Stylable {
         this.mode = config.mode || `production`;
         this.resolveNamespace = config.resolveNamespace;
         this.moduleResolver =
-            config.resolveModule || createDefaultResolver(this.fileSystem, this.resolveOptions);
+            config.resolveModule ||
+            createDefaultResolver({ fs: this.fileSystem, ...this.resolveOptions });
         this.cssParser = config.cssParser || cssParse;
         this.resolverCache = config.resolverCache; // ToDo: v5 default to `new Map()`
         this.fileProcessorCache = config.fileProcessorCache;

--- a/packages/core/test/features/st-import.spec.ts
+++ b/packages/core/test/features/st-import.spec.ts
@@ -211,9 +211,10 @@ describe(`features/st-import`, () => {
         `);
     });
     it(`should error on unresolved file`, () => {
-        const resolveErrorMessage = `Stylable could not resolve "./missing.st.css" from "/"`;
-        const resolveErrorMessagePackage = `Stylable could not resolve "missing-package/index.st.css" from "/"`;
-
+        const resolveErrorMessage =
+            'Stylable could not resolve "./missing.st.css" from "/"\nVisited paths:\n/missing.st.css\n/missing.st.css.js\n/missing.st.css.mjs\n/missing.st.css.cjs\n/missing.st.css.ts\n/missing.st.css.mts\n/missing.st.css.cts\n/missing.st.css.json';
+        const resolveErrorMessagePackage =
+            'Stylable could not resolve "missing-package/index.st.css" from "/"';
         testStylableCore(`
             /* @transform-error(relative) word(./missing.st.css) ${stImportDiagnostics.UNKNOWN_IMPORTED_FILE(
                 `./missing.st.css`,
@@ -532,10 +533,11 @@ describe(`features/st-import`, () => {
                 }
             `);
         });
-        it(`should error on unresolved file`, () => {
-            const resolveErrorMessage = `Stylable could not resolve "./missing.st.css" from "/"`;
-            const resolveErrorMessagePackage = `Stylable could not resolve "missing-package/index.st.css" from "/"`;
-    
+        it(`should error on unresolved file (:import)`, () => {
+            const resolveErrorMessage =
+                'Stylable could not resolve "./missing.st.css" from "/"\nVisited paths:\n/missing.st.css\n/missing.st.css.js\n/missing.st.css.mjs\n/missing.st.css.cjs\n/missing.st.css.ts\n/missing.st.css.mts\n/missing.st.css.cts\n/missing.st.css.json';
+            const resolveErrorMessagePackage =
+                'Stylable could not resolve "missing-package/index.st.css" from "/"';
             testStylableCore(`
                 :import{
                     /* @transform-error(relative) word(./missing.st.css) ${stImportDiagnostics.UNKNOWN_IMPORTED_FILE(

--- a/packages/core/test/features/st-import.spec.ts
+++ b/packages/core/test/features/st-import.spec.ts
@@ -211,8 +211,8 @@ describe(`features/st-import`, () => {
         `);
     });
     it(`should error on unresolved file`, () => {
-        const resolveErrorMessage = `resolve './missing.st.css' in '/'\n  No description file found in / or above\n  No description file found in / or above\n  no extension\n    /missing.st.css doesn't exist\n  .js\n    /missing.st.css.js doesn't exist\n  .json\n    /missing.st.css.json doesn't exist\n  .node\n    /missing.st.css.node doesn't exist\n  as directory\n    /missing.st.css doesn't exist`;
-        const resolveErrorMessagePackage = `resolve 'missing-package/index.st.css' in '/'\n  Parsed request is a module\n  No description file found in / or above\n  resolve as module\n    /node_modules doesn't exist or is not a directory`;
+        const resolveErrorMessage = `Stylable could not resolve "./missing.st.css" from "/"`;
+        const resolveErrorMessagePackage = `Stylable could not resolve "missing-package/index.st.css" from "/"`;
 
         testStylableCore(`
             /* @transform-error(relative) word(./missing.st.css) ${stImportDiagnostics.UNKNOWN_IMPORTED_FILE(
@@ -533,9 +533,9 @@ describe(`features/st-import`, () => {
             `);
         });
         it(`should error on unresolved file`, () => {
-            const resolveErrorMessage = `resolve './missing.st.css' in '/'\n  No description file found in / or above\n  No description file found in / or above\n  no extension\n    /missing.st.css doesn't exist\n  .js\n    /missing.st.css.js doesn't exist\n  .json\n    /missing.st.css.json doesn't exist\n  .node\n    /missing.st.css.node doesn't exist\n  as directory\n    /missing.st.css doesn't exist`;
-            const resolveErrorMessagePackage = `resolve 'missing-package/index.st.css' in '/'\n  Parsed request is a module\n  No description file found in / or above\n  resolve as module\n    /node_modules doesn't exist or is not a directory`;
-
+            const resolveErrorMessage = `Stylable could not resolve "./missing.st.css" from "/"`;
+            const resolveErrorMessagePackage = `Stylable could not resolve "missing-package/index.st.css" from "/"`;
+    
             testStylableCore(`
                 :import{
                     /* @transform-error(relative) word(./missing.st.css) ${stImportDiagnostics.UNKNOWN_IMPORTED_FILE(

--- a/packages/core/test/stylable-resolver.spec.ts
+++ b/packages/core/test/stylable-resolver.spec.ts
@@ -1,25 +1,10 @@
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
-import { testStylableCore, generateStylableResult } from '@stylable/core-test-kit';
-import { Stylable, MinimalFS } from '@stylable/core';
-
-function createResolveExtendsResults(
-    fileSystem: MinimalFS,
-    fileToProcess: string,
-    classNameToLookup: string,
-    isElement = false
-) {
-    const stylable = new Stylable({
-        fileSystem,
-        projectRoot: '/',
-    });
-
-    return stylable.resolver.resolveExtends(
-        stylable.analyze(fileToProcess),
-        classNameToLookup,
-        isElement
-    );
-}
+import {
+    testStylableCore,
+    generateStylableResult,
+    createResolveExtendsResults,
+} from '@stylable/core-test-kit';
 
 describe('stylable-resolver', () => {
     it('should resolve extend classes', () => {

--- a/packages/core/test/stylable.spec.ts
+++ b/packages/core/test/stylable.spec.ts
@@ -43,6 +43,23 @@ describe('Stylable', () => {
             expect(fsMetaAfter, `meta cached`).to.equal(fsMetaBefore);
         });
     });
+
+    describe('resolveModule option', () => {
+        it('should accept resolve options', () => {
+            const { stylable } = testStylableCore(
+                {
+                    '/abc.js': ``,
+                },
+                {
+                    stylableConfig: {
+                        resolveModule: { alias: { '@abc': '/abc.js' } },
+                    },
+                }
+            );
+
+            expect(stylable.resolvePath('/', '@abc')).to.equal('/abc.js');
+        });
+    });
     describe(`transformation`, () => {
         it(`should transform a stylesheet from meta`, () => {
             const src = `

--- a/packages/e2e-test-kit/src/dts-kit.ts
+++ b/packages/e2e-test-kit/src/dts-kit.ts
@@ -1,5 +1,5 @@
-import fs, { readFileSync, symlinkSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { nodeFs as fs } from '@file-services/node';
+import { join } from 'node:path';
 import { Stylable } from '@stylable/core';
 import { generateDTSContent } from '@stylable/module-utils';
 import { createTempDirectorySync, ITempDirectorySync } from './file-system-helpers';
@@ -27,18 +27,19 @@ export class DTSKit {
             resolveNamespace(ns) {
                 return ns;
             },
+
         });
     }
 
     public populate(files: Record<string, string>, generateDts = true) {
         for (const filePath in files) {
-            writeFileSync(this.sourcePath(filePath), files[filePath]);
+            fs.writeFileSync(this.sourcePath(filePath), files[filePath]);
             if (generateDts && filePath.endsWith('.st.css')) {
                 this.genDTS(filePath);
             }
         }
         for (const filePath in this.testKit) {
-            writeFileSync(this.sourcePath(filePath), this.testKit[filePath]);
+            fs.writeFileSync(this.sourcePath(filePath), this.testKit[filePath]);
         }
     }
 
@@ -81,11 +82,11 @@ export class DTSKit {
     }
 
     public write(internalPath: string, content: string) {
-        writeFileSync(this.sourcePath(internalPath), content);
+        fs.writeFileSync(this.sourcePath(internalPath), content);
     }
 
     public read(internalPath: string) {
-        return readFileSync(this.sourcePath(internalPath), { encoding: 'utf8' });
+        return fs.readFileSync(this.sourcePath(internalPath), { encoding: 'utf8' });
     }
 
     public dispose() {
@@ -93,7 +94,7 @@ export class DTSKit {
     }
 
     public linkNodeModules() {
-        symlinkSync(
+        fs.symlinkSync(
             join(__dirname, '../../../node_modules'),
             join(this.tmp.path, 'node_modules'),
             'junction'

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -4,7 +4,7 @@
   "description": "Stylable plugin for esbuild",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha \"dist/test/**/*.spec.js\""
+    "test": "mocha \"dist/test/**/*.spec.js\" --timeout 10000"
   },
   "peerDependencies": {
     "esbuild": ">=0.17.18"

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -10,6 +10,7 @@
     "esbuild": ">=0.17.18"
   },
   "dependencies": {
+    "@file-services/node": "^8.2.0",
     "@stylable/build-tools": "^5.16.0",
     "@stylable/cli": "^5.16.0",
     "@stylable/core": "^5.16.0",

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -1,4 +1,4 @@
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 import { relative, join, isAbsolute, dirname } from 'path';
 import type { Plugin, PluginBuild } from 'esbuild';
 import {

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -1,4 +1,4 @@
-import fs, { readFileSync, writeFileSync } from 'fs';
+import { nodeFs as fs } from '@file-services/node';
 import { relative, join, isAbsolute, dirname } from 'path';
 import type { Plugin, PluginBuild } from 'esbuild';
 import {
@@ -365,10 +365,10 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
                         }
                         const distFilePath = join(stylable.projectRoot, distFile);
 
-                        writeFileSync(
+                        fs.writeFileSync(
                             distFilePath,
                             sortMarkersByDepth(
-                                readFileSync(distFilePath, 'utf8'),
+                                fs.readFileSync(distFilePath, 'utf8'),
                                 stylable,
                                 idForPath,
                                 optimize.removeUnusedComponents ? mapping : {}

--- a/packages/esbuild/test/e2e/esbuild-testkit.ts
+++ b/packages/esbuild/test/e2e/esbuild-testkit.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'node:path';
 import { readFileSync, symlinkSync, writeFileSync } from 'node:fs';
-import { nodeFs } from '@file-services/node';
+import fs from '@file-services/node';
 import { BuildContext, BuildOptions, context } from 'esbuild';
 import { createTempDirectorySync, runServer } from '@stylable/e2e-test-kit';
 
@@ -34,7 +34,7 @@ export class ESBuildTestKit {
         if (tmp) {
             const t = createTempDirectorySync('esbuild-testkit');
             this.disposables.push(() => t.remove());
-            nodeFs.copyDirectorySync(projectDir, t.path);
+            fs.copyDirectorySync(projectDir, t.path);
             buildFile = join(t.path, 'build.js');
             projectDir = t.path;
 

--- a/packages/esbuild/test/e2e/rebuild/rebuild.spec.ts
+++ b/packages/esbuild/test/e2e/rebuild/rebuild.spec.ts
@@ -2,12 +2,12 @@ import { expect } from 'chai';
 import { ESBuildTestKit } from '../esbuild-testkit';
 import { sleep } from 'promise-assist';
 
-describe('Stylable ESBuild plugin rebuild on change', () => {
+describe('Stylable ESBuild plugin rebuild on change', function () {
     const tk = new ESBuildTestKit();
 
     afterEach(() => tk.dispose());
 
-    it('should pick up rebuild', async () => {
+    it('should pick up rebuild', async function () {
         const { context, read, write } = await tk.build({
             project: 'rebuild',
             tmp: true,

--- a/packages/eslint-plugin-stylable/package.json
+++ b/packages/eslint-plugin-stylable/package.json
@@ -7,6 +7,7 @@
     "test": "mocha \"dist/test/**/*.spec.js\" --timeout 5000"
   },
   "dependencies": {
+    "@file-services/node": "^8.2.0",
     "@stylable/core": "^5.16.0",
     "@typescript-eslint/utils": "^5.61.0"
   },

--- a/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
+++ b/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { nodeFs as fs } from '@file-services/node';
 import path from 'path';
 import { Stylable, StylableMeta, createDefaultResolver } from '@stylable/core';
 import { safeParse, StylableExports } from '@stylable/core/dist/index-internal';
@@ -22,7 +22,7 @@ export default createRule({
     defaultOptions: [{ exposeDiagnosticsReports: false, resolveOptions: {} }], // TODO: allow to pass resolve config
     create(context, options) {
         const [{ exposeDiagnosticsReports, resolveOptions }] = options as Options;
-        const moduleResolver = createDefaultResolver(fs, resolveOptions);
+        const moduleResolver = createDefaultResolver({ fs, ...resolveOptions });
 
         const stylable = new Stylable({
             fileSystem: fs,

--- a/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
+++ b/packages/eslint-plugin-stylable/src/stylable-es-lint.ts
@@ -1,4 +1,4 @@
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 import path from 'path';
 import { Stylable, StylableMeta, createDefaultResolver } from '@stylable/core';
 import { safeParse, StylableExports } from '@stylable/core/dist/index-internal';

--- a/packages/experimental-loader/package.json
+++ b/packages/experimental-loader/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@stylable/core": "^5.16.0",
     "@stylable/runtime": "^5.16.0",
+    "@stylable/webpack-plugin": "^5.16.0",
     "css-loader": "^6.8.1",
     "decache": "^4.6.2",
     "loader-utils": "^3.2.1"

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -1,5 +1,5 @@
 import postcss from 'postcss';
-import { processNamespace, MinimalFS } from '@stylable/core';
+import { processNamespace, MinimalFS, createLegacyResolver } from '@stylable/core';
 import {
     emitDiagnostics,
     DiagnosticsMode,
@@ -64,11 +64,15 @@ const stylableLoader: LoaderDefinition = function (content) {
     };
     const mode = this._compiler!.options.mode === 'development' ? 'development' : 'production';
 
+    const resolveModule = createLegacyResolver(
+        this.fs as unknown as MinimalFS,
+        this._compiler!.options.resolve
+    );
     const stylable = getStylable(this._compiler!, {
         projectRoot: this.rootContext,
         fileSystem: this.fs as unknown as MinimalFS,
         mode,
-        resolveOptions: this._compiler!.options.resolve,
+        resolveModule,
         resolveNamespace,
     });
 

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -1,5 +1,5 @@
 import postcss from 'postcss';
-import { processNamespace, MinimalFS } from '@stylable/core';
+import { processNamespace } from '@stylable/core';
 import {
     emitDiagnostics,
     DiagnosticsMode,
@@ -66,12 +66,12 @@ const stylableLoader: LoaderDefinition = function (content) {
     const mode = this._compiler!.options.mode === 'development' ? 'development' : 'production';
 
     const resolveModule = createLegacyResolver(
-        this.fs as unknown as MinimalFS,
-        this._compiler!.options.resolve
+        this.fs as any,
+        this._compiler!.options.resolve as any
     );
     const stylable = getStylable(this._compiler!, {
         projectRoot: this.rootContext,
-        fileSystem: this.fs as unknown as MinimalFS,
+        fileSystem: this.fs as any,
         mode,
         resolveModule,
         resolveNamespace,

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -9,7 +9,7 @@ import { Warning, CssSyntaxError } from './warning';
 import { getStylable } from './cached-stylable-factory';
 import { createRuntimeTargetCode } from './create-runtime-target-code';
 import { addBuildInfo } from './add-build-info';
-import { createLegacyResolver } from '@stylable/webpack-plugin';
+import { createWebpackResolver } from '@stylable/webpack-plugin';
 import type { LoaderDefinition, LoaderContext } from 'webpack';
 
 // TODO: maybe adopt the code
@@ -65,7 +65,7 @@ const stylableLoader: LoaderDefinition = function (content) {
     };
     const mode = this._compiler!.options.mode === 'development' ? 'development' : 'production';
 
-    const resolveModule = createLegacyResolver(
+    const resolveModule = createWebpackResolver(
         this.fs as any,
         this._compiler!.options.resolve as any
     );

--- a/packages/experimental-loader/src/stylable-transform-loader.ts
+++ b/packages/experimental-loader/src/stylable-transform-loader.ts
@@ -1,5 +1,5 @@
 import postcss from 'postcss';
-import { processNamespace, MinimalFS, createLegacyResolver } from '@stylable/core';
+import { processNamespace, MinimalFS } from '@stylable/core';
 import {
     emitDiagnostics,
     DiagnosticsMode,
@@ -9,6 +9,7 @@ import { Warning, CssSyntaxError } from './warning';
 import { getStylable } from './cached-stylable-factory';
 import { createRuntimeTargetCode } from './create-runtime-target-code';
 import { addBuildInfo } from './add-build-info';
+import { createLegacyResolver } from '@stylable/webpack-plugin';
 import type { LoaderDefinition, LoaderContext } from 'webpack';
 
 // TODO: maybe adopt the code

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -7,6 +7,7 @@
     "test": "mocha \"./dist/test/**/*.spec.js\""
   },
   "dependencies": {
+    "@file-services/node": "^8.2.0",
     "@stylable/core": "^5.16.0",
     "@stylable/module-utils": "^5.16.0",
     "@stylable/node": "^5.16.0",

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -30,12 +30,12 @@ function getCacheKey(
 }
 
 export interface StylableJestConfig {
-    stylable?: Partial<StylableConfig>;
+    stylable?: Partial<Omit<StylableConfig, 'fileSystem'>>;
     configPath?: string;
 }
 
 export const createTransformer = (options?: StylableJestConfig) => {
-    let config: Partial<StylableConfig> = {
+    let config = {
         ...options?.stylable,
     };
 

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { nodeFs as fs } from '@file-services/node';
 import type { StylableConfig } from '@stylable/core';
 import { validateDefaultConfig } from '@stylable/core/dist/index-internal';
 import { stylableModuleFactory } from '@stylable/module-utils';

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -1,4 +1,4 @@
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 import type { StylableConfig } from '@stylable/core';
 import { validateDefaultConfig } from '@stylable/core/dist/index-internal';
 import { stylableModuleFactory } from '@stylable/module-utils';

--- a/packages/jest/test/fixtures/default-config/stylable.config.js
+++ b/packages/jest/test/fixtures/default-config/stylable.config.js
@@ -5,9 +5,10 @@ const { createDefaultResolver } = require('@stylable/core');
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createDefaultResolver(fs, {
+            resolveModule: createDefaultResolver({
+                fs,
                 alias: {
-                    'wp-alias': join(__dirname, 'webpack-alias1'),
+                    'wp-alias/*': join(__dirname, 'webpack-alias1') + '/*',
                 },
             }),
         };

--- a/packages/jest/test/jest.spec.ts
+++ b/packages/jest/test/jest.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 import nodeEval from 'node-eval';
 import stylableTransformer from '@stylable/jest';
 import type { RuntimeStylesheet } from '@stylable/runtime';

--- a/packages/jest/test/jest.spec.ts
+++ b/packages/jest/test/jest.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import fs, { readFileSync } from 'fs';
+import { nodeFs as fs } from '@file-services/node';
 import nodeEval from 'node-eval';
 import stylableTransformer from '@stylable/jest';
 import type { RuntimeStylesheet } from '@stylable/runtime';
@@ -9,7 +9,7 @@ import { createDefaultResolver } from '@stylable/core';
 describe('jest process', () => {
     it('should process stylable sources using createTransformer API', () => {
         const filename = require.resolve('@stylable/jest/test/fixtures/test.st.css');
-        const content = readFileSync(filename, 'utf8');
+        const content = fs.readFileSync(filename, 'utf8');
         const transformer = stylableTransformer.createTransformer();
 
         const module = nodeEval(
@@ -23,7 +23,7 @@ describe('jest process', () => {
 
     it('should process stylable sources with a custom namespace resolver', () => {
         const filename = require.resolve('@stylable/jest/test/fixtures/test.st.css');
-        const content = readFileSync(filename, 'utf8');
+        const content = fs.readFileSync(filename, 'utf8');
         const transformer = stylableTransformer.createTransformer({
             stylable: { resolveNamespace: (ns, _srcPath) => `${ns}-custom` },
         });
@@ -41,7 +41,7 @@ describe('jest process', () => {
         const filename = require.resolve(
             '@stylable/jest/test/fixtures/default-config/index.st.css'
         );
-        const content = readFileSync(filename, 'utf8');
+        const content = fs.readFileSync(filename, 'utf8');
         const transformer = stylableTransformer.createTransformer({
             stylable: { resolveNamespace: (ns, _srcPath) => `${ns}-custom` },
             configPath: join(dirname(filename), 'stylable.config.js'),
@@ -59,13 +59,14 @@ describe('jest process', () => {
         const filename = require.resolve(
             '@stylable/jest/test/fixtures/default-config/index.st.css'
         );
-        const content = readFileSync(filename, 'utf8');
+        const content = fs.readFileSync(filename, 'utf8');
         const transformer = stylableTransformer.createTransformer({
             stylable: {
                 resolveNamespace: (ns, _srcPath) => `${ns}-custom`,
-                resolveModule: createDefaultResolver(fs, {
+                resolveModule: createDefaultResolver({
+                    fs,
                     alias: {
-                        'wp-alias': join(dirname(filename), 'webpack-alias2'),
+                        'wp-alias/*': join(dirname(filename), 'webpack-alias2') + '/*',
                     },
                 }),
             },
@@ -84,7 +85,7 @@ describe('jest process', () => {
         const filename = require.resolve(
             '@stylable/jest/test/fixtures/default-config/index.st.css'
         );
-        const content = readFileSync(filename, 'utf8');
+        const content = fs.readFileSync(filename, 'utf8');
         let foundError = false;
 
         try {

--- a/packages/jest/test/tsconfig.json
+++ b/packages/jest/test/tsconfig.json
@@ -4,5 +4,9 @@
     "outDir": "../dist/test",
     "types": ["node", "externals", "mocha"]
   },
-  "references": [{ "path": "../../runtime/src" }, { "path": "../src" }]
+  "references": [
+    { "path": "../../runtime/src" },
+    { "path": "../../core/src" },
+    { "path": "../src" }
+  ]
 }

--- a/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
+++ b/packages/language-service/test/lib-new/features/ls-st-import.spec.ts
@@ -1287,7 +1287,7 @@ describe('LS: st-import', () => {
                         },
                     }
                 );
-                const defaultResolveModule = createDefaultResolver(fs, {});
+                const defaultResolveModule = createDefaultResolver({ fs });
                 const entryPath = fs.join(tempDir.path, 'src', 'entry.st.css');
                 /**
                  * mapping like this cannot override the original resolved package

--- a/packages/language-service/test/test-kit/test-lang-service.ts
+++ b/packages/language-service/test/test-kit/test-lang-service.ts
@@ -8,7 +8,7 @@ import { CompletionItem, TextEdit } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-css-languageservice';
 import { URI } from 'vscode-uri';
 import { expect } from 'chai';
-import nodeFs from '@file-services/node';
+import fs from '@file-services/node';
 
 export interface TestOptions {
     testOnNativeFileSystem: string;
@@ -112,10 +112,10 @@ function setupFileSystem(input: string | IDirectoryContents, options: Partial<Te
     const content = typeof input === `string` ? { '/entry.st.css': input } : input;
     if (options.testOnNativeFileSystem) {
         options.stylableConfig ||= {};
-        options.stylableConfig.filesystem = nodeFs;
+        options.stylableConfig.filesystem = fs;
         options.stylableConfig.projectRoot = options.testOnNativeFileSystem;
-        copyDirectory(nodeFs, options.testOnNativeFileSystem, content);
-        return nodeFs;
+        copyDirectory(fs, options.testOnNativeFileSystem, content);
+        return fs;
     } else {
         return createMemoryFs(content);
     }

--- a/packages/module-utils/test/generate-dts.spec.ts
+++ b/packages/module-utils/test/generate-dts.spec.ts
@@ -219,7 +219,7 @@ describe('Generate DTS', function () {
     it('should not expose imported symbols', () => {
         tk.populate({
             'origin.st.css': `
-                .cls {
+                .cls { 
                     container-name: cont;
                 }
                 @property --customProp;
@@ -253,7 +253,6 @@ describe('Generate DTS', function () {
                 
                 eq<string>(classes.cls);
                 eq<string>(classes.CompRoot);
-                eq<string>(vars.customProp);
                 eq<string>(vars.customProp);
                 eq<string>(stVars.buildVar);
                 eq<string>(keyframes.anim);

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,6 +7,7 @@
     "test": "mocha \"./dist/test/**/*.spec.js\" --timeout 10000"
   },
   "dependencies": {
+    "@file-services/node": "^8.2.0",
     "@stylable/build-tools": "^5.16.0",
     "@stylable/core": "^5.16.0",
     "@stylable/module-utils": "^5.16.0",

--- a/packages/node/src/find-files.ts
+++ b/packages/node/src/find-files.ts
@@ -1,6 +1,6 @@
 import type { IFileSystem } from '@file-services/types';
 
-export type FileSystem = any;
+export type FileSystem = IFileSystem;
 
 export function findFiles(
     fs: Pick<IFileSystem, 'readdirSync' | 'statSync'>,

--- a/packages/node/src/loader.ts
+++ b/packages/node/src/loader.ts
@@ -1,5 +1,5 @@
 import { defaultStylableMatcher } from './common';
-import nodeFs from '@file-services/node';
+import fs from '@file-services/node';
 import { stylableModuleFactory } from '@stylable/module-utils';
 import { loadStylableConfigEsm } from '@stylable/build-tools';
 import { resolveNamespace } from './resolve-namespace';
@@ -14,14 +14,14 @@ async function generateJsModule(sheetSource: string, filePath: string) {
 }
 async function initiateModuleFactory() {
     const defaultConfig = await loadStylableConfigEsm(process.cwd(), (potentialConfigModule: any) =>
-        potentialConfigModule.defaultConfig?.(nodeFs)
+        potentialConfigModule.defaultConfig?.(fs)
     );
     return stylableModuleFactory(
         {
             resolveNamespace,
             ...(defaultConfig?.config || {}),
             projectRoot: '/',
-            fileSystem: nodeFs,
+            fileSystem: fs,
             resolverCache: new Map(),
         },
         {
@@ -53,7 +53,7 @@ export async function load(
 ): Promise<LoaderResult> {
     if (defaultStylableMatcher(url)) {
         const filePath = fileURLToPath(url);
-        const sheetSource = nodeFs.readFileSync(filePath, { encoding: 'utf-8' });
+        const sheetSource = fs.readFileSync(filePath, { encoding: 'utf-8' });
         const moduleSource = await generateJsModule(sheetSource, filePath);
         return {
             shortCircuit: true,

--- a/packages/node/src/require-hook.ts
+++ b/packages/node/src/require-hook.ts
@@ -7,7 +7,7 @@ import { resolveNamespace } from './resolve-namespace';
 
 export interface Options {
     matcher: (filename: string) => boolean;
-    stylableConfig: Partial<StylableConfig>;
+    stylableConfig: Partial<Omit<StylableConfig, 'fileSystem'>>;
     afterCompile?: (code: string, filename: string) => string;
     runtimePath?: string;
     ignoreJSModules?: boolean;
@@ -24,7 +24,7 @@ export function attachHook({
     ignoreJSModules,
     configPath,
 }: Partial<Options> = {}) {
-    let options: Partial<StylableConfig> = {
+    let options = {
         ...stylableConfig,
     };
 

--- a/packages/node/src/require-hook.ts
+++ b/packages/node/src/require-hook.ts
@@ -1,7 +1,7 @@
 import type { StylableConfig } from '@stylable/core';
 import { validateDefaultConfig } from '@stylable/core/dist/index-internal';
 import { stylableModuleFactory } from '@stylable/module-utils';
-import fs from 'fs';
+import { nodeFs as fs } from '@file-services/node';
 import { defaultStylableMatcher } from './common';
 import { resolveNamespace } from './resolve-namespace';
 

--- a/packages/node/src/require-hook.ts
+++ b/packages/node/src/require-hook.ts
@@ -1,7 +1,7 @@
 import type { StylableConfig } from '@stylable/core';
 import { validateDefaultConfig } from '@stylable/core/dist/index-internal';
 import { stylableModuleFactory } from '@stylable/module-utils';
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 import { defaultStylableMatcher } from './common';
 import { resolveNamespace } from './resolve-namespace';
 

--- a/packages/node/test/fixtures/default-config/stylable.config.js
+++ b/packages/node/test/fixtures/default-config/stylable.config.js
@@ -1,13 +1,14 @@
 //@ts-check
-const { join } = require('path');
+const { posix: {join} } = require('path');
 const { createDefaultResolver } = require('@stylable/core');
 
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createDefaultResolver(fs, {
+            resolveModule: createDefaultResolver({
+                fs,
                 alias: {
-                    'wp-alias': join(__dirname, 'webpack-alias1'),
+                    'wp-alias/*': join(__dirname, 'webpack-alias1') + '/*',
                 },
             }),
         };

--- a/packages/node/test/loader.spec.ts
+++ b/packages/node/test/loader.spec.ts
@@ -69,7 +69,7 @@ describeIf(nodeMajorVersion > 14)('node loader', () => {
                 console.log(classes);
             `,
             'stylable.config.js': `
-                export function defaultConfig(fs) {
+                export function defaultConfig() {
                     return {
                         resolveNamespace(namespace, path) {
                             return 'x-' + namespace;
@@ -107,7 +107,7 @@ describeIf(nodeMajorVersion > 14)('node loader', () => {
             `,
             'stylable.config.js': `
                 module.exports = {
-                    defaultConfig(fs) {
+                    defaultConfig() {
                         return {
                             resolveNamespace(namespace, path) {
                                 return 'x-' + namespace;

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -10,6 +10,7 @@
     "rollup": "^2.70.0 || ^3.0.0"
   },
   "dependencies": {
+    "@file-services/node": "^8.2.0",
     "@stylable/build-tools": "^5.16.0",
     "@stylable/cli": "^5.16.0",
     "@stylable/core": "^5.16.0",

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'rollup';
-import fs from 'fs';
+import { nodeFs as fs } from '@file-services/node';
 import { join, parse } from 'path';
 import { Stylable, StylableConfig } from '@stylable/core';
 import {

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'rollup';
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 import { join, parse } from 'path';
 import { Stylable, StylableConfig } from '@stylable/core';
 import {

--- a/packages/rollup-plugin/test/projects/config-file-resolver-override/stylable.config.js
+++ b/packages/rollup-plugin/test/projects/config-file-resolver-override/stylable.config.js
@@ -4,9 +4,10 @@ module.exports = {
         const { createDefaultResolver } = require('@stylable/core');
         const { join } = require('path');
         return {
-            resolveModule: createDefaultResolver(fs, {
+            resolveModule: createDefaultResolver({
+                fs,
                 alias: {
-                    components: join(__dirname, 'src/components'),
+                    'components/*': join(__dirname, 'src/components') + '/*',
                 },
             }),
         };

--- a/packages/rollup-plugin/test/rollup-native-css.spec.ts
+++ b/packages/rollup-plugin/test/rollup-native-css.spec.ts
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { rollupRunner } from './test-kit/rollup-runner';
 import { getProjectPath } from './test-kit/test-helpers';
 import { createDefaultResolver } from '@stylable/core';
-import { nodeFs } from '@file-services/node';
+import { nodeFs as fs } from '@file-services/node';
 
 describe('StylableRollupPlugin - import native CSS', function () {
     this.timeout(30000);
 
     const project = 'native-css';
 
-    const resolve = createDefaultResolver(nodeFs, {});
+    const resolve = createDefaultResolver({ fs });
     const runner = rollupRunner({
         projectPath: getProjectPath(project),
         entry: './src/index.js',

--- a/packages/rollup-plugin/test/rollup-native-css.spec.ts
+++ b/packages/rollup-plugin/test/rollup-native-css.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { rollupRunner } from './test-kit/rollup-runner';
 import { getProjectPath } from './test-kit/test-helpers';
 import { createDefaultResolver } from '@stylable/core';
-import { nodeFs as fs } from '@file-services/node';
+import fs from '@file-services/node';
 
 describe('StylableRollupPlugin - import native CSS', function () {
     this.timeout(30000);

--- a/packages/rollup-plugin/test/rollup-stc-config.spec.ts
+++ b/packages/rollup-plugin/test/rollup-stc-config.spec.ts
@@ -1,4 +1,4 @@
-import { nodeFs } from '@file-services/node';
+import fs from '@file-services/node';
 import { expect } from 'chai';
 import { rollupRunner } from './test-kit/rollup-runner';
 import { getProjectPath } from './test-kit/test-helpers';
@@ -27,16 +27,15 @@ describe('StylableRollupPlugin', function () {
     it('should recovers in watch mode when broken "stc" source file is invalid', async () => {
         await runner.ready;
 
-        const indexFilePath = nodeFs.join(runner.projectDir, 'src', 'index.st.css');
+        const indexFilePath = fs.join(runner.projectDir, 'src', 'index.st.css');
 
         // Simulate error by using value function without a symbol.
-        await runner.act(
-            () => nodeFs.promises.writeFile(indexFilePath, '.root { color: value(); }'),
-            { strict: false }
-        );
+        await runner.act(() => fs.promises.writeFile(indexFilePath, '.root { color: value(); }'), {
+            strict: false,
+        });
 
         // Revert error to normal.
-        await runner.act(() => nodeFs.promises.writeFile(indexFilePath, '.root {color: green;}'));
+        await runner.act(() => fs.promises.writeFile(indexFilePath, '.root {color: green;}'));
 
         const outputFiles = runner.getOutputFiles();
         expect(outputFiles['index.st.css'], '"stc" watch has been triggered').to.eql(

--- a/packages/rollup-plugin/test/test-kit/test-helpers.ts
+++ b/packages/rollup-plugin/test/test-kit/test-helpers.ts
@@ -1,6 +1,6 @@
 import type { RollupWatcher, RollupWatcherEvent } from 'rollup';
 import { dirname, join } from 'path';
-import { nodeFs } from '@file-services/node';
+import fs from '@file-services/node';
 import { createTempDirectorySync } from '@stylable/e2e-test-kit';
 import { deferred } from 'promise-assist';
 
@@ -50,8 +50,8 @@ export async function actAndWaitForBuild(
 export function createTempProject(projectToCopy: string, nodeModulesToLink: string, entry: string) {
     const tempDir = createTempDirectorySync('local-rollup-test');
     const projectPath = join(tempDir.path, 'project');
-    nodeFs.copyDirectorySync(projectToCopy, projectPath);
-    nodeFs.symlinkSync(nodeModulesToLink, join(tempDir.path, 'node_modules'), 'junction');
+    fs.copyDirectorySync(projectToCopy, projectPath);
+    fs.symlinkSync(nodeModulesToLink, join(tempDir.path, 'node_modules'), 'junction');
     return {
         context: tempDir.path,
         input: join(tempDir.path, 'project', entry),

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -1,4 +1,5 @@
-import { Stylable, StylableMeta, createLegacyResolver } from '@stylable/core';
+import { Stylable, StylableMeta } from '@stylable/core';
+import { createLegacyResolver } from '@stylable/webpack-plugin';
 import { STSymbol } from '@stylable/core/dist/index-internal';
 import { resolveNamespace } from '@stylable/node';
 import { createMetadataForStylesheet } from './create-metadata-stylesheet';

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -1,5 +1,5 @@
 import { Stylable, StylableMeta } from '@stylable/core';
-import { createLegacyResolver } from '@stylable/webpack-plugin';
+import { createWebpackResolver } from '@stylable/webpack-plugin';
 import { STSymbol } from '@stylable/core/dist/index-internal';
 import { resolveNamespace } from '@stylable/node';
 import { createMetadataForStylesheet } from './create-metadata-stylesheet';
@@ -56,7 +56,7 @@ export class StylableManifestPlugin {
         this.options = Object.assign({}, defaultOptions, options);
     }
     public apply(compiler: Compiler) {
-        const resolveModule = createLegacyResolver(compiler.inputFileSystem as any, {
+        const resolveModule = createWebpackResolver(compiler.inputFileSystem as any, {
             ...compiler.options.resolve as any,
             extensions: [],
         });

--- a/packages/webpack-extensions/src/stylable-manifest-plugin.ts
+++ b/packages/webpack-extensions/src/stylable-manifest-plugin.ts
@@ -56,23 +56,13 @@ export class StylableManifestPlugin {
         this.options = Object.assign({}, defaultOptions, options);
     }
     public apply(compiler: Compiler) {
-        const fs = {
-            readlinkSync: (filePath: string) =>
-                (compiler.inputFileSystem as any).readlinkSync(filePath),
-            statSync: (filePath: string) => (compiler.inputFileSystem as any).statSync(filePath),
-            readFileSync: (filePath: string) =>
-                (compiler.inputFileSystem as any).readFileSync(filePath).toString(),
-        };
-        const resolveModule = createLegacyResolver(fs, {
-            ...compiler.options.resolve,
+        const resolveModule = createLegacyResolver(compiler.inputFileSystem as any, {
+            ...compiler.options.resolve as any,
             extensions: [],
         });
         const stylable = new Stylable({
             projectRoot: compiler.context,
             fileSystem: {
-                readlinkSync: (filePath) =>
-                    (compiler.inputFileSystem as any).readlinkSync(filePath),
-                statSync: (filePath) => (compiler.inputFileSystem as any).statSync(filePath),
                 readFileSync: (filePath) =>
                     (compiler.inputFileSystem as any).readFileSync(filePath).toString(),
             },

--- a/packages/webpack-extensions/src/stylable-metadata-loader.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-loader.ts
@@ -1,4 +1,4 @@
-import { Stylable, processNamespace, MinimalFS } from '@stylable/core';
+import { Stylable, processNamespace, MinimalFS, createLegacyResolver } from '@stylable/core';
 import { createStylableResolverCacheMap } from '@stylable/webpack-plugin';
 import findConfig from 'find-config';
 import type { LoaderDefinition, LoaderContext } from 'webpack';
@@ -49,14 +49,15 @@ function createStylable(
     if (!loader._compiler) {
         throw new Error('Stylable metadata loader requires a compiler instance');
     }
+    const resolveModule = createLegacyResolver(loader.fs as unknown as MinimalFS, {
+        ...loader._compiler.options.resolve,
+        extensions: [],
+    });
     return new Stylable({
         projectRoot: loader.rootContext,
         fileSystem: loader.fs as unknown as MinimalFS,
         mode: loader._compiler.options.mode === 'development' ? 'development' : 'production',
-        resolveOptions: {
-            ...loader._compiler.options.resolve,
-            extensions: [],
-        },
+        resolveModule,
         resolveNamespace,
         resolverCache: createStylableResolverCacheMap(loader._compiler),
     });

--- a/packages/webpack-extensions/src/stylable-metadata-loader.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-loader.ts
@@ -1,5 +1,5 @@
 import { Stylable, processNamespace } from '@stylable/core';
-import { createStylableResolverCacheMap, createLegacyResolver } from '@stylable/webpack-plugin';
+import { createStylableResolverCacheMap, createWebpackResolver } from '@stylable/webpack-plugin';
 import findConfig from 'find-config';
 import type { LoaderDefinition, LoaderContext } from 'webpack';
 import { createMetadataForStylesheet } from './create-metadata-stylesheet';
@@ -49,7 +49,7 @@ function createStylable(
     if (!loader._compiler) {
         throw new Error('Stylable metadata loader requires a compiler instance');
     }
-    const resolveModule = createLegacyResolver(loader.fs as any, {
+    const resolveModule = createWebpackResolver(loader.fs as any, {
         ...(loader._compiler.options.resolve as any),
         extensions: [],
     });

--- a/packages/webpack-extensions/src/stylable-metadata-loader.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-loader.ts
@@ -1,5 +1,5 @@
-import { Stylable, processNamespace, MinimalFS, createLegacyResolver } from '@stylable/core';
-import { createStylableResolverCacheMap } from '@stylable/webpack-plugin';
+import { Stylable, processNamespace, MinimalFS } from '@stylable/core';
+import { createStylableResolverCacheMap, createLegacyResolver } from '@stylable/webpack-plugin';
 import findConfig from 'find-config';
 import type { LoaderDefinition, LoaderContext } from 'webpack';
 import { createMetadataForStylesheet } from './create-metadata-stylesheet';

--- a/packages/webpack-extensions/src/stylable-metadata-loader.ts
+++ b/packages/webpack-extensions/src/stylable-metadata-loader.ts
@@ -1,4 +1,4 @@
-import { Stylable, processNamespace, MinimalFS } from '@stylable/core';
+import { Stylable, processNamespace } from '@stylable/core';
 import { createStylableResolverCacheMap, createLegacyResolver } from '@stylable/webpack-plugin';
 import findConfig from 'find-config';
 import type { LoaderDefinition, LoaderContext } from 'webpack';
@@ -49,13 +49,13 @@ function createStylable(
     if (!loader._compiler) {
         throw new Error('Stylable metadata loader requires a compiler instance');
     }
-    const resolveModule = createLegacyResolver(loader.fs as unknown as MinimalFS, {
-        ...loader._compiler.options.resolve,
+    const resolveModule = createLegacyResolver(loader.fs as any, {
+        ...(loader._compiler.options.resolve as any),
         extensions: [],
     });
     return new Stylable({
         projectRoot: loader.rootContext,
-        fileSystem: loader.fs as unknown as MinimalFS,
+        fileSystem: loader.fs as any,
         mode: loader._compiler.options.mode === 'development' ? 'development' : 'production',
         resolveModule,
         resolveNamespace,

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -18,6 +18,7 @@
     "@stylable/optimizer": "^5.16.0",
     "@stylable/runtime": "^5.16.0",
     "decache": "^4.6.2",
+    "enhanced-resolve": "^5.15.0",
     "lodash.clonedeep": "^4.5.0",
     "postcss": "^8.4.29"
   },

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -54,3 +54,4 @@ export {
     WebpackCreateHash,
     WebpackOutputOptions,
 } from './types';
+export { createLegacyResolver } from './legacy-module-resolver';

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -54,4 +54,4 @@ export {
     WebpackCreateHash,
     WebpackOutputOptions,
 } from './types';
-export { createLegacyResolver } from './legacy-module-resolver';
+export { createWebpackResolver } from './legacy-module-resolver';

--- a/packages/webpack-plugin/src/legacy-module-resolver.ts
+++ b/packages/webpack-plugin/src/legacy-module-resolver.ts
@@ -1,7 +1,5 @@
-// in browser build this gets remapped to an empty object via our package.json->"browser"
 import nodeModule from 'module';
 // importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
-// this allows @stylable/core to be bundled for browser usage without special custom configuration
 import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
 import type { ResolveOptions } from 'enhanced-resolve';
 
@@ -20,7 +18,9 @@ function bundleSafeRequireExtensions(): string[] {
 }
 
 const resolverContext = {};
-
+/**
+ * @deprecated this resolve is slow as hell and not recommended.
+ */
 export function createWebpackResolver(fileSystem: ResolveOptions['fileSystem'], resolveOptions: Partial<ResolveOptions>) {
     const extensions =
         resolveOptions.extensions && resolveOptions.extensions.length

--- a/packages/webpack-plugin/src/legacy-module-resolver.ts
+++ b/packages/webpack-plugin/src/legacy-module-resolver.ts
@@ -3,7 +3,7 @@ import nodeModule from 'module';
 // importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
 // this allows @stylable/core to be bundled for browser usage without special custom configuration
 import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
-import type { MinimalFS } from '@stylable/core';
+import type { ResolveOptions } from 'enhanced-resolve';
 
 function bundleSafeRequireExtensions(): string[] {
     let extensions: string[];
@@ -21,7 +21,7 @@ function bundleSafeRequireExtensions(): string[] {
 
 const resolverContext = {};
 
-export function createLegacyResolver(fileSystem: MinimalFS, resolveOptions: any) {
+export function createLegacyResolver(fileSystem: ResolveOptions['fileSystem'], resolveOptions: Partial<ResolveOptions>) {
     const extensions =
         resolveOptions.extensions && resolveOptions.extensions.length
             ? resolveOptions.extensions
@@ -30,7 +30,6 @@ export function createLegacyResolver(fileSystem: MinimalFS, resolveOptions: any)
         ...resolveOptions,
         extensions,
         useSyncFileSystemCalls: true,
-        cache: false,
         fileSystem,
     });
 

--- a/packages/webpack-plugin/src/legacy-module-resolver.ts
+++ b/packages/webpack-plugin/src/legacy-module-resolver.ts
@@ -21,7 +21,7 @@ function bundleSafeRequireExtensions(): string[] {
 
 const resolverContext = {};
 
-export function createLegacyResolver(fileSystem: ResolveOptions['fileSystem'], resolveOptions: Partial<ResolveOptions>) {
+export function createWebpackResolver(fileSystem: ResolveOptions['fileSystem'], resolveOptions: Partial<ResolveOptions>) {
     const extensions =
         resolveOptions.extensions && resolveOptions.extensions.length
             ? resolveOptions.extensions

--- a/packages/webpack-plugin/src/legacy-module-resolver.ts
+++ b/packages/webpack-plugin/src/legacy-module-resolver.ts
@@ -3,8 +3,7 @@ import nodeModule from 'module';
 // importing the factory directly, as we feed it our own fs, and don't want graceful-fs to be implicitly imported
 // this allows @stylable/core to be bundled for browser usage without special custom configuration
 import ResolverFactory from 'enhanced-resolve/lib/ResolverFactory.js';
-import type { ModuleResolver } from './types';
-import type { MinimalFS } from './cached-process-file';
+import type { MinimalFS } from '@stylable/core';
 
 function bundleSafeRequireExtensions(): string[] {
     let extensions: string[];
@@ -22,7 +21,7 @@ function bundleSafeRequireExtensions(): string[] {
 
 const resolverContext = {};
 
-export function createLegacyResolver(fileSystem: MinimalFS, resolveOptions: any): ModuleResolver {
+export function createLegacyResolver(fileSystem: MinimalFS, resolveOptions: any) {
     const extensions =
         resolveOptions.extensions && resolveOptions.extensions.length
             ? resolveOptions.extensions
@@ -35,7 +34,7 @@ export function createLegacyResolver(fileSystem: MinimalFS, resolveOptions: any)
         fileSystem,
     });
 
-    return (directoryPath, request): string => {
+    return (directoryPath: string, request: string): string => {
         const res = eResolver.resolveSync(resolverContext, directoryPath, request);
         if (res === false) {
             throw new Error(

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -49,7 +49,7 @@ import type {
 import { parse } from 'postcss';
 import { getWebpackEntities, StylableWebpackEntities } from './webpack-entities';
 import { resolveConfig as resolveStcConfig, STCBuilder } from '@stylable/cli';
-import { createLegacyResolver } from './legacy-module-resolver';
+import { createWebpackResolver } from './legacy-module-resolver';
 
 type OptimizeOptions = OptimizeConfig & {
     minify?: boolean;
@@ -370,7 +370,7 @@ export class StylableWebpackPlugin {
         const stylableConfig = this.getStylableConfig(compiler)?.config;
 
         validateDefaultConfig(stylableConfig?.defaultConfig);
-        const resolveModule = createLegacyResolver(topLevelFs, {
+        const resolveModule = createWebpackResolver(topLevelFs, {
             ...resolverOptions,
             extensions: [], // use Stylable's default extensions
         });

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-import { MinimalFS, Stylable, StylableConfig } from '@stylable/core';
+import { MinimalFS, Stylable, StylableConfig, createLegacyResolver } from '@stylable/core';
 import {
     OptimizeConfig,
     DiagnosticsMode,
@@ -369,7 +369,10 @@ export class StylableWebpackPlugin {
         const stylableConfig = this.getStylableConfig(compiler)?.config;
 
         validateDefaultConfig(stylableConfig?.defaultConfig);
-
+        const resolveModule = createLegacyResolver(topLevelFs, {
+            ...resolverOptions,
+            extensions: [], // use Stylable's default extensions
+        });
         this.stylable = new Stylable(
             this.options.stylableConfig(
                 {
@@ -380,16 +383,13 @@ export class StylableWebpackPlugin {
                      */
                     fileSystem: topLevelFs,
                     mode: compiler.options.mode === 'production' ? 'production' : 'development',
-                    resolveOptions: {
-                        ...resolverOptions,
-                        extensions: [], // use Stylable's default extensions
-                    },
                     resolveNamespace: createNamespaceStrategyNode({
                         hashSalt: compiler.options.output.hashSalt || '',
                     }),
                     requireModule: createDecacheRequire(compiler),
                     optimizer: this.options.optimizer,
                     resolverCache: createStylableResolverCacheMap(compiler),
+                    resolveModule,
                     /**
                      * config order is user determined
                      * each configuration points receives the default options,

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-import { MinimalFS, Stylable, StylableConfig, createLegacyResolver } from '@stylable/core';
+import { MinimalFS, Stylable, StylableConfig } from '@stylable/core';
 import {
     OptimizeConfig,
     DiagnosticsMode,
@@ -49,6 +49,7 @@ import type {
 import { parse } from 'postcss';
 import { getWebpackEntities, StylableWebpackEntities } from './webpack-entities';
 import { resolveConfig as resolveStcConfig, STCBuilder } from '@stylable/cli';
+import { createLegacyResolver } from './legacy-module-resolver';
 
 type OptimizeOptions = OptimizeConfig & {
     minify?: boolean;

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-import { MinimalFS, Stylable, StylableConfig } from '@stylable/core';
+import { Stylable, StylableConfig } from '@stylable/core';
 import {
     OptimizeConfig,
     DiagnosticsMode,
@@ -359,7 +359,7 @@ export class StylableWebpackPlugin {
             return;
         }
 
-        const resolverOptions: ResolveOptionsWebpackOptions = {
+        const resolverOptions: Omit<ResolveOptionsWebpackOptions, 'fileSystem' | 'resolver' | 'plugins'> = {
             ...compiler.options.resolve,
             aliasFields:
                 compiler.options.resolve.byDependency?.esm?.aliasFields ||
@@ -796,7 +796,7 @@ function isWebpackConfigProcessor(config: any): config is {
     webpackPlugin: (
         options: Required<StylableWebpackPluginOptions>,
         compiler: Compiler,
-        fs: MinimalFS
+        fs: unknown
     ) => Required<StylableWebpackPluginOptions>;
 } {
     return typeof config === 'object' && typeof config.webpackPlugin === 'function';

--- a/packages/webpack-plugin/test/e2e/projects/native-css/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/native-css/webpack.config.js
@@ -1,4 +1,4 @@
-const { createDefaultResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/core');
 const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
@@ -12,7 +12,8 @@ module.exports = {
         new StylableWebpackPlugin({
             stylableConfig(config, compiler) {
                 // set custom resolve for test
-                const resolve = createDefaultResolver(compiler.inputFileSystem, {});
+
+                const resolve = createLegacyResolver(compiler.inputFileSystem, {});
                 config.resolveModule = (path, request) => {
                     if (request === './resolve-me') {
                         return resolve(path, './custom-resolved.css');

--- a/packages/webpack-plugin/test/e2e/projects/native-css/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/native-css/webpack.config.js
@@ -1,5 +1,4 @@
-const { createLegacyResolver } = require('@stylable/core');
-const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
+const { StylableWebpackPlugin, createLegacyResolver } = require('@stylable/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 /** @type {import('webpack').Configuration} */

--- a/packages/webpack-plugin/test/e2e/projects/native-css/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/native-css/webpack.config.js
@@ -1,4 +1,4 @@
-const { StylableWebpackPlugin, createLegacyResolver } = require('@stylable/webpack-plugin');
+const { StylableWebpackPlugin, createWebpackResolver } = require('@stylable/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 /** @type {import('webpack').Configuration} */
@@ -12,7 +12,7 @@ module.exports = {
             stylableConfig(config, compiler) {
                 // set custom resolve for test
 
-                const resolve = createLegacyResolver(compiler.inputFileSystem, {});
+                const resolve = createWebpackResolver(compiler.inputFileSystem, {});
                 config.resolveModule = (path, request) => {
                     if (request === './resolve-me') {
                         return resolve(path, './custom-resolved.css');

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/stylable.config.js
@@ -1,11 +1,11 @@
 //@ts-check
 const { join } = require('path');
-const { createDefaultResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/core');
 
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createDefaultResolver(fs, {
+            resolveModule: createLegacyResolver(fs, {
                 alias: {
                     'wp-alias': join(__dirname, 'src/wrong'),
                 },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/stylable.config.js
@@ -1,11 +1,11 @@
 //@ts-check
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/webpack-plugin');
+const { createWebpackResolver } = require('@stylable/webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createLegacyResolver(fs, {
+            resolveModule: createWebpackResolver(fs, {
                 alias: {
                     'wp-alias': join(__dirname, 'src/wrong'),
                 },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/stylable.config.js
@@ -1,6 +1,6 @@
 //@ts-check
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/webpack.config.js
@@ -1,7 +1,7 @@
 const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { join } = require('path');
-const { createDefaultResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/core');
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
@@ -12,7 +12,7 @@ module.exports = {
         new StylableWebpackPlugin({
             stylableConfig: (config) => ({
                 ...config,
-                resolveModule: createDefaultResolver(config.fileSystem, {
+                resolveModule: createLegacyResolver(config.fileSystem, {
                     alias: {
                         'wp-alias': join(__dirname, 'src/webpack-alias'),
                     },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/webpack.config.js
@@ -1,7 +1,7 @@
 const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/webpack-plugin');
 
 /** @type {import('webpack').Configuration} */
 module.exports = {

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/webpack.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-inline-override/webpack.config.js
@@ -1,7 +1,7 @@
 const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/webpack-plugin');
+const { createWebpackResolver } = require('@stylable/webpack-plugin');
 
 /** @type {import('webpack').Configuration} */
 module.exports = {
@@ -12,7 +12,7 @@ module.exports = {
         new StylableWebpackPlugin({
             stylableConfig: (config) => ({
                 ...config,
-                resolveModule: createLegacyResolver(config.fileSystem, {
+                resolveModule: createWebpackResolver(config.fileSystem, {
                     alias: {
                         'wp-alias': join(__dirname, 'src/webpack-alias'),
                     },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-override/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-override/stylable.config.js
@@ -1,11 +1,11 @@
 //@ts-check
 const { join } = require('path');
-const { createDefaultResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/core');
 
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createDefaultResolver(fs, {
+            resolveModule: createLegacyResolver(fs, {
                 alias: {
                     'wp-alias': join(__dirname, 'src/wrong'),
                 },
@@ -18,7 +18,7 @@ module.exports = {
             stylableConfig(defaultStylableConfig) {
                 return {
                     ...defaultStylableConfig,
-                    resolveModule: createDefaultResolver(fs, {
+                    resolveModule: createLegacyResolver(fs, {
                         alias: {
                             'wp-alias': join(__dirname, 'src/webpack-alias'),
                         },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-override/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-override/stylable.config.js
@@ -1,11 +1,11 @@
 //@ts-check
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/webpack-plugin');
+const { createWebpackResolver } = require('@stylable/webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createLegacyResolver(fs, {
+            resolveModule: createWebpackResolver(fs, {
                 alias: {
                     'wp-alias': join(__dirname, 'src/wrong'),
                 },
@@ -18,7 +18,7 @@ module.exports = {
             stylableConfig(defaultStylableConfig) {
                 return {
                     ...defaultStylableConfig,
-                    resolveModule: createLegacyResolver(fs, {
+                    resolveModule: createWebpackResolver(fs, {
                         alias: {
                             'wp-alias': join(__dirname, 'src/webpack-alias'),
                         },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-override/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver-override/stylable.config.js
@@ -1,6 +1,6 @@
 //@ts-check
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver/stylable.config.js
@@ -1,12 +1,16 @@
 //@ts-check
 const { join } = require('path');
-const { createDefaultResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/core');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {
+        /////////////////////////////////////////
+        /////////////////////////////////////////
+        /////////////////////////////////////////
+        /////////////////////////////////////////
         return {
-            resolveModule: createDefaultResolver(fs, {
+            resolveModule: createLegacyResolver(fs, {
                 alias: {
                     'wp-alias': join(__dirname, 'src/webpack-alias'),
                 },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver/stylable.config.js
@@ -1,12 +1,12 @@
 //@ts-check
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/webpack-plugin');
+const { createWebpackResolver } = require('@stylable/webpack-plugin');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {
         return {
-            resolveModule: createLegacyResolver(fs, {
+            resolveModule: createWebpackResolver(fs, {
                 alias: {
                     'wp-alias': join(__dirname, 'src/webpack-alias'),
                 },

--- a/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver/stylable.config.js
+++ b/packages/webpack-plugin/test/e2e/projects/stylable-config-resolver/stylable.config.js
@@ -1,14 +1,10 @@
 //@ts-check
 const { join } = require('path');
-const { createLegacyResolver } = require('@stylable/core');
+const { createLegacyResolver } = require('@stylable/webpack-plugin');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
     defaultConfig(fs) {
-        /////////////////////////////////////////
-        /////////////////////////////////////////
-        /////////////////////////////////////////
-        /////////////////////////////////////////
         return {
             resolveModule: createLegacyResolver(fs, {
                 alias: {


### PR DESCRIPTION
This PR replaces `enhanced-resolve` default resolver with `@file-services/resolve` which is much faster and easier to use.

Notes: 
* This is a breaking change
* The old resolver created by `createDefaultResolver` is now available from the `@stylable/webpack-plugin` package and also used by default in it
* Need to migration guide:
    * minimal explanation on the difference between the options of the old and new resolver with an emphasis on `alias`.
    * removal of `resolveOptions`



