### PR TITLE
chore!: deprecate resolveExtends of custom-selector

### DIFF
--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -9,7 +9,6 @@ import {
     StylableSymbol,
     CSSClass,
     STSymbol,
-    STCustomSelector,
     VarSymbol,
     CSSVarSymbol,
     KeyframesSymbol,
@@ -20,7 +19,6 @@ import {
     CSSContains,
     STStructure,
 } from './features';
-import type { StylableTransformer } from './stylable-transformer';
 import { findRule } from './helpers/rule';
 import type { ModuleResolver } from './types';
 import { CustomValueExtension, isCustomValue, stTypes } from './custom-values';
@@ -374,7 +372,6 @@ export class StylableResolver {
                         meta,
                         deepResolved.symbol,
                         false,
-                        undefined,
                         validateClassResolveExtends(meta, name, diagnostics, deepResolved)
                     );
                     break;
@@ -429,7 +426,6 @@ export class StylableResolver {
         meta: StylableMeta,
         nameOrSymbol: string | ClassSymbol | ElementSymbol,
         isElement = false,
-        transformer?: StylableTransformer,
         reportError?: ReportError
     ): CSSResolvePath {
         const name = typeof nameOrSymbol === `string` ? nameOrSymbol : nameOrSymbol.name;
@@ -439,23 +435,6 @@ export class StylableResolver {
                     ? meta.getTypeElement(nameOrSymbol)
                     : meta.getClass(nameOrSymbol)
                 : nameOrSymbol;
-
-        const customSelector = isElement
-            ? null
-            : STCustomSelector.getCustomSelectorExpended(meta, name);
-
-        if (!symbol && !customSelector) {
-            return [];
-        }
-
-        if (customSelector && transformer) {
-            const parsed = transformer.resolveSelectorElements(meta, customSelector);
-            if (parsed.length === 1) {
-                return parsed[0][parsed[0].length - 1].resolved;
-            } else {
-                return [];
-            }
-        }
 
         if (!symbol) {
             return [];


### PR DESCRIPTION
This PR removes the optional `transformer` argument from `resolver.resolveExtends` function.

Passing the transformer argument currently instructs the resolver to first seek a custom selector before inspecting the stylesheet meta for a class and then determining its type accordingly.

There are several reasons for removing this API:
- It is not utilized within Stylable or, to the best of our knowledge, outside of the Stylable repository.
- This functionality relies on custom-selector, which we intend to deprecate in favor of the new structure-mode with mapped selectors, which provides an alternative method for deducing the extended type.
- This is the only workflow that necessitates the presence of the transformer argument in the resolver, complicating our refactoring plans.

In the future, there may be a need for a similar method to resolve such issues, and we anticipate reintroducing similar functionality when it becomes necessary.