### PR TITLE
chore(rollup-template): add required tslib dev dependency

### DIFF
--- a/packages/create-stylable-app/template/ts-react-rollup/template.js
+++ b/packages/create-stylable-app/template/ts-react-rollup/template.js
@@ -26,6 +26,7 @@ module.exports = {
         'rollup-plugin-copy',
         'rollup-plugin-serve',
         'serve',
+        'tslib',
         'typescript',
     ],
     packageJson: {


### PR DESCRIPTION
This PR add `tslib` as dependency for the rollup template which is required* by the `@rollup/plugin-typescript` when `output.preserveModules = true`.