### PR TITLE
fix(core): scope nested global selector issues

### DIFF
--- a/packages/core/src/helpers/selector.ts
+++ b/packages/core/src/helpers/selector.ts
@@ -199,7 +199,8 @@ export function scopeNestedSelector(
             );
             // merge scope flags
             const nestStartWithNesting = first.type === `nesting`;
-            const nestedStartWithGlobal = first.type === `pseudo_class` && first.value === `global`;
+            const nestedStartWithGlobal =
+                rootScopeLevel && first.type === `pseudo_class` && first.value === `global`;
             const nestStartWithScope =
                 rootScopeLevel &&
                 scopeAst.nodes.every((node, i) => {

--- a/packages/core/test/features/css-class.spec.ts
+++ b/packages/core/test/features/css-class.spec.ts
@@ -3,6 +3,7 @@ import {
     testStylableCore,
     shouldReportNoDiagnostics,
     diagnosticBankReportToStrings,
+    deindent,
 } from '@stylable/core-test-kit';
 import { expect } from 'chai';
 import type * as postcss from 'postcss';
@@ -1018,6 +1019,26 @@ describe(`features/css-class`, () => {
             const { meta } = sheets['/valid.st.css'];
 
             shouldReportNoDiagnostics(meta);
+        });
+        it('should nest -st-global classes', () => {
+            const { sheets } = testStylableCore(`
+                .global {
+                    -st-global: "body";
+                }
+                @st-scope html {
+                    .global {}
+                }
+            `);
+            const { meta } = sheets['/entry.st.css'];
+
+            shouldReportNoDiagnostics(meta);
+            expect(deindent(meta.targetAst!.toString())).to.eql(
+                deindent(`
+                body {
+                }
+                html body {}
+            `)
+            );
         });
     });
     describe(`css-pseudo-element`, () => {

--- a/packages/core/test/features/st-mixin.spec.ts
+++ b/packages/core/test/features/st-mixin.spec.ts
@@ -1271,7 +1271,6 @@ describe(`features/st-mixin`, () => {
             shouldReportNoDiagnostics(meta);
         });
         it(`should append mixin rules`, () => {
-            // ToDo: fix ":global(.part)" to transform with mixin root
             const { sheets } = testStylableCore({
                 '/mixin.js': `
                     module.exports = function() {
@@ -1302,7 +1301,7 @@ describe(`features/st-mixin`, () => {
                         @rule[1] .entry__root Element { d: Capital element } 
                         @rule[2] .entry__root element { d: lowercase element } 
                         @rule[3] .entry__root .entry__part { d: class namespaced in context } 
-                        @rule[4] .part { d: global class } 
+                        @rule[4] .entry__root .part { d: global class } 
                         @rule[5] .entry__root .entry__x, .entry__root .entry__y { d: multiple selectors } 
                     */
                     .root {


### PR DESCRIPTION
This pr fix the code that combines 2 selectors into a single selector in order to fix 2 bugs:

- when nesting a global selector into a `@st-scope`, the   parent selector is ignored
- when mixining a JS mixin, any nested rule that starts with `:global()` is missing the mixed into selector