### PR TITLE
refactor(types)!: enhance type definitions for resolved CSS and JS values

### DIFF
--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -183,7 +183,7 @@ export class StylablePublicApi {
                     name,
                     kind: 'js-func',
                     args: [],
-                    func: resolvedSymbols.js[name].symbol,
+                    func: resolvedSymbols.js[name].symbol as (...args: any[]) => any,
                 };
                 for (const arg of Object.values(data.options)) {
                     mixRef.args.push(arg.value);
@@ -374,10 +374,10 @@ function appendMixin(context: FeatureTransformContext, config: ApplyMixinContext
         handleCSSMixin(context, config, resolveChain);
         return;
     } else if (resolvedType === `js`) {
-        const resolvedMixin = resolvedSymbols.js[symbolName];
-        if (typeof resolvedMixin.symbol === 'function') {
+        const jsValue = resolvedSymbols.js[symbolName].symbol;
+        if (typeof jsValue === 'function') {
             try {
-                handleJSMixin(context, config, resolvedMixin.symbol);
+                handleJSMixin(context, config, jsValue as (...args: any[]) => any);
             } catch (e) {
                 context.diagnostics.report(diagnostics.FAILED_TO_APPLY_MIXIN(String(e)), {
                     node: config.rule,

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -480,7 +480,7 @@ export function resolveReferencedVarNames(
                     break;
                 case 'import': {
                     const resolved = context.resolver.deepResolve(symbol);
-                    if (resolved?._kind === 'css' && resolved.symbol._kind === 'var') {
+                    if (resolved?._kind === 'css' && resolved.symbol?._kind === 'var') {
                         varsToCheck.push({ meta: resolved.meta, name: resolved.symbol.name });
                     }
                     break;

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -400,21 +400,16 @@ function evaluateValueCall(
             const type = resolvedSymbols.mainNamespace[varName];
             if (type === `js`) {
                 const deepResolve = resolvedSymbols.js[varName];
-                const importedType = typeof deepResolve.symbol;
-                if (importedType === 'string') {
+                const jsValue = deepResolve.symbol;
+                if (typeof jsValue === 'string') {
                     parsedNode.resolvedValue = context.evaluator.valueHook
-                        ? context.evaluator.valueHook(
-                              deepResolve.symbol,
-                              varName,
-                              false,
-                              passedThrough
-                          )
-                        : deepResolve.symbol;
+                        ? context.evaluator.valueHook(jsValue, varName, false, passedThrough)
+                        : jsValue;
                 } else if (node) {
                     // unsupported Javascript value
                     // ToDo: provide actual exported id (default/named as x)
                     context.diagnostics.report(
-                        diagnostics.CANNOT_USE_JS_AS_VALUE(importedType, varName),
+                        diagnostics.CANNOT_USE_JS_AS_VALUE(typeof jsValue, varName),
                         {
                             node,
                             word: varName,

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -187,7 +187,9 @@ export function processDeclarationValue(
                 const formatterArgs = getFormatterArgs(parsedNode);
                 try {
                     // ToDo: check if function instead of calling on a non function
-                    parsedNode.resolvedValue = (formatter.symbol as Function)(...formatterArgs);
+                    parsedNode.resolvedValue = (formatter.symbol as (...args: any[]) => any)(
+                        ...formatterArgs
+                    );
                     if (evaluator.valueHook && typeof parsedNode.resolvedValue === 'string') {
                         parsedNode.resolvedValue = evaluator.valueHook(
                             parsedNode.resolvedValue,

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -186,7 +186,8 @@ export function processDeclarationValue(
                 const formatter = resolvedSymbols.js[value];
                 const formatterArgs = getFormatterArgs(parsedNode);
                 try {
-                    parsedNode.resolvedValue = formatter.symbol.apply(null, formatterArgs);
+                    // ToDo: check if function instead of calling on a non function
+                    parsedNode.resolvedValue = (formatter.symbol as Function)(...formatterArgs);
                     if (evaluator.valueHook && typeof parsedNode.resolvedValue === 'string') {
                         parsedNode.resolvedValue = evaluator.valueHook(
                             parsedNode.resolvedValue,

--- a/packages/core/src/index-internal.ts
+++ b/packages/core/src/index-internal.ts
@@ -47,7 +47,12 @@ export {
     EmitDiagnosticsContext,
     reportDiagnostic,
 } from './report-diagnostic';
-export { StylableResolver, StylableResolverCache } from './stylable-resolver';
+export {
+    StylableResolver,
+    StylableResolverCache,
+    isValidCSSResolve,
+    CSSResolveMaybe,
+} from './stylable-resolver';
 export { CacheItem, FileProcessor, cachedProcessFile, processFn } from './cached-process-file';
 export { createStylableFileProcessor } from './create-stylable-processor';
 export { packageNamespaceFactory } from './resolve-namespace-factories';

--- a/packages/core/src/stylable-resolver.ts
+++ b/packages/core/src/stylable-resolver.ts
@@ -84,7 +84,7 @@ export type CSSResolvePath = Array<CSSResolve<ClassSymbol | ElementSymbol>>;
 
 export interface JSResolve {
     _kind: 'js';
-    symbol: any;
+    symbol: unknown;
     meta: null;
 }
 
@@ -390,7 +390,7 @@ export class StylableResolver {
                             meta,
                             name,
                             diagnostics,
-                            deepResolved as CSSResolve
+                            deepResolved as CSSResolve<ClassSymbol>
                         )
                     );
                     break;
@@ -534,7 +534,7 @@ function validateClassResolveExtends(
     meta: StylableMeta,
     name: string,
     diagnostics: Diagnostics,
-    deepResolved: CSSResolve<StylableSymbol> | JSResolve | null
+    deepResolved: CSSResolve<ClassSymbol>
 ): ReportError | undefined {
     return (res, extend) => {
         const decl = findRule(meta.sourceAst, '.' + name);
@@ -557,7 +557,7 @@ function validateClassResolveExtends(
                 });
             }
         } else {
-            if (deepResolved?.symbol.alias) {
+            if (deepResolved.symbol.alias) {
                 meta.sourceAst.walkRules(new RegExp('\\.' + name), (rule) => {
                     diagnostics.report(CSSClass.diagnostics.UNKNOWN_IMPORT_ALIAS(name), {
                         node: rule,

--- a/packages/language-service/src/lib/completion-providers.ts
+++ b/packages/language-service/src/lib/completion-providers.ts
@@ -565,6 +565,7 @@ export const ExtendCompletionPlugin: LangServicePlugin = {
                             return (
                                 res &&
                                 res._kind === 'css' &&
+                                res.symbol &&
                                 (res.symbol._kind === 'class' || res.symbol._kind === 'element')
                             );
                         })

--- a/packages/webpack-extensions/src/types.ts
+++ b/packages/webpack-extensions/src/types.ts
@@ -1,4 +1,5 @@
-import type { CSSResolve, Imported, JSResolve, StylableMeta } from '@stylable/core';
+import type { Imported, JSResolve, StylableMeta } from '@stylable/core';
+import type { CSSResolveMaybe } from '@stylable/core/dist/index-internal';
 
 export interface Metadata {
     entry: string;
@@ -24,5 +25,5 @@ export type MetadataList = Array<{
 
 export type ResolvedImport = {
     stImport: Imported;
-    resolved: CSSResolve | JSResolve | null;
+    resolved: CSSResolveMaybe | JSResolve | null;
 };


### PR DESCRIPTION
This PR enhances the type definitions for resolved CSS and JS values in the following ways:

1. The CSS resolved type now accurately represents the scenario where the `symbol` field can be `undefined` when the stylesheet exists, but the queried symbol definition is missing.
2. The JS resolved symbol type (exported value) has been updated from the loose `any` type to the more precise `unknown` type.