### PR TITLE
fix: at-rule mixin collecting extra rules regression

### DIFF
--- a/packages/core/src/helpers/rule.ts
+++ b/packages/core/src/helpers/rule.ts
@@ -106,13 +106,14 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule | postcs
                 node.name === 'container'
             ) {
                 let scopeSelector = node.name === 'st-scope' ? node.params : '';
+                let atruleHasMixin = isNestedInMixin || false;
                 if (scopeSelector) {
                     const ast = parseSelectorWithCache(scopeSelector, { clone: true });
                     const matchesSelectors = isRoot
                         ? ast
                         : ast.filter((node) => containsPrefix(node));
                     if (matchesSelectors.length) {
-                        isNestedInMixin = true;
+                        atruleHasMixin = true;
                         scopeSelector = stringifySelector(
                             matchesSelectors.map((selectorNode) => {
                                 if (!isRoot) {
@@ -133,7 +134,7 @@ export function createSubsetAst<T extends postcss.Root | postcss.AtRule | postcs
                     }),
                     isRoot,
                     getCustomSelector,
-                    isNestedInMixin
+                    atruleHasMixin
                 );
                 if (atRuleSubset.nodes) {
                     mixinRoot.append(atRuleSubset);

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -2066,6 +2066,33 @@ describe(`features/st-mixin`, () => {
 
             shouldReportNoDiagnostics(meta);
         });
+        it('should collect only st-scope nested rules', () => {
+            const { sheets } = testStylableCore({
+                '/mix.st.css': `
+                    .before { color: RED; }
+                    @st-scope .mix {
+                        .inside { color: green; }
+                    }
+                    .after { color: RED; }
+                `,
+                '/entry.st.css': `
+                    @st-import [mix] from './mix.st.css';
+                    
+                    .into {-st-mixin: mix;}
+                `,
+            });
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            expect(deindent(meta.targetAst!.toString())).to.eql(
+                deindent(`
+                    .entry__into {}
+                        .entry__into .mix__inside { color: green; }
+                `)
+            );
+        });
     });
     describe(`higher-level feature integrations`, () => {
         // ToDo: move to their higher level feature spec when created


### PR DESCRIPTION
This PR resolves a regression where mixins defined within an at-rule, such as `@st-scope`, would inadvertently include extra rules that followed them.

This regression occurred during the [handling of certain native-CSS nested mixin scenarios](https://github.com/wix/stylable/pull/2898).

> this fix will also be backported to version 5.