### PR TITLE
fix(runtime): expose stylesheet types in package exports

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,6 +13,9 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./stylesheet": {
+      "types": "./stylesheet.d.ts"
+    },
     "./package.json": "./package.json",
     "./dist/index.js": "./dist/index.js",
     "./dist/index.mjs": "./dist/index.mjs"


### PR DESCRIPTION
This pr introduces the addition of `@stylable/runtime/stylesheet` mapping to the exports field in the `package.json` of the runtime package. 

This is specifically aimed at facilitating projects that utilize `TypeScript` with `moduleResolution: node16` in conjunction with the [global stylesheet types approach](https://stylable.io/docs/getting-started/typescript-integration#global-definition).