### PR TITLE
feat: improve output capabilities of cli

### DIFF
--- a/packages/cli/src/config/resolve-options.ts
+++ b/packages/cli/src/config/resolve-options.ts
@@ -34,10 +34,25 @@ export function getCliArguments(): Arguments<CliArguments> {
             description: 'output esm module (.mjs)',
             defaultDescription: String(defaults.esm),
         })
+        .option('esmCss', {
+            type: 'boolean',
+            description: 'output esm module (.inject.mjs) with inline css injection',
+            defaultDescription: String(defaults.esmCss),
+        })
         .option('cjs', {
             type: 'boolean',
             description: 'output commonjs module (.js)',
             defaultDescription: String(defaults.cjs),
+        })
+        .option('cjsCss', {
+            type: 'boolean',
+            description: 'output commonjs module (.inject.js) with inline css injection',
+            defaultDescription: String(defaults.cjsCss),
+        })
+        .option('copyAssets', {
+            type: 'boolean',
+            description: 'emit assets found in css files',
+            defaultDescription: String(defaults.copyAssets),
         })
         .option('css', {
             type: 'boolean',
@@ -235,6 +250,9 @@ export function createDefaultOptions(): BuildOptions {
         cjs: false,
         esm: false,
         dts: false,
+        esmCss: false,
+        cjsCss: false,
+        copyAssets: true,
         esmExt: '.mjs',
         cjsExt: '.js',
         injectCSSRequest: false,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -139,10 +139,14 @@ export interface BuildOptions {
     cjs?: boolean;
     /** commonjs module extension */
     cjsExt?: '.cjs' | '.js';
+    /** cjs with inline css injection */
+    cjsCss?: boolean;
     /** output esm module (.mjs) */
     esm?: boolean;
     /** esm module extension */
     esmExt?: '.mjs' | '.js';
+    /** esm with inline css injection */
+    esmCss?: boolean;
     /** template of the css file emitted when using outputCSS */
     outputCSSNameTemplate?: string;
     /** should include the css in the generated JS module */
@@ -151,6 +155,8 @@ export interface BuildOptions {
     outputCSS?: boolean;
     /** should output source .st.css file to dist */
     outputSources?: boolean;
+    /** should copy assets to dist */
+    copyAssets?: boolean;
     /** should add namespace reference to the .st.css copy  */
     useNamespaceReference?: boolean;
     /** should inject css import in the JS module for the generated css from outputCSS */
@@ -196,4 +202,9 @@ export interface BuildContext {
     diagnosticsManager?: DiagnosticsManager;
 }
 
-export type ModuleFormats = Array<['esm', '.js' | '.mjs'] | ['cjs', '.js' | '.cjs']>;
+export type ModuleFormats = Array<
+    | ['esm', '.js' | '.mjs']
+    | ['esm+css', '.js' | '.mjs']
+    | ['cjs', '.js' | '.cjs']
+    | ['cjs+css', '.js' | '.cjs']
+>;

--- a/packages/esbuild/src/stylable-esbuild-plugin.ts
+++ b/packages/esbuild/src/stylable-esbuild-plugin.ts
@@ -346,6 +346,7 @@ export const stylablePlugin = (initialPluginOptions: ESBuildOptions = {}): Plugi
                                     relative,
                                     dirname,
                                     isAbsolute,
+                                    ensureDirectorySync: fs.ensureDirectorySync,
                                 });
                             }
                         }


### PR DESCRIPTION
feat: add cjs+css and esm+css direct outputs
feat: make copyAssets and generateManifest separated from the generateIndex flow.
feat: manifest not expose the direct dependencies
fix: add ensureDirectorySync to buildDTS