### PR TITLE
feat: expose computed build vars source location

### DIFF
--- a/packages/core/src/features/st-var.ts
+++ b/packages/core/src/features/st-var.ts
@@ -209,11 +209,11 @@ export function get(meta: StylableMeta, name: string): VarSymbol | undefined {
 
 // Stylable StVar Public APIs
 
-const UNKNOWN_LOCATION = {
+const UNKNOWN_LOCATION = Object.freeze({
     offset: -1,
     line: -1,
     column: -1,
-} as const;
+} as const);
 export class StylablePublicApi {
     constructor(private stylable: Stylable) {}
 


### PR DESCRIPTION
This PR exposes the source location (meta, start, end) of computed build vars calculated using `stylable.stVar.flatten(meta)` or `stylable.stVar.getComputed(meta)`.