### PR TITLE
feat!: strict class -st-global mapping

### DIFF
--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -668,6 +668,7 @@ function parseStGlobal(
         context.diagnostics.report(diagnostics.UNSUPPORTED_MULTI_SELECTORS_ST_GLOBAL(), {
             node: decl,
         });
+        return;
     } else {
         for (const node of selector[0].nodes) {
             if (node.type === 'combinator') {

--- a/packages/core/src/features/css-class.ts
+++ b/packages/core/src/features/css-class.ts
@@ -99,6 +99,11 @@ export const diagnostics = {
         'error',
         () => `unsupported multi selector in -st-global`
     ),
+    UNSUPPORTED_COMPLEX_SELECTOR: createDiagnosticReporter(
+        '00010',
+        'error',
+        () => `unsupported complex selector`
+    ),
     IMPORT_ISNT_EXTENDABLE: createDiagnosticReporter(
         '00005',
         'error',
@@ -663,6 +668,15 @@ function parseStGlobal(
         context.diagnostics.report(diagnostics.UNSUPPORTED_MULTI_SELECTORS_ST_GLOBAL(), {
             node: decl,
         });
+    } else {
+        for (const node of selector[0].nodes) {
+            if (node.type === 'combinator') {
+                context.diagnostics.report(diagnostics.UNSUPPORTED_COMPLEX_SELECTOR(), {
+                    node: decl,
+                });
+                return;
+            }
+        }
     }
     return selector[0].nodes;
 }

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -147,12 +147,6 @@ describe(`features/css-class`, () => {
                 /* @transform-remove */
                 -st-global: "[attr=val]";
             }
-            
-            /* @rule(complex) .y .z */
-            .d {
-                /* @transform-remove */
-                -st-global: ".y .z";
-            }
 
             /* @rule(not only classes compound) .yy[attr] */
             .e {
@@ -176,9 +170,6 @@ describe(`features/css-class`, () => {
         expect(CSSClass.get(meta, `c`), `c symbol`).to.contain({
             name: 'c',
         });
-        expect(CSSClass.get(meta, `d`), `d symbol`).to.contain({
-            name: 'd',
-        });
         expect(CSSClass.get(meta, `e`), `e symbol`).to.contain({
             name: 'e',
         });
@@ -188,7 +179,6 @@ describe(`features/css-class`, () => {
             x: true,
             z: true,
             zz: true,
-            y: true,
             yy: true,
         });
 
@@ -213,6 +203,12 @@ describe(`features/css-class`, () => {
                 /* @analyze-error(multi) ${classDiagnostics.UNSUPPORTED_MULTI_SELECTORS_ST_GLOBAL()} */
                 -st-global: ".y , .z";
             }
+
+            /* @rule(complex) .entry__c */
+            .c {
+                /* @analyze-error(complex) ${classDiagnostics.UNSUPPORTED_COMPLEX_SELECTOR()} */
+                -st-global: ".y .z";
+            }
         `);
 
         const { meta, exports } = sheets['/entry.st.css'];
@@ -225,6 +221,7 @@ describe(`features/css-class`, () => {
         // JS exports
         expect(exports.classes.a, `a (empty) JS export`).to.eql(`entry__a`);
         expect(exports.classes.b, `b (multi) JS export`).to.eql(`y`);
+        expect(exports.classes.c, `c (complex) JS export`).to.eql(`entry__c`);
     });
     it(`should escape`, () => {
         const { sheets } = testStylableCore(

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -198,7 +198,7 @@ describe(`features/css-class`, () => {
                 -st-global: "";
             }
 
-            /* @rule(empty) .y */
+            /* @rule(multi) .entry__b */
             .b {
                 /* @analyze-error(multi) ${classDiagnostics.UNSUPPORTED_MULTI_SELECTORS_ST_GLOBAL()} */
                 -st-global: ".y , .z";
@@ -214,13 +214,11 @@ describe(`features/css-class`, () => {
         const { meta, exports } = sheets['/entry.st.css'];
 
         // meta.globals
-        expect(meta.globals).to.eql({
-            y: true,
-        });
+        expect(meta.globals).to.eql({});
 
         // JS exports
         expect(exports.classes.a, `a (empty) JS export`).to.eql(`entry__a`);
-        expect(exports.classes.b, `b (multi) JS export`).to.eql(`y`);
+        expect(exports.classes.b, `b (multi) JS export`).to.eql(`entry__b`);
         expect(exports.classes.c, `c (complex) JS export`).to.eql(`entry__c`);
     });
     it(`should escape`, () => {

--- a/packages/core/test/stylable-transformer/global.spec.ts
+++ b/packages/core/test/stylable-transformer/global.spec.ts
@@ -13,7 +13,7 @@ describe('Stylable postcss transform (Global)', () => {
                         @st-import [test] from './imported.st.css';
                         .root {}
                         .test {}
-                        .x { -st-global: '.a .b'; }
+                        .x { -st-global: '.a.b'; }
                         :global(.c .d) {}
                         :global(.e) {}
                     `,
@@ -38,7 +38,7 @@ describe('Stylable postcss transform (Global)', () => {
             e: true,
         });
         expect((meta.targetAst!.nodes[1] as postcss.Rule).selector).to.equal('.global-test');
-        expect((meta.targetAst!.nodes[2] as postcss.Rule).selector).to.equal('.a .b');
+        expect((meta.targetAst!.nodes[2] as postcss.Rule).selector).to.equal('.a.b');
         expect((meta.targetAst!.nodes[3] as postcss.Rule).selector).to.equal('.c .d');
         expect((meta.targetAst!.nodes[4] as postcss.Rule).selector).to.equal('.e');
     });


### PR DESCRIPTION
This PR makes the `-st-global` mapping from class symbol more strict, disallowing complex selectors and improving the already disallowed multi selector by not transforming it or collecting globals.