### PR TITLE
feat: ignore namespace collision of file deleted files

### DIFF
--- a/packages/core/src/helpers/namespace.ts
+++ b/packages/core/src/helpers/namespace.ts
@@ -42,7 +42,7 @@ export interface CreateNamespaceOptions {
         strict: boolean,
         namespace: string,
         filePath: string,
-        usedBy?: string
+        usedByMap: Map<string, string>
     ) => string;
     hashSeparator?: string;
     strict?: boolean;
@@ -75,8 +75,9 @@ export function defaultNoMatchHandler(
     strict: boolean,
     ns: string,
     stylesheetPath: string,
-    usedBy?: string
+    usedByMap: Map<string, string>
 ): string {
+    const usedBy = usedByMap.get(ns);
     throw new Error(
         `Could not create namespace for:\n${stylesheetPath}\nthe last valid namespace tried was ${JSON.stringify(
             ns
@@ -146,16 +147,11 @@ export function createNamespaceStrategy(options: CreateNamespaceOptions) {
             if (usedBy === stylesheetPath) {
                 return finalNamespace;
             } else if (strict) {
-                return handleNoMatch(strict, finalNamespace, stylesheetPath, usedBy);
+                return handleNoMatch(strict, finalNamespace, stylesheetPath, usedNamespaces);
             }
             i++;
         }
 
-        return handleNoMatch(
-            strict,
-            finalNamespace,
-            stylesheetPath,
-            usedNamespaces.get(finalNamespace)
-        );
+        return handleNoMatch(strict, finalNamespace, stylesheetPath, usedNamespaces);
     };
 }

--- a/packages/core/test/helpers/namespace.spec.ts
+++ b/packages/core/test/helpers/namespace.spec.ts
@@ -119,7 +119,12 @@ describe('createNamespaceStrategy', () => {
     it('should throw when no unique namespace can be generated and hash slice size is larger then hash length', () => {
         function getErrorMessage() {
             try {
-                defaultNoMatchHandler(false, 'x-1', '/package/x2.st.css', '/package/x1.st.css');
+                defaultNoMatchHandler(
+                    false,
+                    'x-1',
+                    '/package/x2.st.css',
+                    new Map([['x-1', '/package/x1.st.css']])
+                );
             } catch (e) {
                 return (e as Error).message;
             }
@@ -140,7 +145,12 @@ describe('createNamespaceStrategy', () => {
     it('should throw when no unique namespace can be generated in strict mode', () => {
         function getErrorMessage() {
             try {
-                defaultNoMatchHandler(true, 'x', '/package/x1.st.css', '/package/x.st.css');
+                defaultNoMatchHandler(
+                    true,
+                    'x',
+                    '/package/x1.st.css',
+                    new Map([['x', '/package/x.st.css']])
+                );
             } catch (e) {
                 return (e as Error).message;
             }


### PR DESCRIPTION
When moving files with strict namesapce we didn't clear the cache for the namespace and moving files around caused it to break. in this PR I introduced a devMode to the node resolve namespace Api which checks if the file was deleted when collision happens.