### PR TITLE
chore: deprecation info for unknown custom-properties in build-var

### DIFF
--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -99,9 +99,9 @@ export const diagnostics = {
     UNKNOWN_CUSTOM_PROP: createDiagnosticReporter('07011', 'info', (names: string[]) => {
         const msgStart =
             names.length > 1
-                ? `Unknown custom-properties "${names.join(', ')}"`
-                : `Unknown custom-property "${names[0]}"`;
-        return `${msgStart} are currently not namespaced, but will be namespaced to stylesheet in Stylable 6. To retain current behavior either enclose value in quotes or define a global custom-property for the used properties.`;
+                ? `Unknown custom-properties "${names.join(', ')}" are`
+                : `Unknown custom-property "${names[0]}" is`;
+        return `${msgStart} currently not namespaced. However, in Stylable 6, it will be namespaced to the stylesheet. To maintain the current behavior, either wrap the value in quotes or establish a global custom property. If you intend for the custom property to be namespaced based on a different stylesheet context where the variable may be utilized, please reconsider your approach, as this will not be supported in future versions.`;
     }),
 };
 

--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -96,6 +96,13 @@ export const diagnostics = {
         'error',
         (name: string) => `unknown var "${name}"`
     ),
+    UNKNOWN_CUSTOM_PROP: createDiagnosticReporter('07011', 'info', (names: string[]) => {
+        const msgStart =
+            names.length > 1
+                ? `Unknown custom-properties "${names.join(', ')}"`
+                : `Unknown custom-property "${names[0]}"`;
+        return `${msgStart} are currently not namespaced, but will be namespaced to stylesheet in Stylable 6. To retain current behavior either enclose value in quotes or define a global custom-property for the used properties.`;
+    }),
 };
 
 // HOOKS
@@ -124,6 +131,33 @@ export const hooks = createFeature<{
             });
         }
         return;
+    },
+    transformInit({ context }) {
+        const { cssVar } = context.getResolvedSymbols(context.meta);
+        for (const [_localName, localSymbol] of Object.entries(
+            STSymbol.getAllByType(context.meta, 'var')
+        )) {
+            const value = postcssValueParser(stripQuotation(localSymbol.text));
+            const unknownUsedProps: string[] = [];
+            value.walk((node) => {
+                if (node.type === 'function' && node.value.toLowerCase() === 'var') {
+                    for (const argNode of node.nodes) {
+                        if (
+                            argNode.type === 'word' &&
+                            argNode.value.startsWith('--') &&
+                            !cssVar[argNode.value]
+                        ) {
+                            unknownUsedProps.push(argNode.value);
+                        }
+                    }
+                }
+            });
+            if (unknownUsedProps.length) {
+                context.diagnostics.report(diagnostics.UNKNOWN_CUSTOM_PROP(unknownUsedProps), {
+                    node: localSymbol.node,
+                });
+            }
+        }
     },
     prepareAST({ node, toRemove }) {
         if (node.type === 'rule' && node.selector === ':vars') {

--- a/packages/core/src/stylable-transformer.ts
+++ b/packages/core/src/stylable-transformer.ts
@@ -175,6 +175,7 @@ export class StylableTransformer {
         };
         STImport.hooks.transformInit({ context });
         STGlobal.hooks.transformInit({ context });
+        STVar.hooks.transformInit({ context });
         if (!this.experimentalSelectorInference) {
             meta.transformedScopes = validateScopes(this, meta);
         }

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -1,4 +1,4 @@
-import { STImport, CSSCustomProperty, STSymbol } from '@stylable/core/dist/features';
+import { STImport, STVar, CSSCustomProperty, STSymbol } from '@stylable/core/dist/features';
 import { generateScopedCSSVar } from '@stylable/core/dist/helpers/css-custom-property';
 import {
     testStylableCore,
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 
 const stImportDiagnostics = diagnosticBankReportToStrings(STImport.diagnostics);
 const stSymbolDiagnostics = diagnosticBankReportToStrings(STSymbol.diagnostics);
+const stVarDiagnostics = diagnosticBankReportToStrings(STVar.diagnostics);
 const customPropertyDiagnostics = diagnosticBankReportToStrings(CSSCustomProperty.diagnostics);
 
 describe(`features/css-custom-property`, () => {
@@ -748,7 +749,7 @@ describe(`features/css-custom-property`, () => {
         });
         it(`should NOT define property as var value (change in v5)`, () => {
             // ToDo: in the future property should be able to be defined in var value
-            const { sheets } = testStylableCore(`
+            testStylableCore(`
                 :vars {
                     myVar: var(--color);
                 }
@@ -758,8 +759,50 @@ describe(`features/css-custom-property`, () => {
                     prop: value(myVar);
                 }
             `);
+        });
+        it(`should report deprecation info on unknown custom properties`, () => {
+            const { sheets } = testStylableCore({
+                './other.st.css': `
+                    @property --knownA;
+                `,
+                './invalid.st.css': `
+                    :vars {
+                        /* @transform-info(single) ${stVarDiagnostics.UNKNOWN_CUSTOM_PROP([
+                            '--unknown1',
+                        ])} */
+                        single: var(--unknown1);
 
-            const { meta } = sheets['/entry.st.css'];
+                        /* @transform-info(between) ${stVarDiagnostics.UNKNOWN_CUSTOM_PROP([
+                            '--unknown2',
+                        ])} */
+                        betweenValue: before var(--unknown2) after;
+
+                        /* @transform-info(multiple) ${stVarDiagnostics.UNKNOWN_CUSTOM_PROP([
+                            '--unknownY',
+                            '--unknownX',
+                            '--unknownZ',
+                        ])} */
+                        multiple: var(--unknownY) var(--unknownX, var(--unknownZ));
+                    }
+                `,
+                './valid.st.css': `
+                    @st-import [--knownA] from './other.st.css';
+                    @property --knownB;
+                    .root {
+                        --knownC: green;
+                    }
+
+                    :vars {
+                        single: var(--knownA);
+
+                        betweenValue: before var(--knownB) after;
+
+                        multiple: var(--knownC) var(--knownB, var(--knownA));
+                    }
+                `,
+            });
+
+            const { meta } = sheets['/valid.st.css'];
 
             shouldReportNoDiagnostics(meta);
         });


### PR DESCRIPTION
This PR introduces a deprecation warning for build-vars that reference undefined custom properties in `Stylable@5`.

While the current evaluation mechanism remains unchanged, it will be updated in version 6 (as detailed in the [related PR](https://github.com/wix/stylable/pull/2921)). Users are recommended to either define global custom properties or wrap the value in quotes to achieve the intended result.