### PR TITLE
feat(formatter): group similar name at-rules

### DIFF
--- a/packages/code-formatter/src/format-css.ts
+++ b/packages/code-formatter/src/format-css.ts
@@ -172,19 +172,21 @@ function formatAst(ast: AnyNode, index: number, options: FormatOptions) {
             ast.value ||= ' '; // minimal space
         }
     } else if (ast.type === 'atrule') {
-        const prevType = ast.prev()?.type;
+        const prevNode = ast.prev();
+        const prevType = prevNode?.type;
+        const childrenLen = ast.nodes?.length ?? -1;
+        const hasNestedChildren = childrenLen === -1;
         const hasCommentBefore = prevType === 'comment';
         const hasRuleBefore = prevType === 'rule';
 
-        /* The postcss type does not represent the reality there are atRules without nodes */
-        const childrenLen = ast.nodes?.length ?? -1;
         const separation =
-            (childrenLen === -1 && !hasRuleBefore) || hasCommentBefore ? 0 : linesBetween;
+            hasCommentBefore || (hasNestedChildren && !hasRuleBefore) ? 0 : linesBetween;
 
         ast.raws.before =
             index !== 0 || indentLevel > 0
                 ? NL.repeat(index !== 0 ? separation + 1 : 1) + indent.repeat(indentLevel)
                 : '';
+
         ast.raws.after = childrenLen ? NL + indent.repeat(indentLevel) : '';
         ast.raws.afterName = ast.params.length
             ? enforceOneSpaceAround(ast.raws.afterName || '')

--- a/packages/code-formatter/src/format-css.ts
+++ b/packages/code-formatter/src/format-css.ts
@@ -178,9 +178,12 @@ function formatAst(ast: AnyNode, index: number, options: FormatOptions) {
         const hasNestedChildren = childrenLen === -1;
         const hasCommentBefore = prevType === 'comment';
         const hasRuleBefore = prevType === 'rule';
+        const isSameTypeAsPrev = prevType === 'atrule' && prevNode?.name === ast.name;
 
         const separation =
-            hasCommentBefore || (hasNestedChildren && !hasRuleBefore) ? 0 : linesBetween;
+            hasCommentBefore || (hasNestedChildren && !hasRuleBefore && isSameTypeAsPrev)
+                ? 0
+                : linesBetween;
 
         ast.raws.before =
             index !== 0 || indentLevel > 0

--- a/packages/code-formatter/test/formatter-experimental.spec.ts
+++ b/packages/code-formatter/test/formatter-experimental.spec.ts
@@ -971,6 +971,18 @@ describe('formatter - experimental', () => {
                 `,
             });
         });
+        it('should group similar named atRules with no body', () => {
+            testFormatCss({
+                message: 'top-level',
+                source: `@aaa 1;@aaa 2;@bbb 1;@bbb 2;@aaa 3`,
+                expect: `@aaa 1;\n@aaa 2;\n\n@bbb 1;\n@bbb 2;\n\n@aaa 3\n`,
+            });
+            testFormatCss({
+                message: 'nested',
+                source: `@top {@aaa 1;@aaa 2;@bbb 1;@bbb 2;@aaa 3}`,
+                expect: `@top {\n    @aaa 1;\n    @aaa 2;\n\n    @bbb 1;\n    @bbb 2;\n\n    @aaa 3\n}\n`,
+            });
+        });
         it('should set body into lines and indent accordingly', () => {
             testFormatCss({
                 deindent: true,
@@ -1065,6 +1077,7 @@ describe('formatter - experimental', () => {
                         @parens (a1: 1px, (a2: 2px) (a3: 3px)) {}
         
                         @function f(b1, b2, f-nest(b3)) {}
+
                         @square [c1, c2, c3[c4]) {}
         
                     `,


### PR DESCRIPTION
This PR changes the formatter behavior in order to group same name at-rules while maintaining spacing for other at-rule types.

**Before this PR, the following code would remain unchanged:**
```css
@namespace "abc"
@st-import "./a.st.css"
@st-import "./b.st.css"
@property --a;
@property --b;
```

**After this PR, the formatted code will be:**
```css
@namespace "abc"

@st-import "./a.st.css"
@st-import "./b.st.css"

@property --a;
@property --b;
```