### PR TITLE
feat(core): add missing native definitions

### DIFF
--- a/packages/core/src/native-reserved-lists.ts
+++ b/packages/core/src/native-reserved-lists.ts
@@ -4,6 +4,7 @@ export const nativePseudoClasses = [
     'any',
     'any-link',
     'checked',
+    'indeterminate',
     'default',
     'defined',
     'dir',
@@ -48,6 +49,14 @@ export const nativePseudoClasses = [
     'valid',
     'visited',
     'where',
+    'user-valid',
+    'user-invalid',
+    'autofill',
+    'modal',
+    'popover-open',
+    'future',
+    'past',
+    'picture-in-picture',
 ];
 
 export const CSSWideKeywords = ['initial', 'inherit', 'unset'];
@@ -100,6 +109,15 @@ export const nativePseudoElements = [
     'selection',
     'slotted',
     'spelling-error',
+    'file-selector-button',
+    'highlight',
+    'part',
+    'target-text',
+    'view-transition',
+    'view-transition-group',
+    'view-transition-image-pair',
+    'view-transition-new',
+    'view-transition-old',
 ];
 
 export const nativeFunctionsDic: Record<string, { preserveQuotes: boolean }> = {
@@ -188,6 +206,7 @@ export const nativeFunctionsDic: Record<string, { preserveQuotes: boolean }> = {
     oklch: { preserveQuotes: true },
     supports: { preserveQuotes: true },
     anchor: { preserveQuotes: true },
+    'anchor-size': { preserveQuotes: true },
     selector: { preserveQuotes: true /* TODO:transform the nested selector */ },
     style: { preserveQuotes: true /* TODO: transform the dashed ident property */ },
     'image-set': { preserveQuotes: true },

--- a/packages/core/src/native-reserved-lists.ts
+++ b/packages/core/src/native-reserved-lists.ts
@@ -182,6 +182,7 @@ export const nativeFunctionsDic: Record<string, { preserveQuotes: boolean }> = {
     scaleY: { preserveQuotes: false },
     scaleZ: { preserveQuotes: false },
     scroll: { preserveQuotes: false },
+    view: { preserveQuotes: true },
     sepia: { preserveQuotes: false },
     skew: { preserveQuotes: false },
     skewX: { preserveQuotes: false },

--- a/packages/core/test/features/st-structure.spec.ts
+++ b/packages/core/test/features/st-structure.spec.ts
@@ -58,13 +58,15 @@ describe('@st structure', () => {
         it('should prevent automatic .class=>::part definition', () => {
             testStylableCore(`
                 @st .root;
-                .part {}
+                .customPart {}
     
                 /* 
-                    @transform-error ${transformerStringDiagnostics.UNKNOWN_PSEUDO_ELEMENT(`part`)}
-                    @rule .entry__root::part
+                    @transform-error ${transformerStringDiagnostics.UNKNOWN_PSEUDO_ELEMENT(
+                        `customPart`
+                    )}
+                    @rule .entry__root::customPart
                 */
-                .root::part {}
+                .root::customPart {}
             `);
         });
         it('should register css class', () => {


### PR DESCRIPTION
This PR add missing native css definitions. 

> Notice that some of them are experimental, but well supported.

### pseudo-classes

**:indeterminate**
- https://drafts.csswg.org/selectors/#indeterminate

**:placeholder-shown**
- https://drafts.csswg.org/selectors/#placeholder

**:user-valid**
- https://drafts.csswg.org/selectors/#user-pseudos

**:autofill**
- https://drafts.csswg.org/selectors/#autofill

**:modal**
- https://drafts.csswg.org/selectors/#modal-state

**:popover-open**
- https://developer.mozilla.org/en-US/docs/Web/CSS/:popover-open

**:future** / **:past**
- https://drafts.csswg.org/selectors/#the-future-pseudo
- https://drafts.csswg.org/selectors/#the-past-pseudo

**:picture-in-picture**
- https://drafts.csswg.org/selectors/#pip-state

### pseudo-elements

**::file-selector-button**
- https://drafts.csswg.org/css-pseudo/#file-selector-button-pseudo

**::highlight**
- https://drafts.csswg.org/css-highlight-api/#custom-highlight-pseudo

**::part**
- https://drafts.csswg.org/css-shadow-parts/#part

**::target-text**
- https://drafts.csswg.org/css-pseudo/#selectordef-target-text

**::view-transition** / **::view-transition-group** / **::view-transition-image-pair** / **::view-transition-new** / **::view-transition-old**
- https://drafts.csswg.org/css-view-transitions/#selectordef-view-transition

### value functions
**anchor-size()**
- https://www.w3.org/TR/css-anchor-position-1/#anchor-size-fn

**view()**
- https://drafts.csswg.org/scroll-animations/#view-notation