### PR TITLE
fix(formatter): respect multi-line decl initial comment line

### DIFF
--- a/packages/code-formatter/src/format-css.ts
+++ b/packages/code-formatter/src/format-css.ts
@@ -112,7 +112,10 @@ function formatAst(ast: AnyNode, index: number, options: FormatOptions) {
             } else if (betweenNode.postSpace.includes('\n' /* don't use NL */) && valueHasNewline) {
                 newBetween += betweenNode.preComments.join(``);
                 hasNewLineBeforeValue = true;
-                newBetween += ':' + afterComments + NL;
+                const independentCommentSpace = afterComments
+                    ? NL + indent.repeat(indentLevel + 1)
+                    : '';
+                newBetween += ':' + independentCommentSpace + afterComments + NL;
             } else {
                 newBetween += betweenNode.preComments.join(``);
                 newBetween += ': ' + afterComments;

--- a/packages/code-formatter/src/format-css.ts
+++ b/packages/code-formatter/src/format-css.ts
@@ -109,11 +109,17 @@ function formatAst(ast: AnyNode, index: number, options: FormatOptions) {
                     ':' +
                     afterComments +
                     betweenNode.postSpace.replace(/\s+/gu, ' ');
-            } else if (betweenNode.postSpace.includes('\n' /* don't use NL */) && valueHasNewline) {
+            } else if (
+                valueHasNewline &&
+                (betweenNode.postSpace.includes('\n' /* don't use NL */) ||
+                    betweenNode.postCommentsSpace.includes('\n' /* don't use NL */))
+            ) {
                 newBetween += betweenNode.preComments.join(``);
                 hasNewLineBeforeValue = true;
                 const independentCommentSpace = afterComments
-                    ? NL + indent.repeat(indentLevel + 1)
+                    ? betweenNode.postSpace.includes('\n')
+                        ? NL + indent.repeat(indentLevel + 1)
+                        : ' '
                     : '';
                 newBetween += ':' + independentCommentSpace + afterComments + NL;
             } else {
@@ -672,13 +678,18 @@ function parseDeclBetweenRaws(between: string) {
         preSpace: '',
         preComments: [] as string[],
         postSpace: '',
+        postCommentsSpace: '',
         postComments: [] as string[],
         colon: false,
     };
     for (const node of beforeAst) {
         if (node.type === 'space') {
             if (beforeNode.colon) {
-                beforeNode.postSpace += stringifyCSSValue(node);
+                if (!beforeNode.postComments.length) {
+                    beforeNode.postSpace += stringifyCSSValue(node);
+                } else {
+                    beforeNode.postCommentsSpace += stringifyCSSValue(node);
+                }
             } else {
                 beforeNode.preSpace += stringifyCSSValue(node);
             }

--- a/packages/code-formatter/test/formatter-experimental.spec.ts
+++ b/packages/code-formatter/test/formatter-experimental.spec.ts
@@ -666,13 +666,21 @@ describe('formatter - experimental', () => {
                 source: `
                     .root {
                         prop1: 
+
                     /*start standalone line*/
+
                                 AAA,
+
                     /*inline before*/ BBB /*inline after*/
+
                         CCC
+
                                 /*middle standalone line*/
+
                                 DDD
+
                         /*end standalone line*/
+                        
                         ;
                     }
                 `,

--- a/packages/code-formatter/test/formatter-experimental.spec.ts
+++ b/packages/code-formatter/test/formatter-experimental.spec.ts
@@ -660,8 +660,9 @@ describe('formatter - experimental', () => {
                 `,
             });
         });
-        it('should respect newlines for comments', () => {
+        it('should respect newlines for comments (multiline decl)', () => {
             testFormatCss({
+                message: 'standalone initial comment',
                 deindent: true,
                 source: `
                     .root {
@@ -694,6 +695,27 @@ describe('formatter - experimental', () => {
                             /*middle standalone line*/
                             DDD
                             /*end standalone line*/;
+                    }
+
+                `,
+            });
+            testFormatCss({
+                message: 'inline initial comment',
+                deindent: true,
+                source: `
+                    .root {
+                        prop1:   /*start standalone line*/
+
+                                AAA
+                                BBB
+                        ;
+                    }
+                `,
+                expect: `
+                    .root {
+                        prop1: /*start standalone line*/
+                            AAA
+                            BBB;
                     }
 
                 `,

--- a/packages/code-formatter/test/formatter-experimental.spec.ts
+++ b/packages/code-formatter/test/formatter-experimental.spec.ts
@@ -660,6 +660,37 @@ describe('formatter - experimental', () => {
                 `,
             });
         });
+        it('should respect newlines for comments', () => {
+            testFormatCss({
+                deindent: true,
+                source: `
+                    .root {
+                        prop1: 
+                    /*start standalone line*/
+                                AAA,
+                    /*inline before*/ BBB /*inline after*/
+                        CCC
+                                /*middle standalone line*/
+                                DDD
+                        /*end standalone line*/
+                        ;
+                    }
+                `,
+                expect: `
+                    .root {
+                        prop1:
+                            /*start standalone line*/
+                            AAA,
+                            /*inline before*/ BBB /*inline after*/
+                            CCC
+                            /*middle standalone line*/
+                            DDD
+                            /*end standalone line*/;
+                    }
+
+                `,
+            });
+        });
         it('should respect newline', () => {
             testFormatCss({
                 deindent: true,


### PR DESCRIPTION
This PR fixes the handling of multi-line declaration values to preserve the original position of comments at the top level of declarations. 

**For example, given the unformatted code:**
```css
.a {
    prop:
            /*initial comment*/
        val1
                val2  
}
```

**Before this PR, the comment would be moved to the declaration line:**
```css
.a {
    prop: /*initial comment*/
        val1
        val2  
}
```

**After this PR, the comment remains on its own line:**
```css
.a {
    prop:
        /*initial comment*/
        val1
        val2  
}
```
