### PR TITLE
fix: esbuild plugin break after stylable error (#2938) 5.x

### DIFF
--- a/packages/esbuild/test/e2e/esbuild-testkit.ts
+++ b/packages/esbuild/test/e2e/esbuild-testkit.ts
@@ -1,8 +1,8 @@
 import { dirname, join } from 'node:path';
-import { readFileSync, symlinkSync, writeFileSync, cpSync } from 'node:fs';
+import { readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { BuildContext, BuildOptions, context, Plugin } from 'esbuild';
 import { createTempDirectorySync, runServer } from '@stylable/e2e-test-kit';
-
+import { nodeFs } from '@file-services/node';
 import playwright from 'playwright-core';
 
 type BuildFn = (
@@ -35,7 +35,7 @@ export class ESBuildTestKit {
         if (tmp) {
             const t = createTempDirectorySync('esbuild-testkit');
             this.disposables.push(() => t.remove());
-            cpSync(projectDir, t.path, { recursive: true });
+            nodeFs.copyDirectorySync(projectDir, t.path);
             buildFile = join(t.path, 'build.js');
             projectDir = t.path;
 

--- a/packages/esbuild/test/e2e/rebuild/rebuild.spec.ts
+++ b/packages/esbuild/test/e2e/rebuild/rebuild.spec.ts
@@ -7,8 +7,8 @@ describe('Stylable ESBuild plugin rebuild on change', () => {
 
     afterEach(() => tk.dispose());
 
-    it('should pick up rebuild', async () => {
-        const { context, read, write } = await tk.build({
+    it('should pick up rebuild', async function () {
+        const { context, read, write, act } = await tk.build({
             project: 'rebuild',
             tmp: true,
         });
@@ -16,8 +16,28 @@ describe('Stylable ESBuild plugin rebuild on change', () => {
         expect(css1, 'initial color').to.includes('color: red');
         await context.watch();
         await sleep(2222);
-        write('a.st.css', `.root{color: green}`);
+        await act(() => {
+            write('a.st.css', `.root{color: green}`);
+        });
+        const css2 = read('dist/index.js');
+        expect(css2, 'color after change').to.includes('color: green');
+    });
+
+    it('should stay alive after error', async function () {
+        const { context, read, write, act } = await tk.build({
+            project: 'rebuild',
+            tmp: true,
+        });
+        const css1 = read('dist/index.js');
+        expect(css1, 'initial color').to.includes('color: red');
+        await context.watch();
         await sleep(2222);
+        await act(() => {
+            write('a.st.css', `.root{}}}}}`);
+        });
+        await act(() => {
+            write('a.st.css', `.root{color: green}`);
+        });
         const css2 = read('dist/index.js');
         expect(css2, 'color after change').to.includes('color: green');
     });


### PR DESCRIPTION
cherry-pick fix to esbuild from #2938