### PR TITLE
fix(cli): resolveNamespace cli arg should override stylable.config

### DIFF
--- a/packages/cli/src/build-stylable.ts
+++ b/packages/cli/src/build-stylable.ts
@@ -7,7 +7,6 @@ import {
     createBuildIdentifier,
     createDefaultOptions,
     hasStylableCSSOutput,
-    NAMESPACE_RESOLVER_MODULE_REQUEST,
 } from './config/resolve-options';
 import { DiagnosticsManager } from './diagnostics-manager';
 import { createDefaultLogger, levels } from './logger';
@@ -51,7 +50,7 @@ export async function buildStylable(
         }),
         outputFiles = new Map(),
         requireModule = require,
-        resolveNamespace = requireModule(NAMESPACE_RESOLVER_MODULE_REQUEST).resolveNamespace,
+        resolveNamespace,
         configFilePath,
         watchOptions = {},
     }: BuildStylableContext = {}
@@ -92,10 +91,13 @@ export async function buildStylable(
                 fileSystem,
                 requireModule,
                 projectRoot,
-                resolveNamespace,
                 resolverCache,
                 fileProcessorCache,
                 ...config?.defaultConfig,
+                resolveNamespace:
+                    resolveNamespace ||
+                    config?.defaultConfig?.resolveNamespace ||
+                    requireModule('@stylable/node').resolveNamespace,
             });
 
             const { service, generatedFiles } = await build(buildOptions, {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,9 +16,11 @@ async function main() {
         config,
     } = argv;
     const rootDir = resolve(argv.rootDir);
-    const { resolveNamespace } = require(require.resolve(namespaceResolver, {
-        paths: [rootDir],
-    }));
+    const explicitResolveNs =
+        namespaceResolver &&
+        require(require.resolve(namespaceResolver, {
+            paths: [rootDir],
+        }));
 
     //
     const log = createLogger(
@@ -42,7 +44,7 @@ async function main() {
         overrideBuildOptions,
         defaultOptions,
         fs,
-        resolveNamespace,
+        resolveNamespace: explicitResolveNs?.resolveNamespace,
         watch,
         log,
         configFilePath: config,

--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -7,8 +7,6 @@ import type { CliArguments, BuildOptions, PartialBuildOptions } from '../types';
 
 const { join } = nodeFs;
 
-export const NAMESPACE_RESOLVER_MODULE_REQUEST = '@stylable/node';
-
 export function getCliArguments(): Arguments<CliArguments> {
     const defaults = createDefaultOptions();
     return yargs
@@ -85,10 +83,12 @@ export function getCliArguments(): Arguments<CliArguments> {
             alias: 'unsr',
         })
         .option('namespaceResolver', {
+            type: 'string',
             description:
                 'node request to a module that exports a stylable resolveNamespace function',
             alias: 'nsr',
-            default: NAMESPACE_RESOLVER_MODULE_REQUEST,
+            defaultDescription:
+                'default to @stylable/node, if stylable.config resolveNamespace is undefined',
         })
         .option('injectCSSRequest', {
             type: 'boolean',

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -102,7 +102,7 @@ export interface CliArguments {
     bundle: string | undefined;
     dtsSourceMap: boolean | undefined;
     useNamespaceReference: boolean | undefined;
-    namespaceResolver: string;
+    namespaceResolver?: string | undefined;
     injectCSSRequest: boolean | undefined;
     cssFilename: string | undefined;
     cssInJs: boolean | undefined;


### PR DESCRIPTION
This pr fix an issue that caused the `resolveNamespace` cli argument to be overridden in case a `stylable.config ` resolveNamespace is present.

The cli argument `default` is replaced with a `defaultDescription` in order to identify between explicit path and the default path, and the default override order is now done in a single place inside.