### PR TITLE
feat(core): expose css custom properties api

### DIFF
--- a/packages/core/src/features/css-custom-property.ts
+++ b/packages/core/src/features/css-custom-property.ts
@@ -7,6 +7,7 @@ import {
     generateScopedCSSVar,
     atPropertyValidationWarnings,
 } from '../helpers/css-custom-property';
+import type { Stylable } from '../stylable';
 import { validateAllowedNodesUntil, stringifyFunction } from '../helpers/value';
 import { globalValue, GLOBAL_FUNC } from '../helpers/global';
 import { plugableRecord } from '../helpers/plugable-record';
@@ -281,6 +282,16 @@ function addCSSProperty({
         safeRedeclare: !final || !!alias,
         node,
     });
+}
+
+const UNKNOWN_LOCATION = {
+    offset: -1,
+    line: -1,
+    column: -1,
+} as const;
+
+export class StylablePublicApi {
+    constructor(private stylable: Stylable) {}
 }
 
 function analyzeDeclValueVarCalls(context: FeatureContext, decl: postcss.Declaration) {

--- a/packages/core/src/features/css-custom-property.ts
+++ b/packages/core/src/features/css-custom-property.ts
@@ -288,11 +288,11 @@ function addCSSProperty({
     });
 }
 
-const UNKNOWN_LOCATION = {
+const UNKNOWN_LOCATION = Object.freeze({
     offset: -1,
     line: -1,
     column: -1,
-} as const;
+});
 
 export class StylablePublicApi {
     constructor(private stylable: Stylable) {}

--- a/packages/core/src/stylable.ts
+++ b/packages/core/src/stylable.ts
@@ -73,6 +73,7 @@ export class Stylable {
     public resolver: StylableResolver;
     public stModule = new STImport.StylablePublicApi(this);
     public stScope = new STScope.StylablePublicApi(this);
+    public cssCustomProperty = new CSSCustomProperty.StylablePublicApi(this);
     public stVar = new STVar.StylablePublicApi(this);
     public stMixin = new STMixin.StylablePublicApi(this);
     public cssClass = new CSSClass.StylablePublicApi(this);

--- a/packages/core/test/features/css-custom-property.spec.ts
+++ b/packages/core/test/features/css-custom-property.spec.ts
@@ -6,7 +6,11 @@ import {
     diagnosticBankReportToStrings,
     deindent,
 } from '@stylable/core-test-kit';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiSubset from 'chai-subset';
+import type { StylableMeta } from '../../src';
+
+chai.use(chaiSubset);
 
 const stImportDiagnostics = diagnosticBankReportToStrings(STImport.diagnostics);
 const stSymbolDiagnostics = diagnosticBankReportToStrings(STSymbol.diagnostics);
@@ -1103,6 +1107,129 @@ describe(`features/css-custom-property`, () => {
                     @property --no-body;
                 `)
             );
+        });
+    });
+    describe('introspection', () => {
+        function expectSourceLocation({
+            source: { meta, start, end },
+            expected,
+        }: {
+            source: { meta: StylableMeta; start: { offset: number }; end: { offset: number } };
+            expected: string;
+        }) {
+            const actualSrc = meta.sourceAst.toString().slice(start.offset, end.offset);
+            expect(actualSrc).to.eql(expected);
+        }
+        describe('getProperties', () => {
+            it('should resolve all local properties', () => {
+                const { stylable, sheets } = testStylableCore(
+                    deindent(`
+                        @property --defInAtRule {
+                            syntax: '<color>';
+                            initial-value: green;
+                            inherits: false;
+                        }
+
+                        .root {
+                            --defineInPropName: green;
+
+                            color: var(--defineInDeclValue);
+                        }
+                    `)
+                );
+
+                const { meta } = sheets['/entry.st.css'];
+
+                const properties = stylable.cssCustomProperty.getProperties(meta);
+
+                expect(properties).to.containSubset({
+                    '--defInAtRule': {
+                        meta,
+                        localName: '--defInAtRule',
+                        targetName: '--entry-defInAtRule',
+                    },
+                    '--defineInPropName': {
+                        meta,
+                        localName: '--defineInPropName',
+                        targetName: '--entry-defineInPropName',
+                    },
+                    '--defineInDeclValue': {
+                        meta,
+                        localName: '--defineInDeclValue',
+                        targetName: '--entry-defineInDeclValue',
+                    },
+                });
+                expectSourceLocation({
+                    source: properties['--defInAtRule'].source,
+                    expected: `@property --defInAtRule {\n    syntax: '<color>';\n    initial-value: green;\n    inherits: false;\n}`,
+                });
+                expectSourceLocation({
+                    source: properties['--defineInPropName'].source,
+                    expected: `--defineInPropName: green;`,
+                });
+                expectSourceLocation({
+                    source: properties['--defineInDeclValue'].source,
+                    expected: `color: var(--defineInDeclValue);`,
+                });
+            });
+            it('should resolve imported properties', () => {
+                const { stylable, sheets } = testStylableCore({
+                    'deep.st.css': `
+                        .x {
+                            --deep: red;
+                        }
+                    `,
+                    'proxy.st.css': `
+                        @st-import [--deep as --deepReassign1] from './deep.st.css';
+                        .x {
+                            --proxy: var(--deepReassign1);
+                        }
+                    `,
+                    'entry.st.css': deindent(`
+                        @st-import [--proxy as --proxyReassign, --deepReassign1 as --deepReassign2] from './proxy.st.css';
+
+                        .x {
+                            --local: green;
+                        }
+                    `),
+                });
+
+                const { meta } = sheets['/entry.st.css'];
+                const { meta: proxyMeta } = sheets['/proxy.st.css'];
+                const { meta: deepMeta } = sheets['/deep.st.css'];
+
+                const properties = stylable.cssCustomProperty.getProperties(meta);
+
+                expect(properties).to.containSubset({
+                    '--local': {
+                        meta,
+                        localName: '--local',
+                        targetName: '--entry-local',
+                    },
+                    '--proxyReassign': {
+                        meta: proxyMeta,
+                        localName: '--proxy',
+                        targetName: '--proxy-proxy',
+                    },
+                    '--deepReassign2': {
+                        meta: deepMeta,
+                        localName: '--deep',
+                        targetName: '--deep-deep',
+                    },
+                });
+                expectSourceLocation({
+                    source: properties['--local'].source,
+                    expected: `--local: green;`,
+                });
+                expectSourceLocation({
+                    source: properties['--proxyReassign'].source,
+                    expected: `--proxy: var(--deepReassign1);`,
+                });
+                expectSourceLocation({
+                    source: properties['--deepReassign2'].source,
+                    expected: `--deep: red;`,
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
This PR exposes the available css custom properties available in a stylesheet with their:

- local name in context stylesheet
- local name in definition stylesheet
- transformed name
- source location (meta, start, end)

using the api: `stylable.cssCustomProperty.getProperties(meta)`