### PR TITLE
chore: remove ignoreDeprecations from ts-config

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -59,8 +59,8 @@
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    "importsNotUsedAsValues": "error",                   /* Specify emit/checking behavior for imports that are only used for types. */
-    "ignoreDeprecations": "5.0",
+    // "importsNotUsedAsValues": "error",                   /* Specify emit/checking behavior for imports that are only used for types. */
+    // "ignoreDeprecations": "5.0",
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */


### PR DESCRIPTION
This PR removes the [`ignoreDeprecations` typescript compile option](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#deprecations-and-default-changes). 
The deprecation ignore config is supposed to last until 5.4 (typescript is currently at 5.3.3).

We should try to enable `verbatimModuleSyntax` instead of the deprecated `importsNotUsedAsValues` config.