### PR TITLE
feat(core)!: normalize build-var value

### DIFF
--- a/packages/core/src/features/feature.ts
+++ b/packages/core/src/features/feature.ts
@@ -98,7 +98,6 @@ export interface FeatureHooks<T extends NodeTypes = NodeTypes> {
         context: FeatureTransformContext;
         ast: postcss.Root;
         transformer: StylableTransformer;
-        cssVarsMapping: Record<string, string>;
         path: string[];
     }) => void;
 }

--- a/packages/core/src/features/st-mixin.ts
+++ b/packages/core/src/features/st-mixin.ts
@@ -122,8 +122,8 @@ export const hooks = createFeature({
         }
         return isMarker;
     },
-    transformLastPass({ context, ast, transformer, cssVarsMapping, path }) {
-        ast.walkRules((rule) => appendMixins(context, transformer, rule, cssVarsMapping, path));
+    transformLastPass({ context, ast, transformer, path }) {
+        ast.walkRules((rule) => appendMixins(context, transformer, rule, path));
     },
 });
 
@@ -212,7 +212,6 @@ function appendMixins(
     context: FeatureTransformContext,
     transformer: StylableTransformer,
     rule: postcss.Rule,
-    cssPropertyMapping: Record<string, string>,
     path: string[] = []
 ) {
     const [decls, mixins] = collectRuleMixins(context, rule);
@@ -221,7 +220,7 @@ function appendMixins(
     }
     for (const mixin of mixins) {
         if (mixin.valid) {
-            appendMixin(context, { transformer, mixDef: mixin, rule, path, cssPropertyMapping });
+            appendMixin(context, { transformer, mixDef: mixin, rule, path });
         }
     }
     for (const mixinDecl of decls) {
@@ -359,7 +358,6 @@ interface ApplyMixinContext {
     mixDef: AnalyzedMixin & { valid: true };
     rule: postcss.Rule;
     path: string[];
-    cssPropertyMapping: Record<string, string>;
 }
 
 function appendMixin(context: FeatureTransformContext, config: ApplyMixinContext) {
@@ -475,8 +473,7 @@ function handleCSSMixin(
                 context.diagnostics,
                 mixDef.data.originDecl,
                 stVarOverride,
-                config.path,
-                config.cssPropertyMapping
+                config.path
             );
             collectOptionalArgs(
                 { meta: resolved.meta, resolver: context.resolver },

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -271,7 +271,6 @@ export function parseVarsFromExpr(expr: string) {
 
 function collectVarSymbols(context: FeatureContext, rule: postcss.Rule) {
     rule.walkDecls((decl) => {
-        collectUrls(context.meta, decl); // ToDo: remove
         warnOnDeprecatedCustomValues(context, decl);
 
         // check type annotation
@@ -313,20 +312,6 @@ function warnOnDeprecatedCustomValues(context: FeatureContext, decl: postcss.Dec
                         word: node.name,
                     }
                 );
-            }
-        },
-        false
-    );
-}
-
-// ToDo: remove after moving :vars removal to end of analyze.
-// url collection should pickup vars value during general decls walk
-function collectUrls(meta: StylableMeta, decl: postcss.Declaration) {
-    processDeclarationFunctions(
-        decl,
-        (node) => {
-            if (node.type === 'url') {
-                meta.urls.push(node.url);
             }
         },
         false

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -23,7 +23,6 @@ export interface EvalValueData {
     node?: postcss.Node;
     meta: StylableMeta;
     stVarOverride?: Record<string, string> | null;
-    cssVarsMapping?: Record<string, string>;
     args?: string[];
     rootArgument?: string;
     initialNode?: postcss.Node;
@@ -63,7 +62,6 @@ export class StylableEvaluator {
             this.valueHook,
             context.diagnostics,
             context.passedThrough,
-            data.cssVarsMapping,
             data.args,
             data.rootArgument,
             data.initialNode
@@ -94,8 +92,7 @@ export function resolveArgumentsValue(
     diagnostics: Diagnostics,
     node: postcss.Node,
     variableOverride?: Record<string, string>,
-    path?: string[],
-    cssVarsMapping?: Record<string, string>
+    path?: string[]
 ) {
     const resolvedArgs = {} as Record<string, string>;
     for (const k in options) {
@@ -108,7 +105,6 @@ export function resolveArgumentsValue(
             transformer.replaceValueHook,
             diagnostics,
             path,
-            cssVarsMapping,
             undefined
         );
     }
@@ -125,7 +121,6 @@ export function processDeclarationValue(
     valueHook?: replaceValueHook,
     diagnostics: Diagnostics = new Diagnostics(),
     passedThrough: string[] = [],
-    cssVarsMapping: Record<string, string> = {},
     args: string[] = [],
     rootArgument?: string,
     initialNode?: postcss.Node
@@ -155,7 +150,6 @@ export function processDeclarationValue(
                         node,
                         meta,
                         stVarOverride: variableOverride,
-                        cssVarsMapping,
                         args,
                         rootArgument,
                         initialNode,
@@ -228,7 +222,6 @@ export function processDeclarationValue(
                         node,
                         meta,
                         stVarOverride: variableOverride,
-                        cssVarsMapping,
                         args,
                         rootArgument,
                         initialNode,
@@ -312,7 +305,6 @@ export function evalDeclarationValue(
     valueHook?: replaceValueHook,
     diagnostics?: Diagnostics,
     passedThrough: string[] = [],
-    cssVarsMapping?: Record<string, string>,
     args: string[] = [],
     getResolvedSymbols: (meta: StylableMeta) => MetaResolvedSymbols = createSymbolResolverWithCache(
         resolver,
@@ -329,7 +321,6 @@ export function evalDeclarationValue(
         valueHook,
         diagnostics,
         passedThrough,
-        cssVarsMapping,
         args
     ).outputValue;
 }

--- a/packages/core/src/stylable-processor.ts
+++ b/packages/core/src/stylable-processor.ts
@@ -51,15 +51,7 @@ export class StylableProcessor implements FeatureContext {
             }
         });
 
-        const isStylable = this.meta.type === 'stylable';
         root.walkDecls((decl) => {
-            const parent = decl.parent as postcss.ChildNode;
-            if (parent.type === 'rule' && parent.selector === ':vars' && isStylable) {
-                // ToDo: remove once
-                // - custom property definition is allowed in var value
-                // - url collection is removed from st-var
-                return;
-            }
             CSSClass.hooks.analyzeDeclaration({ context: this, decl });
             CSSCustomProperty.hooks.analyzeDeclaration({ context: this, decl });
             CSSContains.hooks.analyzeDeclaration({ context: this, decl });

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -314,7 +314,6 @@ export class StylableTransformer {
                 value: decl.value,
                 meta,
                 node: decl,
-                cssVarsMapping: cssVarsMapping.localToGlobal,
             }).outputValue;
         };
 
@@ -354,7 +353,6 @@ export class StylableTransformer {
             context: transformContext,
             ast,
             transformer: this,
-            cssVarsMapping: cssVarsMapping.localToGlobal,
             path,
         };
         if (this.experimentalSelectorInference) {

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -757,22 +757,84 @@ describe(`features/css-custom-property`, () => {
 
             shouldReportNoDiagnostics(meta);
         });
-        it(`should NOT define property as var value (change in v5)`, () => {
-            // ToDo: in the future property should be able to be defined in var value
-            const { sheets } = testStylableCore(`
-                :vars {
-                    myVar: var(--color);
-                }
+        it(`should define property as var value`, () => {
+            const { sheets } = testStylableCore({
+                './origin.st.css': `
+                    :vars {
+                        x: var(--x);
+                    }
+                `,
+                './entry.st.css': `
+                    @st-import [x as importedVar] from './origin.st.css';
+                    :vars {
+                        y: var(--y);
+                        z: value(y) value(importedVar);
+                    }
 
-                .root {
-                    /* @decl prop: var(--color) */
-                    prop: value(myVar);
-                }
-            `);
+                    .root {
+                        /* @decl(local) prop: var(--entry-y) */
+                        prop: value(y);
+
+                        /* @decl(imported) prop: var(--origin-x) */
+                        prop: value(importedVar);
+
+                        /* @decl(mix) prop: var(--entry-y) var(--origin-x) */
+                        prop: value(z);
+                    }
+                `,
+            });
+
+            const { meta, exports } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+
+            // symbols
+            expect(CSSCustomProperty.get(meta, `--y`), `--y symbol`).to.eql({
+                _kind: `cssVar`,
+                name: `--y`,
+                global: false,
+                alias: undefined,
+            });
+
+            // JS exports
+            expect(exports.vars, `JS export`).to.eql({ y: `--entry-y` });
+        });
+        it(`should preserve string value with custom property`, () => {
+            const { sheets } = testStylableCore({
+                './origin.st.css': `
+                    :vars {
+                        x: 'var(--x)';
+                    }
+                `,
+                './entry.st.css': `
+                    @st-import [x as importedVar] from './origin.st.css';
+                    :vars {
+                        y: "var(--y)";
+                        z: value(y) value(importedVar);
+                    }
+
+                    .root {
+                        /* @decl(local) prop: var(--y) */
+                        prop: value(y);
+
+                        /* @decl(imported) prop: var(--x) */
+                        prop: value(importedVar);
+
+                        /* @decl(mix) prop: var(--y) var(--x) */
+                        prop: value(z);
+                    }
+                `,
+            });
 
             const { meta } = sheets['/entry.st.css'];
 
             shouldReportNoDiagnostics(meta);
+
+            // symbols
+            expect(CSSCustomProperty.get(meta, `--y`), `--y symbol`).to.eql(undefined);
+
+            // JS exports
+            expect(exports.vars, `JS export`).to.eql(undefined);
         });
     });
     describe(`st-formatter`, () => {
@@ -883,6 +945,46 @@ describe(`features/css-custom-property`, () => {
                     );
                 }
             `);
+
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+        });
+        it('should namespace custom-props within build vars', () => {
+            const { sheets } = testStylableCore({
+                './mix.st.css': `
+                    :vars {
+                        x: var(--x);
+                    }
+                    .mix {
+                        val: value(x);
+                    }
+                `,
+                './entry.st.css': `
+                    @st-import [mix as importedMix] from './mix.st.css';
+                    :vars {
+                        x: var(--y);
+                    }
+                    .localMix {
+                        val: value(x);
+                    }
+
+                    /* @rule(local) .entry__root { val: var(--entry-y); } */
+                    .root {
+                        -st-mixin: localMix;
+                    }
+
+                    /* @rule(imported) .entry__root { val: var(--mix-x); } */
+                    .root {
+                        -st-mixin: importedMix;
+                    }
+
+                    /* @rule(with local override) .entry__root { val: var(--entry-y); } */
+                    .root {
+                        -st-mixin: importedMix(x value(x));
+                    }
+                `,
+            });
 
             const { meta } = sheets['/entry.st.css'];
 

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -772,6 +772,8 @@ describe(`features/css-custom-property`, () => {
                     }
 
                     .root {
+                        --x: context property does not override property from origin;
+
                         /* @decl(local) prop: var(--entry-y) */
                         prop: value(y);
 
@@ -797,7 +799,7 @@ describe(`features/css-custom-property`, () => {
             });
 
             // JS exports
-            expect(exports.vars, `JS export`).to.eql({ y: `--entry-y` });
+            expect(exports.vars, `JS export`).to.eql({ y: `--entry-y`, x: `--entry-x` });
         });
         it(`should preserve string value with custom property`, () => {
             const { sheets } = testStylableCore({


### PR DESCRIPTION
This PR modifies the evaluation method for the Stylable build-vars value to ensure its consistency with other values.

Please note, this introduces a breaking change. We had initially deferred this adjustment until version 6. However, to streamline edge cases, we've decided to alter the behavior now.

### Previous Behavior

In the past, the build-var value wasn't assessed in the same manner as other values. This discrepancy led to symbols defined within it being overlooked, especially when referencing a custom property.

For instance, using `buildVar: var(--dynamicVar)` wouldn't define the `--dynamicVar` symbol. As a result, the evaluation of the build-var would retain a global, un-namespaced custom property. Complicating matters, if this property was defined outside the build-var, it would be namespaced. This behavior can be preserved (shown below).

Another case that is being deprecated/fixed is when evaluating a build-var, it would pickup custom-properties from the evaluated context. That was an unintentional/undocumented/weird behavior that we don't think should be supported, have seen no cases of anyone using it, and unlike the global/undeclared behavior that can be preserved, this "fix" doesn't have any alternatives.

### Retaining the Old Behavior

For legacy code that sets a build-var with a global custom property and wishes to maintain the previous behavior, there are two solutions:

Enclose the value in quotes:
```css
:vars {
    buildVar: "var(--dynamicVar)";
}
```

Define a global custom property:
```css
@property st-global(--dynamicVar);
:vars {
    buildVar: var(--dynamicVar);
}
```

-----

> Notice that a deprecation info diagnostic is introduced in `stylable@5` to report unknown custom-properties in build-vars: https://github.com/wix/stylable/pull/2922 

