### PR TITLE
refactor(cli)!: make `fs` required in `resolveConfig` function

### DIFF
--- a/packages/cli/src/build-stylable.ts
+++ b/packages/cli/src/build-stylable.ts
@@ -56,7 +56,7 @@ export async function buildStylable(
         watchOptions = {},
     }: BuildStylableContext = {}
 ) {
-    const { config } = resolveConfig(rootDir, configFilePath, fs) || {};
+    const { config } = resolveConfig(rootDir, fs, configFilePath) || {};
     validateDefaultConfig(config?.defaultConfig);
 
     const projects = await projectsConfig(rootDir, overrideBuildOptions, defaultOptions, config);

--- a/packages/cli/src/config/projects-config.ts
+++ b/packages/cli/src/config/projects-config.ts
@@ -64,8 +64,7 @@ export async function projectsConfig(
     return projects;
 }
 
-// todo: make fs not optional next major version
-export function resolveConfig(context: string, request?: string, fs?: IFileSystem) {
+export function resolveConfig(context: string, fs: IFileSystem, request?: string) {
     return request ? requireConfigFile(request, context, fs) : resolveConfigFile(context, fs);
 }
 

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -110,8 +110,8 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
         const projectRoot = build.initialOptions.absWorkingDir || process.cwd();
         const configFromFile = resolveConfig(
             projectRoot,
-            typeof configFile === 'string' ? configFile : undefined,
-            fs
+            fs,
+            typeof configFile === 'string' ? configFile : undefined
         );
         const stConfig = stylableConfig(
             {

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -123,8 +123,8 @@ export function stylableRollupPlugin({
                 });
                 configFromFile = resolveStcConfig(
                     stConfig.projectRoot,
-                    typeof stcConfig === 'string' ? stcConfig : undefined,
-                    fs
+                    fs,
+                    typeof stcConfig === 'string' ? stcConfig : undefined
                 );
 
                 stylable = new Stylable({

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -330,8 +330,8 @@ export class StylableWebpackPlugin {
     private getStylableConfig(compiler: Compiler) {
         const configuration = resolveStcConfig(
             compiler.context,
-            typeof this.options.stcConfig === 'string' ? this.options.stcConfig : undefined,
-            getTopLevelInputFilesystem(compiler)
+            getTopLevelInputFilesystem(compiler),
+            typeof this.options.stcConfig === 'string' ? this.options.stcConfig : undefined
         );
 
         return configuration;
@@ -359,7 +359,10 @@ export class StylableWebpackPlugin {
             return;
         }
 
-        const resolverOptions: Omit<ResolveOptionsWebpackOptions, 'fileSystem' | 'resolver' | 'plugins'> = {
+        const resolverOptions: Omit<
+            ResolveOptionsWebpackOptions,
+            'fileSystem' | 'resolver' | 'plugins'
+        > = {
             ...compiler.options.resolve,
             aliasFields:
                 compiler.options.resolve.byDependency?.esm?.aliasFields ||


### PR DESCRIPTION
This PR modifies an internal function argument that was originally intended to be required but was mistakenly set as optional. It is classified as a breaking change because this function is exposed through the `@stylable/cli` index. However, it's worth noting that this function is undocumented and, in all likelihood, not utilized by external parties outside of the project.