### PR TITLE
fix: initial mapped-selector infer with experimentalSelectorInference

### DIFF
--- a/packages/core/test/features/css-pseudo-element.spec.ts
+++ b/packages/core/test/features/css-pseudo-element.spec.ts
@@ -324,6 +324,32 @@ describe('features/css-pseudo-element', () => {
                     }
                 );
             });
+            it('should transform custom element with multiple selector inside nested pseudo-classes', () => {
+                // ToDo: with experimentalSelectorInference=true, the nested selector will be transformed inlined
+                testStylableCore(
+                    `
+                    @custom-selector :--part .partA, .partB;
+                    @custom-selector :--nestedPart ::part, .partC;
+    
+                    /* @rule(1 level) .entry__root:not(.entry__partA,.entry__partB) */
+                    .root:not(::part) {}
+    
+                    /*
+                        notice: partB is pushed at the end because of how custom selectors are
+                        processed atm.
+    
+                        @rule(2 levels) .entry__root:not(.entry__partA,.entry__partC,.entry__partB)
+                    */
+                    .root:not(::nestedPart) {}
+    
+                    /* @rule(custom-selector syntax)
+                            .entry__root:not(.entry__partA, .entry__partB)
+                    */
+                    .root:not(:--part) {}
+                `,
+                    { stylableConfig: { experimentalSelectorInference: true } }
+                );
+            });
         });
     });
     describe('st-import', () => {


### PR DESCRIPTION
This PR fixes the initial inferred selector for the transform/resolve process for a mapped selector that is created using a `@custom-selector` with the new `experimentalSelectorInference=true` _(only in flat-mode and not the new structure-mode)_.

The difference between the old and new inference is that with the old mode the default context was the `root` of the stylesheet, so any internal custom states/parts were inferred against the root, and that worked fine because only flat structured were allowed, so any custom selector mapping that started with `::part` would refer to a part of the `root`.

With the new `experimentalSelectorInference`, the selector context defaults to `*` (universal selector), making `::part` unknown. So to handle mapping to `::part`, it is assumed that any mapped-selector from a pseudo-element starts with an inferred `root`, while keeping the context after combinators as `*`.